### PR TITLE
Redesign README banner with brand palette

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@
 <p align="center">
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT"></a>
   <a href="CONTRIBUTING.md"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome"></a>
-  <img src="https://img.shields.io/badge/Lessons-230+-purple" alt="230+ Lessons">
-  <img src="https://img.shields.io/badge/Phases-20-orange" alt="20 Phases">
+  <img src="https://img.shields.io/badge/Lessons-260+-D97757" alt="260+ Lessons">
+  <img src="https://img.shields.io/badge/Phases-20-191A23" alt="20 Phases">
+  <img src="https://img.shields.io/badge/Complete-60-3D8B6E" alt="60 Complete">
   <img src="https://img.shields.io/github/stars/rohitg00/ai-engineering-from-scratch?style=social" alt="GitHub Stars">
 </p>
 
@@ -21,7 +22,7 @@
 
 ---
 
-230+ hands-on lessons across 20 phases. From linear algebra to autonomous agent swarms. Python, TypeScript, Rust, Julia. Every lesson produces something reusable: prompts, skills, agents, MCP servers.
+260+ hands-on lessons across 20 phases. From linear algebra to autonomous agent swarms. Python, TypeScript, Rust, Julia. Every lesson produces something reusable: prompts, skills, agents, MCP servers.
 
 You learn AI. You build real things. You ship tools others can use.
 

--- a/assets/banner.svg
+++ b/assets/banner.svg
@@ -1,76 +1,132 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="300" viewBox="0 0 1200 300">
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="340" viewBox="0 0 1200 340">
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0f0f23;stop-opacity:1" />
-      <stop offset="50%" style="stop-color:#1a1a3e;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#0d1b2a;stop-opacity:1" />
+      <stop offset="0%" style="stop-color:#191A23;stop-opacity:1" />
+      <stop offset="40%" style="stop-color:#1E1F2A;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#191A23;stop-opacity:1" />
     </linearGradient>
-    <linearGradient id="accent" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#00d4ff;stop-opacity:1" />
-      <stop offset="50%" style="stop-color:#7c3aed;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#f43f5e;stop-opacity:1" />
+    <linearGradient id="coral" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#D97757;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#E08B6D;stop-opacity:1" />
     </linearGradient>
-    <linearGradient id="accent2" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#00d4ff;stop-opacity:0.3" />
-      <stop offset="100%" style="stop-color:#7c3aed;stop-opacity:0.3" />
+    <linearGradient id="coralFade" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#D97757;stop-opacity:0.15" />
+      <stop offset="100%" style="stop-color:#D97757;stop-opacity:0" />
     </linearGradient>
+    <linearGradient id="nodeGlow" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#D97757;stop-opacity:0.6" />
+      <stop offset="100%" style="stop-color:#D97757;stop-opacity:0" />
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="3" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <filter id="softGlow">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
   </defs>
 
-  <rect width="1200" height="300" fill="url(#bg)"/>
+  <rect width="1200" height="340" fill="url(#bg)"/>
 
-  <circle cx="100" cy="50" r="2" fill="#00d4ff" opacity="0.4"/>
-  <circle cx="200" cy="80" r="1.5" fill="#7c3aed" opacity="0.3"/>
-  <circle cx="350" cy="30" r="1" fill="#f43f5e" opacity="0.5"/>
-  <circle cx="500" cy="60" r="2" fill="#00d4ff" opacity="0.2"/>
-  <circle cx="700" cy="40" r="1.5" fill="#7c3aed" opacity="0.4"/>
-  <circle cx="850" cy="70" r="1" fill="#f43f5e" opacity="0.3"/>
-  <circle cx="1000" cy="45" r="2" fill="#00d4ff" opacity="0.5"/>
-  <circle cx="1100" cy="25" r="1.5" fill="#7c3aed" opacity="0.2"/>
-  <circle cx="150" cy="250" r="1" fill="#f43f5e" opacity="0.4"/>
-  <circle cx="400" cy="270" r="2" fill="#00d4ff" opacity="0.3"/>
-  <circle cx="600" cy="260" r="1.5" fill="#7c3aed" opacity="0.5"/>
-  <circle cx="900" cy="240" r="1" fill="#f43f5e" opacity="0.2"/>
-  <circle cx="1050" cy="265" r="2" fill="#00d4ff" opacity="0.4"/>
+  <rect x="0" y="0" width="1200" height="340" fill="url(#coralFade)" opacity="0.3"/>
 
-  <line x1="80" y1="200" x2="180" y2="200" stroke="url(#accent2)" stroke-width="1"/>
-  <line x1="180" y1="200" x2="230" y2="160" stroke="url(#accent2)" stroke-width="1"/>
-  <line x1="230" y1="160" x2="330" y2="180" stroke="url(#accent2)" stroke-width="1"/>
-  <circle cx="80" cy="200" r="3" fill="#00d4ff" opacity="0.5"/>
-  <circle cx="180" cy="200" r="3" fill="#7c3aed" opacity="0.5"/>
-  <circle cx="230" cy="160" r="3" fill="#f43f5e" opacity="0.5"/>
-  <circle cx="330" cy="180" r="3" fill="#00d4ff" opacity="0.5"/>
+  <g opacity="0.12">
+    <line x1="0" y1="68" x2="1200" y2="68" stroke="#32333F" stroke-width="0.5"/>
+    <line x1="0" y1="136" x2="1200" y2="136" stroke="#32333F" stroke-width="0.5"/>
+    <line x1="0" y1="204" x2="1200" y2="204" stroke="#32333F" stroke-width="0.5"/>
+    <line x1="0" y1="272" x2="1200" y2="272" stroke="#32333F" stroke-width="0.5"/>
+    <line x1="240" y1="0" x2="240" y2="340" stroke="#32333F" stroke-width="0.5"/>
+    <line x1="480" y1="0" x2="480" y2="340" stroke="#32333F" stroke-width="0.5"/>
+    <line x1="720" y1="0" x2="720" y2="340" stroke="#32333F" stroke-width="0.5"/>
+    <line x1="960" y1="0" x2="960" y2="340" stroke="#32333F" stroke-width="0.5"/>
+  </g>
 
-  <line x1="870" y1="180" x2="950" y2="160" stroke="url(#accent2)" stroke-width="1"/>
-  <line x1="950" y1="160" x2="1020" y2="190" stroke="url(#accent2)" stroke-width="1"/>
-  <line x1="1020" y1="190" x2="1100" y2="170" stroke="url(#accent2)" stroke-width="1"/>
-  <circle cx="870" cy="180" r="3" fill="#7c3aed" opacity="0.5"/>
-  <circle cx="950" cy="160" r="3" fill="#00d4ff" opacity="0.5"/>
-  <circle cx="1020" cy="190" r="3" fill="#f43f5e" opacity="0.5"/>
-  <circle cx="1100" cy="170" r="3" fill="#7c3aed" opacity="0.5"/>
+  <g opacity="0.25" filter="url(#softGlow)">
+    <line x1="60" y1="220" x2="140" y2="180" stroke="#D97757" stroke-width="1.2"/>
+    <line x1="140" y1="180" x2="200" y2="200" stroke="#D97757" stroke-width="1.2"/>
+    <line x1="200" y1="200" x2="260" y2="160" stroke="#D97757" stroke-width="1.2"/>
+    <line x1="260" y1="160" x2="340" y2="190" stroke="#D97757" stroke-width="1.2"/>
+    <circle cx="60" cy="220" r="3.5" fill="#D97757"/>
+    <circle cx="140" cy="180" r="4.5" fill="#D97757"/>
+    <circle cx="200" cy="200" r="3" fill="#E08B6D"/>
+    <circle cx="260" cy="160" r="5" fill="#D97757"/>
+    <circle cx="340" cy="190" r="3.5" fill="#E08B6D"/>
+  </g>
 
-  <text x="600" y="105" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="48" font-weight="800" fill="white" text-anchor="middle" letter-spacing="-1">
-    AI Engineering from Scratch
+  <g opacity="0.25" filter="url(#softGlow)">
+    <line x1="860" y1="190" x2="920" y2="155" stroke="#D97757" stroke-width="1.2"/>
+    <line x1="920" y1="155" x2="980" y2="175" stroke="#D97757" stroke-width="1.2"/>
+    <line x1="980" y1="175" x2="1050" y2="145" stroke="#D97757" stroke-width="1.2"/>
+    <line x1="1050" y1="145" x2="1130" y2="170" stroke="#D97757" stroke-width="1.2"/>
+    <circle cx="860" cy="190" r="4" fill="#E08B6D"/>
+    <circle cx="920" cy="155" r="3.5" fill="#D97757"/>
+    <circle cx="980" cy="175" r="5" fill="#D97757"/>
+    <circle cx="1050" cy="145" r="3" fill="#E08B6D"/>
+    <circle cx="1130" cy="170" r="4" fill="#D97757"/>
+  </g>
+
+  <g opacity="0.15">
+    <line x1="140" y1="180" x2="920" y2="155" stroke="#D97757" stroke-width="0.5" stroke-dasharray="4,8"/>
+    <line x1="260" y1="160" x2="1050" y2="145" stroke="#D97757" stroke-width="0.5" stroke-dasharray="4,8"/>
+  </g>
+
+  <g opacity="0.3">
+    <circle cx="90" cy="40" r="1.5" fill="#D97757"/>
+    <circle cx="250" cy="55" r="1" fill="#E08B6D"/>
+    <circle cx="420" cy="35" r="1.5" fill="#D97757"/>
+    <circle cx="580" cy="50" r="1" fill="#E08B6D"/>
+    <circle cx="780" cy="38" r="1.5" fill="#D97757"/>
+    <circle cx="950" cy="55" r="1" fill="#E08B6D"/>
+    <circle cx="1100" cy="42" r="1.5" fill="#D97757"/>
+    <circle cx="170" cy="305" r="1" fill="#E08B6D"/>
+    <circle cx="450" cy="315" r="1.5" fill="#D97757"/>
+    <circle cx="750" cy="308" r="1" fill="#E08B6D"/>
+    <circle cx="1020" cy="320" r="1.5" fill="#D97757"/>
+  </g>
+
+  <text x="600" y="95" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="52" font-weight="800" fill="#E8E6E3" text-anchor="middle" letter-spacing="-1.5">
+    AI Engineering
+  </text>
+  <text x="600" y="138" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="28" font-weight="300" fill="#908F8B" text-anchor="middle" letter-spacing="8">
+    FROM SCRATCH
   </text>
 
-  <rect x="350" y="125" width="500" height="3" rx="1.5" fill="url(#accent)" opacity="0.8"/>
+  <rect x="400" y="152" width="400" height="2.5" rx="1.25" fill="url(#coral)" opacity="0.7"/>
 
-  <text x="600" y="165" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="20" fill="#94a3b8" text-anchor="middle" letter-spacing="3">
-    LEARN IT. BUILD IT. SHIP IT FOR OTHERS.
+  <text x="600" y="190" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="15" fill="#908F8B" text-anchor="middle" letter-spacing="1">
+    Learn it. Build it. Ship it for others.
   </text>
 
-  <text x="600" y="210" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="14" fill="#64748b" text-anchor="middle">
-    200+ lessons  |  20 phases  |  Python, TypeScript, Rust, Julia  |  Math to Agent Swarms
-  </text>
+  <g>
+    <text x="600" y="228" font-family="'SF Mono', 'Fira Code', 'Cascadia Code', monospace" font-size="13" fill="#555460" text-anchor="middle" letter-spacing="0.5">
+      260+ lessons  &#183;  20 phases  &#183;  60 complete  &#183;  Math to Agent Swarms
+    </text>
+  </g>
 
-  <rect x="415" y="235" width="80" height="28" rx="14" fill="none" stroke="#00d4ff" stroke-width="1" opacity="0.6"/>
-  <text x="455" y="253" font-family="monospace" font-size="11" fill="#00d4ff" text-anchor="middle">Python</text>
+  <g transform="translate(365, 252)">
+    <rect x="0" y="0" width="82" height="28" rx="14" fill="rgba(217,119,87,0.1)" stroke="#D97757" stroke-width="1"/>
+    <text x="41" y="18" font-family="'SF Mono', 'Fira Code', monospace" font-size="11" fill="#D97757" text-anchor="middle">Python</text>
 
-  <rect x="510" y="235" width="100" height="28" rx="14" fill="none" stroke="#7c3aed" stroke-width="1" opacity="0.6"/>
-  <text x="560" y="253" font-family="monospace" font-size="11" fill="#7c3aed" text-anchor="middle">TypeScript</text>
+    <rect x="96" y="0" width="106" height="28" rx="14" fill="rgba(217,119,87,0.06)" stroke="#908F8B" stroke-width="0.8"/>
+    <text x="149" y="18" font-family="'SF Mono', 'Fira Code', monospace" font-size="11" fill="#908F8B" text-anchor="middle">TypeScript</text>
 
-  <rect x="625" y="235" width="65" height="28" rx="14" fill="none" stroke="#f43f5e" stroke-width="1" opacity="0.6"/>
-  <text x="657" y="253" font-family="monospace" font-size="11" fill="#f43f5e" text-anchor="middle">Rust</text>
+    <rect x="216" y="0" width="68" height="28" rx="14" fill="rgba(217,119,87,0.06)" stroke="#908F8B" stroke-width="0.8"/>
+    <text x="250" y="18" font-family="'SF Mono', 'Fira Code', monospace" font-size="11" fill="#908F8B" text-anchor="middle">Rust</text>
 
-  <rect x="705" y="235" width="65" height="28" rx="14" fill="none" stroke="#10b981" stroke-width="1" opacity="0.6"/>
-  <text x="737" y="253" font-family="monospace" font-size="11" fill="#10b981" text-anchor="middle">Julia</text>
+    <rect x="298" y="0" width="68" height="28" rx="14" fill="rgba(217,119,87,0.06)" stroke="#908F8B" stroke-width="0.8"/>
+    <text x="332" y="18" font-family="'SF Mono', 'Fira Code', monospace" font-size="11" fill="#908F8B" text-anchor="middle">Julia</text>
+  </g>
+
+  <g opacity="0.08">
+    <text x="600" y="330" font-family="system-ui, sans-serif" font-size="10" fill="#E8E6E3" text-anchor="middle" letter-spacing="2">
+      OPEN SOURCE  &#183;  MIT LICENSE  &#183;  ROHITG00
+    </text>
+  </g>
 </svg>


### PR DESCRIPTION
## Summary

- Redesigned banner SVG to match the site's Anthropic-inspired palette (Coral #D97757, Navy #191A23)
- Replaced the old cyan/purple/rose color scheme that didn't match the site
- New design features:
  - Navy background with subtle grid pattern
  - Coral-glowing neural network node clusters on left and right sides
  - Dashed cross-connections between node clusters
  - Soft gaussian blur glow filters on nodes
  - Split typography: bold "AI Engineering" + light tracking "FROM SCRATCH"
  - Coral gradient divider line
  - Monospace stats: "260+ lessons · 20 phases · 60 complete · Math to Agent Swarms"
  - Python pill highlighted in coral (primary language), others in muted gray
  - Subtle OPEN SOURCE · MIT LICENSE · ROHITG00 footer
- Updated badge counts: 230+ -> 260+, added "60 Complete" badge

## Test plan

- [ ] Verify banner.svg renders correctly on GitHub README
- [ ] Check badges render with correct colors
- [ ] Verify dark mode compatibility (banner uses dark bg, works on both)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated course progression information, increasing lesson count from 230+ to 260+
  * Added new "Complete: 60" achievement badge
  * Refreshed badge styling and visual presentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->