### PR TITLE
Move glossary to separate page with callout on homepage

### DIFF
--- a/site/app.js
+++ b/site/app.js
@@ -341,39 +341,27 @@ document.addEventListener('keydown', function(e) {
 })();
 
 (function() {
-  var grid = document.getElementById('glossary-grid');
-  var search = document.getElementById('glossary-search');
-  if (!grid) return;
+  var preview = document.getElementById('glossary-preview');
+  var countEl = document.getElementById('glossary-count');
+  if (!preview || typeof GLOSSARY === 'undefined') return;
 
-  function render(terms) {
-    grid.innerHTML = '';
-    terms.forEach(function(t) {
-      var card = document.createElement('div');
-      card.className = 'gloss-card';
-      card.innerHTML =
-        '<h3 class="gloss-card__term">' + t.term + '</h3>' +
-        '<div class="gloss-card__row">' +
-          '<span class="gloss-card__label">What people say</span>' +
-          '<p>"' + t.says + '"</p>' +
-        '</div>' +
-        '<div class="gloss-card__row">' +
-          '<span class="gloss-card__label">What it actually means</span>' +
-          '<p>' + t.means + '</p>' +
-        '</div>';
-      grid.appendChild(card);
-    });
-  }
+  if (countEl) countEl.textContent = GLOSSARY.length;
 
-  render(GLOSSARY);
-
-  search.addEventListener('input', function() {
-    var q = search.value.toLowerCase();
-    render(GLOSSARY.filter(function(t) {
-      return t.term.toLowerCase().includes(q) ||
-        t.says.toLowerCase().includes(q) ||
-        t.means.toLowerCase().includes(q);
-    }));
+  var sample = GLOSSARY.slice(0, 12);
+  sample.forEach(function(t) {
+    var tag = document.createElement('span');
+    tag.className = 'glossary-callout__tag';
+    tag.textContent = t.term;
+    preview.appendChild(tag);
   });
+
+  var more = document.createElement('a');
+  more.href = 'glossary.html';
+  more.className = 'glossary-callout__tag';
+  more.textContent = '+' + (GLOSSARY.length - 12) + ' more';
+  more.style.borderColor = 'var(--color-accent)';
+  more.style.color = 'var(--color-accent)';
+  preview.appendChild(more);
 })();
 
 document.querySelectorAll('a[href^="#"]').forEach(function(a) {

--- a/site/glossary.html
+++ b/site/glossary.html
@@ -1,0 +1,179 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>AI Glossary — AI Engineering from Scratch</title>
+<meta name="description" content="64 AI and machine learning terms demystified. What people say vs. what they actually mean. From attention mechanisms to zero-shot learning.">
+<meta property="og:title" content="AI Glossary — AI Engineering from Scratch">
+<meta property="og:description" content="64 AI terms demystified. What people say vs. what they actually mean.">
+<meta property="og:type" content="website">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://api.fontshare.com/v2/css?f[]=general-sans@400,500,600,700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+
+<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect width='32' height='32' rx='6' fill='%23191A23'/><text x='4' y='24' font-size='22' fill='%23D97757'>AI</text></svg>">
+
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<header class="header" id="header">
+  <div class="header__inner">
+    <a href="index.html" class="header__logo" aria-label="AI Engineering from Scratch">
+      <svg width="32" height="32" viewBox="0 0 32 32" fill="none" aria-hidden="true">
+        <rect width="32" height="32" rx="6" fill="var(--color-accent)"/>
+        <path d="M8 22L16 10L24 22" stroke="var(--color-bg)" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+        <circle cx="16" cy="14" r="2" fill="var(--color-bg)"/>
+      </svg>
+      <span>AI Eng<span class="hide-mobile"> from Scratch</span></span>
+    </a>
+    <nav class="header__nav" aria-label="Primary">
+      <a href="index.html#phases">Phases</a>
+      <a href="index.html#roadmap">Roadmap</a>
+      <a href="glossary.html" class="header__nav-active">Glossary</a>
+      <a href="https://github.com/rohitg00/ai-engineering-from-scratch" target="_blank" rel="noopener" class="header__github">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
+        <span class="hide-mobile">GitHub</span>
+      </a>
+    </nav>
+    <button class="header__theme" data-theme-toggle aria-label="Toggle theme">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+    </button>
+  </div>
+</header>
+
+<section class="glossary-page">
+  <div class="glossary-page__inner">
+    <div class="glossary-page__header">
+      <a href="index.html" class="glossary-page__back">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M19 12H5M12 19l-7-7 7-7"/></svg>
+        Back to course
+      </a>
+      <h1 class="glossary-page__title">AI Glossary</h1>
+      <p class="glossary-page__sub"><span id="glossary-count">64</span> terms. What people say vs. what they actually mean.</p>
+    </div>
+
+    <div class="glossary-page__controls">
+      <div class="glossary__search-wrap">
+        <svg class="glossary__search-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/></svg>
+        <input type="text" id="glossary-search" class="glossary__search" placeholder="Search terms, definitions..." aria-label="Search glossary terms">
+      </div>
+      <div class="glossary-page__meta">
+        <span id="glossary-showing">Showing all</span>
+      </div>
+    </div>
+
+    <div class="glossary__grid" id="glossary-grid"></div>
+
+    <div class="glossary-page__empty" id="glossary-empty" hidden>
+      <p>No terms match your search.</p>
+    </div>
+  </div>
+</section>
+
+<footer class="footer">
+  <div class="footer__inner">
+    <p>AI Engineering from Scratch -- MIT License</p>
+    <p class="footer__attr">by <a href="https://github.com/rohitg00" target="_blank" rel="noopener">Rohit Ghumare</a></p>
+  </div>
+</footer>
+
+<script src="data.js"></script>
+<script>
+(function() {
+  var toggle = document.querySelector('[data-theme-toggle]');
+  var root = document.documentElement;
+  var theme = matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  root.setAttribute('data-theme', theme);
+  updateIcon();
+
+  toggle && toggle.addEventListener('click', function() {
+    theme = theme === 'dark' ? 'light' : 'dark';
+    root.setAttribute('data-theme', theme);
+    updateIcon();
+  });
+
+  function updateIcon() {
+    if (!toggle) return;
+    toggle.innerHTML = theme === 'dark'
+      ? '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>'
+      : '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';
+  }
+})();
+
+(function() {
+  var header = document.getElementById('header');
+  var lastY = 0;
+  window.addEventListener('scroll', function() {
+    var y = window.scrollY;
+    header.classList.toggle('header--scrolled', y > 40);
+    header.classList.toggle('header--hidden', y > 300 && y > lastY);
+    lastY = y;
+  }, { passive: true });
+})();
+
+(function() {
+  var grid = document.getElementById('glossary-grid');
+  var search = document.getElementById('glossary-search');
+  var countEl = document.getElementById('glossary-count');
+  var showingEl = document.getElementById('glossary-showing');
+  var emptyEl = document.getElementById('glossary-empty');
+  if (!grid) return;
+
+  function render(terms) {
+    grid.innerHTML = '';
+    if (terms.length === 0) {
+      emptyEl.hidden = false;
+      showingEl.textContent = 'No results';
+      return;
+    }
+    emptyEl.hidden = true;
+    showingEl.textContent = terms.length === GLOSSARY.length
+      ? 'Showing all ' + terms.length + ' terms'
+      : 'Showing ' + terms.length + ' of ' + GLOSSARY.length;
+
+    terms.forEach(function(t) {
+      var card = document.createElement('div');
+      card.className = 'gloss-card fade-in visible';
+      card.innerHTML =
+        '<h3 class="gloss-card__term">' + t.term + '</h3>' +
+        '<div class="gloss-card__row">' +
+          '<span class="gloss-card__label">What people say</span>' +
+          '<p>\u201C' + t.says + '\u201D</p>' +
+        '</div>' +
+        '<div class="gloss-card__row">' +
+          '<span class="gloss-card__label">What it actually means</span>' +
+          '<p>' + t.means + '</p>' +
+        '</div>';
+      grid.appendChild(card);
+    });
+  }
+
+  countEl.textContent = GLOSSARY.length;
+  render(GLOSSARY);
+
+  var debounceTimer;
+  search.addEventListener('input', function() {
+    clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(function() {
+      var q = search.value.toLowerCase().trim();
+      if (!q) {
+        render(GLOSSARY);
+        return;
+      }
+      render(GLOSSARY.filter(function(t) {
+        return t.term.toLowerCase().includes(q) ||
+          t.says.toLowerCase().includes(q) ||
+          t.means.toLowerCase().includes(q);
+      }));
+    }, 150);
+  });
+
+  search.focus();
+})();
+</script>
+</body>
+</html>

--- a/site/index.html
+++ b/site/index.html
@@ -33,7 +33,7 @@
     <nav class="header__nav" aria-label="Primary">
       <a href="#phases">Phases</a>
       <a href="#roadmap">Roadmap</a>
-      <a href="#glossary">Glossary</a>
+      <a href="glossary.html">Glossary</a>
       <a href="https://github.com/rohitg00/ai-engineering-from-scratch" target="_blank" rel="noopener" class="header__github">
         <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
         <span class="hide-mobile">GitHub</span>
@@ -236,14 +236,16 @@
   </div>
 </section>
 
-<section class="glossary" id="glossary">
-  <div class="glossary__inner">
-    <h2 class="section-title">Glossary</h2>
-    <p class="section-sub">Key AI terms, demystified. What people say vs. what they actually mean.</p>
-    <div class="glossary__search-wrap">
-      <input type="text" id="glossary-search" class="glossary__search" placeholder="Search terms..." aria-label="Search glossary terms">
-    </div>
-    <div class="glossary__grid fade-in" id="glossary-grid">
+<section class="glossary-callout" id="glossary">
+  <div class="glossary-callout__inner">
+    <div class="glossary-callout__content">
+      <h2 class="glossary-callout__title">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
+        AI Glossary
+      </h2>
+      <p class="glossary-callout__desc"><span id="glossary-count">64</span> terms demystified. What people say vs. what they actually mean.</p>
+      <div class="glossary-callout__preview" id="glossary-preview"></div>
+      <a href="glossary.html" class="btn btn--primary">Browse Full Glossary</a>
     </div>
   </div>
 </section>

--- a/site/style.css
+++ b/site/style.css
@@ -1056,23 +1056,146 @@ a.lesson-row:hover {
   .how__step { max-width: none; }
 }
 
-.glossary {
-  padding: clamp(var(--space-12), 6vw, var(--space-24)) var(--space-6);
+.glossary-callout {
+  padding: clamp(var(--space-12), 6vw, var(--space-20)) var(--space-6);
 }
 
-.glossary__inner {
+.glossary-callout__inner {
+  max-width: 640px;
+  margin: 0 auto;
+  text-align: center;
+}
+
+.glossary-callout__title {
+  font-size: var(--text-xl);
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-3);
+  margin-bottom: var(--space-3);
+  color: var(--color-text);
+}
+
+.glossary-callout__title svg {
+  color: var(--color-accent);
+  flex-shrink: 0;
+}
+
+.glossary-callout__desc {
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+  margin: 0 auto var(--space-6);
+  max-width: 400px;
+}
+
+.glossary-callout__preview {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: var(--space-2);
+  margin-bottom: var(--space-6);
+}
+
+.glossary-callout__tag {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  color: var(--color-text-muted);
+  transition: border-color var(--transition), color var(--transition);
+}
+
+.glossary-callout__tag:hover {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+}
+
+.glossary-page {
+  padding: calc(var(--space-16) + 56px) var(--space-6) var(--space-16);
+  min-height: 100vh;
+}
+
+.glossary-page__inner {
   max-width: var(--content-wide);
   margin: 0 auto;
 }
 
+.glossary-page__header {
+  margin-bottom: var(--space-8);
+}
+
+.glossary-page__back {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+  margin-bottom: var(--space-4);
+  transition: color var(--transition);
+}
+
+.glossary-page__back:hover {
+  color: var(--color-accent);
+}
+
+.glossary-page__title {
+  font-size: var(--text-2xl);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin-bottom: var(--space-2);
+}
+
+.glossary-page__sub {
+  font-size: var(--text-base);
+  color: var(--color-text-muted);
+}
+
+.glossary-page__controls {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  margin-bottom: var(--space-8);
+  flex-wrap: wrap;
+}
+
+.glossary-page__meta {
+  font-size: var(--text-xs);
+  color: var(--color-text-faint);
+  font-family: var(--font-mono);
+}
+
+.glossary-page__empty {
+  text-align: center;
+  padding: var(--space-16) var(--space-6);
+  color: var(--color-text-muted);
+}
+
+.header__nav-active {
+  color: var(--color-accent) !important;
+}
+
 .glossary__search-wrap {
   max-width: 400px;
-  margin: 0 auto var(--space-8);
+  position: relative;
+  flex: 1;
+  min-width: 200px;
+}
+
+.glossary__search-icon {
+  position: absolute;
+  left: 14px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--color-text-faint);
+  pointer-events: none;
 }
 
 .glossary__search {
   width: 100%;
-  padding: var(--space-3) var(--space-4);
+  padding: var(--space-3) var(--space-4) var(--space-3) 42px;
   font-size: var(--text-sm);
   font-family: var(--font-body);
   background: var(--color-surface);


### PR DESCRIPTION
## Summary

The glossary was a 64-card grid embedded in the homepage, adding massive scroll depth and slowing page load. Now it's a separate page with a compact callout on the homepage.

### Homepage callout
- Book icon + "AI Glossary" heading
- Shows count: "64 terms demystified"
- 12 sample term tags as pills (Transformer, Attention, Gradient Descent, etc.)
- "+52 more" link
- "Browse Full Glossary" CTA button

### Glossary page (glossary.html)
- Full standalone page with header, footer, theme toggle
- Large title, back-to-course link
- Search with magnifying glass icon inside the input
- Debounced search (150ms) for smooth typing
- Live result count: "Showing 8 of 64"
- Empty state: "No terms match your search"
- Auto-focuses search on page load
- Active state on "Glossary" nav link

### Navigation
- Header nav updated: `#glossary` anchor -> `glossary.html` link
- Works from both homepage and glossary page (relative paths)

## Test plan

- [ ] Homepage loads without glossary cards (just callout)
- [ ] Click "Browse Full Glossary" navigates to glossary.html
- [ ] Search filters terms in real-time
- [ ] Empty state shows when no matches
- [ ] Back link returns to homepage
- [ ] Theme toggle works on glossary page
- [ ] Mobile responsive (single column grid)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dedicated Glossary page with searchable terms and filtering
  * Theme toggle and scroll-driven header behavior on Glossary page
  * Homepage now displays a glossary preview with "Browse Full Glossary" link

<!-- end of auto-generated comment: release notes by coderabbit.ai -->