### PR TITLE
Expand glossary from 64 to 277 AI/ML terms

### DIFF
--- a/site/data.js
+++ b/site/data.js
@@ -1791,26 +1791,37 @@ const PHASES = [
   }
 ];
 
+
 const GLOSSARY = [
   {
-    "term": "Agent",
-    "says": "An autonomous AI that thinks and acts on its own",
-    "means": "A while loop where an LLM decides what tool to call next, executes it, sees the result, and repeats"
+    "term": "3D Gaussian Splatting",
+    "says": "Fast 3D from photos",
+    "means": "A 3D scene representation using millions of 3D Gaussian ellipsoids, each with position, covariance, color, and opacity. Renders by splatting (projecting) Gaussians onto the image plane and alpha-compositing. 100-1000x faster rendering than NeRF (real-time at 1080p). Trains in minutes instead of hours. The current state-of-the-art for novel view synthesis."
   },
   {
-    "term": "Attention",
-    "says": "How the AI focuses on important parts",
-    "means": "A mechanism where every token computes a weighted sum of all other tokens' values, with weights determined by how relevant they are (via dot product of query and key vectors)"
+    "term": "A/B Testing (ML)",
+    "says": "Just ship both versions and see which wins",
+    "means": "Randomly splitting production traffic between two model variants and measuring a success metric (click-through, accuracy, revenue) with statistical significance testing. Requires enough traffic for power: typically thousands of observations per variant to detect a 1-2% lift."
   },
   {
-    "term": "Alignment",
-    "says": "Making AI safe",
-    "means": "The technical challenge of making an AI system's behavior match human intentions, values, and preferences, including edge cases the designer didn't anticipate"
+    "term": "A100/H100/B200",
+    "says": "The expensive GPUs everyone wants",
+    "means": "NVIDIA data center GPUs. A100 (2020): 80GB HBM2e, 312 TFLOPS FP16. H100 (2023): 80GB HBM3, 990 TFLOPS FP16, 2x A100 for LLM training. B200 (2024): 192GB HBM3e, 4.5 PETAFLOPS FP4. Each generation roughly doubles throughput per dollar for transformer workloads."
   },
   {
-    "term": "Autoregressive",
-    "says": "The AI generates one word at a time",
-    "means": "A model that predicts the next token conditioned on all previous tokens, then feeds that prediction back as input for the next step. GPT, LLaMA, and Claude are all autoregressive."
+    "term": "A2A (Agent-to-Agent Protocol)",
+    "says": "Google's agent protocol",
+    "means": "A peer-to-peer protocol under the Linux Foundation for agent collaboration. Agents publish Agent Cards at /.well-known/agent-card.json describing skills, and delegate tasks via JSON-RPC with a 9-state lifecycle."
+  },
+  {
+    "term": "Ablation Study",
+    "says": "Testing what matters",
+    "means": "Removing one component at a time from a model or pipeline to measure its contribution. If you remove a layer and accuracy drops 5%, that layer is responsible for 5% of performance."
+  },
+  {
+    "term": "Activation Function",
+    "says": "The nonlinearity",
+    "means": "A function applied after each linear layer to introduce nonlinearity. Without it, stacking layers collapses to one linear transform. Common: ReLU, GELU, SiLU, sigmoid, tanh."
   },
   {
     "term": "Adam (Optimizer)",
@@ -1818,19 +1829,169 @@ const GLOSSARY = [
     "means": "Adaptive Moment Estimation. Combines momentum (first moment) with adaptive learning rates per parameter (second moment). Has bias correction for early steps. Works well across most tasks without much tuning."
   },
   {
-    "term": "Backpropagation",
-    "says": "How neural networks learn",
-    "means": "An algorithm that computes how much each weight contributed to the error by applying the chain rule backward through the network, then adjusts weights proportionally"
+    "term": "Adapter",
+    "says": "A plugin for a model",
+    "means": "A small trainable module inserted into a frozen pre-trained model. Typically adds two linear layers (down-project then up-project) with a bottleneck dimension of 8-64. Each adapter adds <1% extra parameters but can match full fine-tuning performance on specific tasks."
   },
   {
-    "term": "Context Window",
-    "says": "How much the AI can remember",
-    "means": "The maximum number of tokens (input + output) that fit in a single API call. Not memory — it's a fixed-size buffer that resets every call"
+    "term": "Adversarial Attack",
+    "says": "Hacking the AI with weird inputs",
+    "means": "Crafting inputs specifically designed to fool a model. For images, adding imperceptible noise (L-infinity norm < 8/255) can flip a classifier's prediction with >99% confidence. For LLMs, adversarial suffixes or jailbreak prompts bypass safety training."
+  },
+  {
+    "term": "Adversarial Training",
+    "says": "Training the AI to be hack-proof",
+    "means": "Augmenting training data with adversarial examples: generate attacks against the current model, add them to the training set with correct labels, retrain. Makes models robust but typically costs 3-10x more compute and can reduce clean accuracy by 1-3%."
+  },
+  {
+    "term": "Agent",
+    "says": "An autonomous AI that thinks and acts on its own",
+    "means": "A while loop where an LLM decides what tool to call next, executes it, sees the result, and repeats. The loop runs until the task is done or a token budget is exhausted."
+  },
+  {
+    "term": "Agentic Workflow",
+    "says": "AI that does things by itself",
+    "means": "A multi-step pipeline where an LLM plans, executes tools, observes results, reflects, and iterates. Unlike a single prompt-response, it runs autonomously across many turns until the task is complete."
+  },
+  {
+    "term": "Alignment",
+    "says": "Making AI safe",
+    "means": "The technical challenge of making an AI system's behavior match human intentions, values, and preferences, including edge cases the designer didn't anticipate."
+  },
+  {
+    "term": "ASR (Automatic Speech Recognition)",
+    "says": "Speech-to-text AI",
+    "means": "Converting audio waveforms into text. Modern ASR uses encoder-decoder transformers (Whisper) trained on hundreds of thousands of hours of labeled audio. Whisper large-v3 achieves <5% word error rate on English, trained on 680K hours of multilingual audio."
+  },
+  {
+    "term": "Attention",
+    "says": "How the AI focuses on important parts",
+    "means": "A mechanism where every token computes a weighted sum of all other tokens' values, with weights determined by how relevant they are (via dot product of query and key vectors). Complexity is O(n^2) in sequence length."
+  },
+  {
+    "term": "Autoencoder",
+    "says": "Compress and decompress, like a zip file for data",
+    "means": "A neural network with an encoder that maps input to a lower-dimensional bottleneck (latent space) and a decoder that reconstructs the input. If input is 784 dims and bottleneck is 32 dims, the network must learn to compress by 24.5x. Used for denoising, anomaly detection, and representation learning."
+  },
+  {
+    "term": "Autoregressive",
+    "says": "The AI generates one word at a time",
+    "means": "A model that predicts the next token conditioned on all previous tokens, then feeds that prediction back as input for the next step. GPT, LLaMA, and Claude are all autoregressive."
+  },
+  {
+    "term": "AWQ (Activation-Aware Weight Quantization)",
+    "says": "Another quantization method",
+    "means": "Quantizes weights to 4-bit by identifying the 1% of weights that matter most (based on activation magnitudes) and keeping them at higher precision. Outperforms naive round-to-nearest quantization by 2-3 perplexity points on 4-bit models."
+  },
+  {
+    "term": "Backpropagation",
+    "says": "How neural networks learn",
+    "means": "An algorithm that computes how much each weight contributed to the error by applying the chain rule backward through the network, then adjusts weights proportionally."
+  },
+  {
+    "term": "Batch Inference",
+    "says": "Running a bunch of inputs at once",
+    "means": "Processing multiple inputs together in a single forward pass to maximize GPU utilization. Throughput scales nearly linearly with batch size until you hit memory limits. A batch of 32 on an H100 might get 25x the tokens/sec of batch size 1."
+  },
+  {
+    "term": "Batch Normalization",
+    "says": "Normalizing stuff during training",
+    "means": "Normalizes activations across the batch dimension: subtract mean, divide by std, then apply learned scale and shift. Stabilizes training and allows higher learning rates. Problematic for small batches and sequence models, which is why transformers use LayerNorm instead."
+  },
+  {
+    "term": "Batch Size",
+    "says": "How many examples you train on at once",
+    "means": "The number of training examples processed together before one gradient update. Larger batches give smoother gradients but use more memory. Typical ranges: 32-512 for vision, 256K-4M tokens for LLM pre-training. Doubling batch size roughly halves training noise."
+  },
+  {
+    "term": "Beam Search",
+    "says": "Trying multiple options at once when generating",
+    "means": "A decoding strategy that maintains k (beam width) partial sequences at each step, expanding each by the top-k next tokens and keeping only the k highest-scoring full sequences. Beam width 4-5 is typical. Better than greedy for translation but can produce bland text for open-ended generation."
+  },
+  {
+    "term": "Bias (ML)",
+    "says": "The AI is racist/sexist",
+    "means": "Systematic errors in model outputs that reflect or amplify societal biases in training data. Measured by comparing model performance or outputs across demographic groups. A hiring model trained on historical data will learn historical discrimination patterns."
+  },
+  {
+    "term": "Bias (Neural Network)",
+    "says": "Some extra number added to the output",
+    "means": "A learnable scalar added after the linear transformation: y = Wx + b. The bias term b shifts the activation function, allowing the neuron to fire even when all inputs are zero. Some modern architectures (e.g., PaLM) remove biases entirely with minimal accuracy loss."
+  },
+  {
+    "term": "Binary Classification",
+    "says": "Yes or no prediction",
+    "means": "Predicting one of two classes (spam/not-spam, positive/negative). Typically uses sigmoid activation on the final layer to output a probability between 0 and 1, trained with binary cross-entropy loss. A threshold (usually 0.5) converts probability to class."
+  },
+  {
+    "term": "BLEU Score",
+    "says": "The metric for translation quality",
+    "means": "Bilingual Evaluation Understudy. Measures n-gram overlap between generated and reference text. BLEU-4 uses 1-gram through 4-gram precision with a brevity penalty. Ranges 0-1 (often reported as 0-100). A score of 30+ is decent for machine translation. Criticized for not capturing semantic equivalence."
+  },
+  {
+    "term": "BM25",
+    "says": "Old-school search",
+    "means": "Best Matching 25, a probabilistic ranking function for text retrieval. Scores documents by term frequency (with saturation) and inverse document frequency: score = sum(IDF(q) * (tf * (k1+1)) / (tf + k1 * (1-b+b*dl/avgdl))). Still competitive with neural retrievers for keyword-heavy queries. Default in Elasticsearch."
+  },
+  {
+    "term": "BPE (Byte Pair Encoding)",
+    "says": "How the model splits words",
+    "means": "A tokenization algorithm that starts with individual bytes/characters and iteratively merges the most frequent adjacent pair. After 50K merges, you get a vocabulary where common words are single tokens and rare words split into subwords. GPT-2/3/4 use BPE. Handles any input without out-of-vocabulary errors."
+  },
+  {
+    "term": "Canary Deployment",
+    "says": "Test it on a few users first",
+    "means": "Rolling out a new model to a small percentage of traffic (1-5%) while monitoring metrics. If error rate or latency spikes, automatically roll back. Safer than full deployment but slower to detect rare failure modes. Often combined with A/B testing."
+  },
+  {
+    "term": "Catastrophic Forgetting",
+    "says": "The model forgot everything it knew",
+    "means": "When fine-tuning on new data causes the model to lose performance on previously learned tasks. The new gradient updates overwrite weights important for old tasks. Mitigation strategies: elastic weight consolidation (EWC), replay buffers, progressive training, or LoRA (which leaves original weights frozen)."
+  },
+  {
+    "term": "Categorical Variable",
+    "says": "Data that has labels instead of numbers",
+    "means": "A variable that takes discrete values from a fixed set (color: red/blue/green, country: US/UK/JP). Must be encoded for neural networks: one-hot encoding (k binary features), label encoding (integers), or learned embeddings (dense vectors). Embeddings are preferred when cardinality is high."
+  },
+  {
+    "term": "Causal Masking",
+    "says": "Preventing the model from cheating by looking ahead",
+    "means": "An attention mask that sets all positions above the diagonal to negative infinity before softmax, so each token can only attend to itself and earlier tokens. Essential for autoregressive generation: without it, the model could see future tokens during training."
   },
   {
     "term": "Chain of Thought (CoT)",
     "says": "Making the AI think step by step",
-    "means": "A prompting technique where you ask the model to show its reasoning steps, which improves accuracy on multi-step problems because each step conditions the next token generation"
+    "means": "A prompting technique where you ask the model to show its reasoning steps, which improves accuracy on multi-step problems because each step conditions the next token generation. On GSM8K math, CoT improves PaLM 540B from 57% to 74%."
+  },
+  {
+    "term": "Chinchilla Scaling",
+    "says": "The right amount of data for your model size",
+    "means": "DeepMind's 2022 finding that optimal training uses roughly 20 tokens per parameter. A 7B model should train on 140B tokens, not 300B. LLaMA challenged this, showing that over-training small models (200+ tokens/parameter) produces better inference-time performance per FLOP."
+  },
+  {
+    "term": "Chroma",
+    "says": "The easy vector database",
+    "means": "An open-source embedding database that runs in-memory or persistent mode. Optimized for developer experience: pip install, 4 lines of code to store and query. Uses HNSW for approximate nearest neighbor. Good for prototyping RAG, limited for production scale beyond a few million vectors."
+  },
+  {
+    "term": "Chunking",
+    "says": "Splitting documents into pieces for RAG",
+    "means": "Breaking long documents into smaller segments for embedding and retrieval. Strategies: fixed-size (512 tokens with overlap), semantic (split at paragraph/section boundaries), recursive (split hierarchically). Chunk size directly affects retrieval quality: too small loses context, too large dilutes relevance."
+  },
+  {
+    "term": "Class Imbalance",
+    "says": "Way more of one label than another",
+    "means": "When class frequencies differ significantly (e.g., 99% negative, 1% positive in fraud detection). A naive model predicting all-negative gets 99% accuracy but catches zero fraud. Fix with: oversampling minority class (SMOTE), undersampling majority, class weights in loss function, or focal loss."
+  },
+  {
+    "term": "Classifier-Free Guidance",
+    "says": "The setting that controls how much the image matches your prompt",
+    "means": "A technique in diffusion models that interpolates between conditional and unconditional predictions: output = unconditional + scale * (conditional - unconditional). Scale of 7.5 is typical for Stable Diffusion. Higher values produce images that match the prompt more closely but with less diversity and potential artifacts."
+  },
+  {
+    "term": "Clustering",
+    "says": "Grouping similar things together",
+    "means": "Unsupervised learning that partitions data into groups where within-group similarity is high. K-means minimizes within-cluster variance (iterates: assign to nearest centroid, recompute centroids). DBSCAN finds dense regions. Hierarchical clustering builds a tree of merges. You must choose k or a density threshold."
   },
   {
     "term": "CNN (Convolutional Neural Network)",
@@ -1838,9 +1999,39 @@ const GLOSSARY = [
     "means": "A neural network that uses convolution operations (sliding filters over the input) to detect local patterns. Stacking convolutions detects increasingly complex features: edges, textures, objects."
   },
   {
-    "term": "CUDA",
-    "says": "GPU programming",
-    "means": "NVIDIA's parallel computing platform. Lets you run matrix operations on thousands of GPU cores simultaneously. PyTorch and TensorFlow use CUDA under the hood."
+    "term": "Concept Drift",
+    "says": "The world changed but your model didn't",
+    "means": "When the statistical relationship between inputs and outputs changes over time. A spam classifier trained in 2023 degrades as spammers adapt. Detected by monitoring prediction distributions and performance metrics. Requires periodic retraining or online learning."
+  },
+  {
+    "term": "Consistency Model",
+    "says": "One-step image generation",
+    "means": "A generative model trained to map any point on a noise trajectory directly to the final clean image in a single step, bypassing the iterative denoising of diffusion models. Achieves comparable quality to 50-step diffusion in 1-2 steps, enabling real-time generation."
+  },
+  {
+    "term": "Constitutional AI",
+    "says": "AI that follows rules",
+    "means": "Anthropic's approach to alignment. Instead of relying solely on human feedback, the model critiques and revises its own outputs based on a set of written principles (a 'constitution'). The model generates, self-critiques, and revises in a loop, then trains on the improved outputs via RLAIF."
+  },
+  {
+    "term": "Content Filtering",
+    "says": "Censoring the AI",
+    "means": "Systems that detect and block harmful, toxic, or policy-violating content in model inputs or outputs. Implemented as classifier models (often fine-tuned BERT or LLaMA) that score content across categories (violence, sexual, hate). Runs in the inference pipeline, adding 10-50ms latency."
+  },
+  {
+    "term": "Context Window",
+    "says": "How much the AI can remember",
+    "means": "The maximum number of tokens (input + output) that fit in a single API call. Not memory -- it's a fixed-size buffer that resets every call. GPT-4: 128K tokens. Claude: 200K. Gemini: 1M+."
+  },
+  {
+    "term": "Continual Learning",
+    "says": "Teaching a model new things without forgetting old things",
+    "means": "Training a model on a stream of tasks sequentially while retaining performance on all previous tasks. Approaches: replay buffers (store old examples), regularization (penalize changing important weights), architecture expansion (add new parameters per task). No approach fully solves catastrophic forgetting yet."
+  },
+  {
+    "term": "Continuous Batching",
+    "says": "Smarter batching for LLM servers",
+    "means": "Instead of waiting for all sequences in a batch to finish generating before starting new ones, insert new requests as slots open up. Pioneered by Orca/vLLM. Increases GPU utilization from 30-50% to 80-95% on LLM serving workloads."
   },
   {
     "term": "Contrastive Learning",
@@ -1848,9 +2039,79 @@ const GLOSSARY = [
     "means": "Training by pulling similar pairs closer and pushing dissimilar pairs apart in embedding space. CLIP uses this: matching image-text pairs vs non-matching ones."
   },
   {
+    "term": "ControlNet",
+    "says": "Guide image generation with a sketch or pose",
+    "means": "A neural network architecture that adds spatial conditioning to a pre-trained diffusion model by copying the encoder blocks and adding zero-initialized convolutions. Accepts edge maps, depth maps, poses, or segmentation masks as input. The zero-init means it starts as an identity function and gradually learns control."
+  },
+  {
+    "term": "Correlation",
+    "says": "Two things are related",
+    "means": "A statistical measure of linear association between two variables, ranging from -1 to +1. Pearson correlation r = cov(X,Y) / (std(X) * std(Y)). r=0.8 means strong positive linear relationship. Critically: correlation does not imply causation, and it misses nonlinear relationships entirely."
+  },
+  {
+    "term": "Cross-Attention",
+    "says": "The decoder looking at the encoder",
+    "means": "An attention mechanism where queries come from one sequence and keys/values come from another. In encoder-decoder models: the decoder's queries attend to the encoder's keys and values. Also used in text-to-image diffusion: queries are image features, keys/values are text embeddings."
+  },
+  {
+    "term": "Cross-Validation",
+    "says": "Testing your model properly",
+    "means": "Splitting data into k folds, training on k-1 folds and testing on the held-out fold, rotating k times. Reports average metric across folds. Gives a more reliable performance estimate than a single train/test split, especially with small datasets (<10K examples)."
+  },
+  {
+    "term": "CUDA",
+    "says": "GPU programming",
+    "means": "NVIDIA's parallel computing platform. Lets you run matrix operations on thousands of GPU cores simultaneously. PyTorch and TensorFlow use CUDA under the hood."
+  },
+  {
+    "term": "Curriculum Learning",
+    "says": "Teaching the model easy stuff first",
+    "means": "Training on examples ordered from easy to hard, mimicking how humans learn. Define difficulty by loss, confidence, or a heuristic. Can speed up convergence by 20-30% and improve final performance on hard examples. The key challenge is defining what 'easy' means for your task."
+  },
+  {
+    "term": "Curse of Dimensionality",
+    "says": "Too many features break everything",
+    "means": "As dimensions increase, data becomes sparse exponentially. In 10D space, you need 10^10 evenly spaced points to match the density of 10 points in 1D. Distance metrics become meaningless (all points are equidistant). KNN fails. Fix: dimensionality reduction, feature selection, or use models with appropriate inductive biases."
+  },
+  {
+    "term": "DALL-E",
+    "says": "OpenAI's image generator",
+    "means": "OpenAI's text-to-image model series. DALL-E 2 used CLIP embeddings + diffusion. DALL-E 3 uses a diffusion model with much better text rendering and prompt following, achieved by training on highly descriptive captions generated by GPT-4. Integrated into ChatGPT."
+  },
+  {
     "term": "Data Augmentation",
     "says": "Making more training data",
     "means": "Creating modified copies of existing data (rotate images, add noise, paraphrase text) to increase training set diversity without collecting new data. Reduces overfitting."
+  },
+  {
+    "term": "Data Drift",
+    "says": "The input data changed on you",
+    "means": "When the distribution of production inputs shifts from what the model was trained on. Example: a model trained on weekday traffic patterns fails on holidays. Detected by monitoring input feature distributions (KL divergence, population stability index). Different from concept drift, which is about the relationship changing."
+  },
+  {
+    "term": "Data Flywheel",
+    "says": "More users means better AI means more users",
+    "means": "A virtuous cycle: deploy model, collect user interactions, use interactions to improve model, deploy improved model, attract more users. The key competitive moat in AI products. Tesla's self-driving, Google Search, and TikTok's recommendation all run on data flywheels."
+  },
+  {
+    "term": "Data Parallelism",
+    "says": "Training on multiple GPUs by splitting the data",
+    "means": "Each GPU holds a full copy of the model but processes different mini-batches. Gradients are averaged across GPUs (all-reduce) before each update. Simple to implement (PyTorch DistributedDataParallel). Linear speedup up to 64-256 GPUs before communication becomes the bottleneck."
+  },
+  {
+    "term": "DDIM (Denoising Diffusion Implicit Models)",
+    "says": "Faster diffusion sampling",
+    "means": "A deterministic sampling method for diffusion models that skips steps in the denoising process. While DDPM needs 1000 steps, DDIM achieves similar quality in 50-100 steps by making the reverse process non-Markovian (each step can skip ahead). Same trained model, just a different sampler."
+  },
+  {
+    "term": "DDPM (Denoising Diffusion Probabilistic Models)",
+    "says": "The original diffusion paper",
+    "means": "The foundational diffusion model formulation: gradually add Gaussian noise over T steps (forward process), then train a neural network to predict and remove the noise at each step (reverse process). T is typically 1000. Each step removes a small amount of noise. Mathematically grounded in score matching and variational inference."
+  },
+  {
+    "term": "Decision Boundary",
+    "says": "The line that separates the classes",
+    "means": "The surface in feature space where the model's predicted class changes. A linear classifier has a hyperplane boundary. Neural networks can learn arbitrarily complex, nonlinear boundaries. The shape of the decision boundary determines what the model can and cannot separate."
   },
   {
     "term": "Decoder",
@@ -1858,14 +2119,44 @@ const GLOSSARY = [
     "means": "In transformers, a decoder uses causal (masked) self-attention so each position can only attend to earlier positions. GPT is decoder-only. BERT is encoder-only. T5 is encoder-decoder."
   },
   {
+    "term": "Deepfake",
+    "says": "Fake videos of real people",
+    "means": "AI-generated or manipulated media (video, audio, images) that convincingly depicts events that never occurred. Face-swap deepfakes use autoencoders or GANs to map one person's expressions onto another's face. Detection relies on artifacts: inconsistent lighting, unnatural blinking, frequency-domain anomalies."
+  },
+  {
+    "term": "DeepSpeed",
+    "says": "Microsoft's training framework",
+    "means": "A PyTorch extension that enables training models too large for a single GPU. ZeRO (Zero Redundancy Optimizer) partitions optimizer states, gradients, and parameters across GPUs. ZeRO Stage 3 can train a 100B parameter model on 64 GPUs where each GPU only holds a fraction of the model."
+  },
+  {
+    "term": "Depthwise Separable Convolution",
+    "says": "Efficient convolution for mobile",
+    "means": "Factorizes a standard convolution into two steps: depthwise (one filter per channel) and pointwise (1x1 convolution to mix channels). Reduces computation by roughly k^2x for a k-sized kernel. A 3x3 depthwise separable conv uses 8-9x fewer operations than a standard 3x3 conv. Used in MobileNet, EfficientNet."
+  },
+  {
+    "term": "Differential Privacy",
+    "says": "Training without leaking anyone's data",
+    "means": "A mathematical guarantee that a model's outputs don't reveal whether any individual was in the training set. Achieved by adding calibrated noise to gradients during training (DP-SGD). The privacy budget epsilon controls the tradeoff: epsilon=1 is strong privacy but hurts accuracy, epsilon=10 is weaker but more useful."
+  },
+  {
     "term": "Diffusion Model",
     "says": "AI that generates images from noise",
-    "means": "A model trained to reverse a gradual noising process — it learns to predict and remove noise, and at generation time starts from pure noise and iteratively denoises"
+    "means": "A model trained to reverse a gradual noising process -- it learns to predict and remove noise, and at generation time starts from pure noise and iteratively denoises."
+  },
+  {
+    "term": "Dimensionality Reduction",
+    "says": "Making data simpler",
+    "means": "Projecting high-dimensional data into fewer dimensions while preserving important structure. PCA finds orthogonal axes of maximum variance. t-SNE and UMAP preserve local neighborhoods for visualization. Autoencoders learn nonlinear projections. Use when features >> samples or for visualization."
+  },
+  {
+    "term": "Distillation",
+    "says": "Making a smaller model that acts like a bigger one",
+    "means": "Training a small 'student' model to mimic a large 'teacher' model's outputs (soft probabilities, not just hard labels). The soft targets carry information about inter-class relationships. A distilled 1B model can often match a 7B model on specific tasks. DistilBERT is 60% the size of BERT with 97% of its performance."
   },
   {
     "term": "DPO (Direct Preference Optimization)",
     "says": "A simpler RLHF",
-    "means": "A training method that skips the reward model entirely — it directly optimizes the language model to prefer the better response in pairs of human preferences"
+    "means": "A training method that skips the reward model entirely -- it directly optimizes the language model to prefer the better response in pairs of human preferences. Simpler to implement than PPO and often produces comparable results."
   },
   {
     "term": "Dropout",
@@ -1880,7 +2171,12 @@ const GLOSSARY = [
   {
     "term": "Embedding",
     "says": "Some AI magic that turns words into numbers",
-    "means": "A learned mapping from discrete items (words, images, users) to dense vectors in continuous space, where similar items end up close together"
+    "means": "A learned mapping from discrete items (words, images, users) to dense vectors in continuous space, where similar items end up close together. OpenAI's text-embedding-3-large produces 3072-dimensional vectors."
+  },
+  {
+    "term": "Emergent Abilities",
+    "says": "The AI just spontaneously learned to do things",
+    "means": "Capabilities that appear only above a certain model scale and are absent below it. Examples: GPT-3 (175B) can do few-shot arithmetic but GPT-2 (1.5B) cannot. Controversial: some researchers argue emergence is an artifact of metric choice (discontinuous metrics like exact-match) rather than true phase transitions."
   },
   {
     "term": "Encoder",
@@ -1893,19 +2189,84 @@ const GLOSSARY = [
     "means": "Exactly that. One complete pass through every example in the training set. Multiple epochs = seeing the data multiple times. More epochs can improve learning but risks overfitting."
   },
   {
+    "term": "ExLlama",
+    "says": "Fast quantized LLM inference",
+    "means": "A highly optimized CUDA kernel for running GPTQ-quantized models. ExLlamaV2 supports 2/3/4/5/6/8-bit quantization with mixed precision per layer. Achieves 2-4x faster inference than standard HuggingFace on consumer GPUs by writing custom CUDA kernels for quantized matrix multiplication."
+  },
+  {
+    "term": "Explainability (XAI)",
+    "says": "Understanding what the AI is thinking",
+    "means": "Techniques for making model decisions interpretable to humans. Post-hoc methods: SHAP (Shapley values for feature importance), LIME (local linear approximation), attention visualization, saliency maps. Inherently interpretable: decision trees, linear models. There's a tradeoff: more complex models are harder to explain."
+  },
+  {
+    "term": "Exploding Gradient",
+    "says": "Training blew up",
+    "means": "Gradients grow exponentially as they propagate backward through many layers, causing weights to become NaN or infinity. Common in deep RNNs. Fix with gradient clipping (cap the norm at 1.0), careful initialization, residual connections, or normalization layers."
+  },
+  {
+    "term": "F1 Score",
+    "says": "The balanced accuracy metric",
+    "means": "The harmonic mean of precision and recall: F1 = 2 * (precision * recall) / (precision + recall). Ranges 0-1. Useful when classes are imbalanced and you care about both false positives and false negatives. F1=0.5 means either precision or recall (or both) is poor."
+  },
+  {
+    "term": "Fairness",
+    "says": "Making AI not discriminate",
+    "means": "Ensuring model predictions are equitable across demographic groups. Multiple formal definitions exist and they are mathematically incompatible: demographic parity (equal positive rate), equalized odds (equal TPR and FPR), individual fairness (similar people get similar predictions). You must choose which definition matters for your use case."
+  },
+  {
+    "term": "FAISS",
+    "says": "Facebook's vector search library",
+    "means": "Meta's library for efficient similarity search on dense vectors. Supports exact and approximate nearest neighbor (ANN) methods: IVF (inverted file index), HNSW, PQ (product quantization). Can search billions of vectors in milliseconds. The backbone of most production RAG systems."
+  },
+  {
     "term": "Feature",
     "says": "A column in your data",
     "means": "An individual measurable property of the data. In classical ML, you engineer features by hand. In deep learning, the network learns features automatically from raw data."
   },
   {
-    "term": "Fine-tuning",
-    "says": "Training the AI on your data",
-    "means": "Starting with a pre-trained model's weights and continuing training on a smaller, task-specific dataset. Only updates existing weights, doesn't add new knowledge from scratch"
+    "term": "Feature Map",
+    "says": "What the CNN sees at each layer",
+    "means": "The output tensor of a convolutional layer. If a layer has 64 filters applied to a 224x224 input, the output is 64 feature maps, each showing where that filter's pattern was detected. Early layers detect edges, middle layers detect textures, deep layers detect object parts."
   },
   {
-    "term": "GPT",
-    "says": "ChatGPT\" or \"The AI",
-    "means": "Generative Pre-trained Transformer — a specific architecture that predicts the next token using a decoder-only transformer trained on large text corpora"
+    "term": "Feature Store",
+    "says": "A database for ML features",
+    "means": "A centralized system that stores, serves, and manages features for ML models. Ensures consistency between training (offline) and serving (online) feature computation. Examples: Feast (open-source), Tecton, Hopsworks. Prevents training-serving skew, the #1 cause of silent ML failures in production."
+  },
+  {
+    "term": "Federated Learning",
+    "says": "Training without sharing data",
+    "means": "A distributed training approach where data stays on local devices. Each device trains a local model, sends only gradient updates (not data) to a central server, which aggregates them. Used by Google for Gboard predictions. Challenges: non-IID data across devices, communication costs, and privacy (gradients can still leak information)."
+  },
+  {
+    "term": "Few-Shot",
+    "says": "Give the model a few examples and it figures it out",
+    "means": "Including 2-10 examples of the desired input-output format in the prompt before the actual query. The model uses in-context learning to infer the pattern. More examples generally improve accuracy up to a point (diminishing returns after 5-8 for most tasks). Costs tokens but requires no training."
+  },
+  {
+    "term": "Fine-tuning",
+    "says": "Training the AI on your data",
+    "means": "Starting with a pre-trained model's weights and continuing training on a smaller, task-specific dataset. Only updates existing weights, doesn't add new knowledge from scratch."
+  },
+  {
+    "term": "Flash Attention",
+    "says": "Faster attention that uses less memory",
+    "means": "An IO-aware implementation of attention that tiles the computation to minimize reads/writes between GPU SRAM and HBM. Reduces memory from O(n^2) to O(n) and speeds up attention 2-4x by avoiding materializing the full n*n attention matrix. Now standard in all major frameworks."
+  },
+  {
+    "term": "FLOPS",
+    "says": "How fast the GPU is",
+    "means": "Floating-point Operations Per Second. Measures computational throughput. An H100 does 990 TFLOPS (10^12) in FP16. Training a GPT-3 sized model takes roughly 3.14 * 10^23 FLOPS. Model FLOPS Utilization (MFU) measures what fraction of theoretical peak you actually achieve (typically 30-60%)."
+  },
+  {
+    "term": "Flow Matching",
+    "says": "A better way to train diffusion models",
+    "means": "Instead of learning to denoise at each noise level separately (DDPM), train a model to predict the velocity field that transports samples from noise to data along straight paths. Simpler training objective, faster sampling (fewer steps needed), and often better FID scores. Used in Stable Diffusion 3."
+  },
+  {
+    "term": "FSDP (Fully Sharded Data Parallelism)",
+    "says": "PyTorch's way to train huge models",
+    "means": "Shards model parameters, gradients, and optimizer states across GPUs, and gathers them on-demand for each layer's forward/backward pass. Like DeepSpeed ZeRO Stage 3 but natively integrated into PyTorch. Memory per GPU: O(model_size / num_GPUs) instead of O(model_size)."
   },
   {
     "term": "GAN (Generative Adversarial Network)",
@@ -1913,14 +2274,84 @@ const GLOSSARY = [
     "means": "A generator network tries to create realistic data while a discriminator network tries to tell real from fake. They train together: the generator gets better at fooling the discriminator, and the discriminator gets better at detecting fakes."
   },
   {
+    "term": "GELU",
+    "says": "The activation function transformers use",
+    "means": "Gaussian Error Linear Unit: GELU(x) = x * Phi(x), where Phi is the standard Gaussian CDF. Approximated as 0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3))). Smoother than ReLU (no hard zero cutoff). Used in GPT, BERT, and most modern transformers."
+  },
+  {
+    "term": "GGUF",
+    "says": "The file format for local LLMs",
+    "means": "A binary format for storing quantized LLMs, designed for llama.cpp. Stores model architecture metadata, tokenizer, and quantized weights in a single file. Supports 2-bit through 8-bit quantization. Replaced GGML format. The standard way to run LLMs on CPUs and consumer GPUs."
+  },
+  {
+    "term": "Goodhart's Law (ML)",
+    "says": "When a measure becomes a target, it stops being a good measure",
+    "means": "When you optimize a proxy metric too aggressively, the model finds shortcuts that game the metric without achieving the true objective. A clickbait detector optimized on click-through rate will maximize clickbait. A code generator optimized on pass@1 will overfit to test patterns. Central to alignment and reward hacking."
+  },
+  {
+    "term": "GPT",
+    "says": "ChatGPT or The AI",
+    "means": "Generative Pre-trained Transformer -- a specific architecture that predicts the next token using a decoder-only transformer trained on large text corpora. GPT-3 has 175B parameters, GPT-4 is believed to be a MoE with ~1.8T total parameters."
+  },
+  {
+    "term": "GPTQ",
+    "says": "A way to make models smaller",
+    "means": "A post-training quantization method that quantizes weights to 3-4 bits by solving a layer-wise least-squares problem. Processes one layer at a time, using second-order information (Hessian) to minimize quantization error. A 4-bit GPTQ model uses 4x less memory than FP16 with typically <1% accuracy loss."
+  },
+  {
     "term": "Gradient",
     "says": "The slope",
     "means": "A vector of partial derivatives pointing in the direction of steepest increase. In ML, you go opposite to the gradient (gradient descent) to minimize the loss."
   },
   {
+    "term": "Gradient Clipping",
+    "says": "Preventing exploding gradients",
+    "means": "Capping gradient values during training to prevent instability. Two methods: clip by value (clamp each element to [-max, max]) or clip by norm (scale the entire gradient vector if its norm exceeds a threshold). Typical threshold: 1.0. Essential for training RNNs, LSTMs, and deep transformers."
+  },
+  {
     "term": "Gradient Descent",
     "says": "How AI improves",
-    "means": "An optimization algorithm that adjusts parameters in the direction that reduces the loss function most steeply, like walking downhill in a high-dimensional landscape"
+    "means": "An optimization algorithm that adjusts parameters in the direction that reduces the loss function most steeply, like walking downhill in a high-dimensional landscape."
+  },
+  {
+    "term": "Graph Neural Network (GNN)",
+    "says": "AI for networks and graphs",
+    "means": "A neural network that operates on graph-structured data by passing messages between connected nodes. Each node aggregates information from its neighbors, updating its representation over multiple rounds. Used for molecular property prediction, social network analysis, and recommendation systems. Key variants: GCN, GAT, GraphSAGE."
+  },
+  {
+    "term": "Greedy Decoding",
+    "says": "Just pick the most likely word each time",
+    "means": "At each step, select the token with the highest probability. Fast (no branching) but often produces repetitive or suboptimal text because it never explores lower-probability tokens that might lead to better overall sequences. Equivalent to temperature=0."
+  },
+  {
+    "term": "Grouped Query Attention (GQA)",
+    "says": "A middle ground between MHA and MQA",
+    "means": "Instead of each attention head having its own key-value pair (MHA) or all heads sharing one (MQA), groups of heads share key-value pairs. LLaMA 2 70B uses 8 KV heads for 64 query heads (8 groups of 8). Reduces KV cache memory by 8x while retaining most of MHA's quality."
+  },
+  {
+    "term": "GRU (Gated Recurrent Unit)",
+    "says": "A simpler LSTM",
+    "means": "A recurrent unit with two gates (reset and update) instead of LSTM's three. The update gate controls how much of the previous hidden state to keep. Fewer parameters than LSTM, similar performance on many tasks. Both largely replaced by transformers for most NLP but still used in small-scale sequential tasks."
+  },
+  {
+    "term": "Guardrails",
+    "says": "Safety rails for AI outputs",
+    "means": "Systems that validate, filter, or constrain LLM inputs and outputs. Can be rule-based (regex, blocklists), model-based (classifiers), or structural (JSON schema validation). Examples: NeMo Guardrails, Guardrails AI, LangChain output parsers. Add 20-100ms latency but prevent harmful or malformed outputs."
+  },
+  {
+    "term": "Hallucination",
+    "says": "The AI is lying or making things up",
+    "means": "The model generates plausible-sounding text that isn't grounded in its training data or the given context -- it's pattern-completing, not fact-retrieving. Rates vary: 5-20% of factual claims in open-ended generation. Mitigated by RAG, citations, and constrained decoding."
+  },
+  {
+    "term": "HNSW (Hierarchical Navigable Small Worlds)",
+    "says": "The fast approximate search algorithm",
+    "means": "A graph-based algorithm for approximate nearest neighbor search. Builds a multi-layer graph where the top layer has few nodes (long-range connections) and the bottom layer has all nodes (short-range). Search starts at the top and greedily descends. O(log n) query time. The default ANN algorithm in most vector databases."
+  },
+  {
+    "term": "Hybrid Search",
+    "says": "Using both keyword and semantic search",
+    "means": "Combining sparse retrieval (BM25/keyword matching) with dense retrieval (vector similarity) for better recall. Typically: run both, normalize scores, combine with a weighted sum (alpha * dense + (1-alpha) * sparse). Alpha of 0.5-0.7 works well for most RAG use cases. Reciprocal rank fusion is another combination method."
   },
   {
     "term": "Hyperparameter",
@@ -1928,14 +2359,14 @@ const GLOSSARY = [
     "means": "Values set before training that control the training process itself: learning rate, batch size, number of layers, dropout rate. Unlike model parameters (weights), these aren't learned from data."
   },
   {
-    "term": "Hallucination",
-    "says": "The AI is lying\" or \"making things up",
-    "means": "The model generates plausible-sounding text that isn't grounded in its training data or the given context — it's pattern-completing, not fact-retrieving"
+    "term": "Image-to-Image",
+    "says": "Transform one image into another",
+    "means": "Using a diffusion model to generate a new image conditioned on an input image. The input is partially noised (controlled by 'strength' parameter, 0-1), then denoised with a text prompt guiding the output. Strength 0.3 makes small changes, 0.8 makes dramatic changes while keeping rough structure."
   },
   {
-    "term": "Inference",
-    "says": "Running the AI",
-    "means": "Using a trained model to make predictions on new data. No weight updates happen. This is what you do in production: send input, get output."
+    "term": "In-Context Learning",
+    "says": "The model learns from examples in the prompt",
+    "means": "The ability of large language models to perform new tasks by conditioning on examples provided in the prompt, without any gradient updates. Emergent at scale: GPT-3 (175B) demonstrated it, smaller models struggle. Mechanistically, the model appears to implement a form of gradient descent in its forward pass."
   },
   {
     "term": "Inductive Bias",
@@ -1943,9 +2374,79 @@ const GLOSSARY = [
     "means": "The assumptions built into a model's architecture. CNNs assume local patterns matter (convolution). RNNs assume order matters (sequential processing). Transformers assume everything might relate to everything (attention). The right bias helps the model learn faster from less data."
   },
   {
+    "term": "Inference",
+    "says": "Running the AI",
+    "means": "Using a trained model to make predictions on new data. No weight updates happen. This is what you do in production: send input, get output."
+  },
+  {
+    "term": "Information Gain",
+    "says": "How much a feature helps the decision",
+    "means": "The reduction in entropy after splitting data on a feature. IG(S, A) = Entropy(S) - sum(|Sv|/|S| * Entropy(Sv)) for each value v of attribute A. Used in decision tree construction (ID3, C4.5) to choose which feature to split on. Higher information gain = more useful feature."
+  },
+  {
+    "term": "Inpainting",
+    "says": "AI fills in the missing part of an image",
+    "means": "Generating content for a masked region of an image while maintaining consistency with the unmasked surroundings. Diffusion models condition on both the text prompt and the visible pixels. The mask defines which pixels to regenerate. Used for object removal, photo restoration, and creative editing."
+  },
+  {
+    "term": "Instruction Tuning",
+    "says": "Teaching the model to follow instructions",
+    "means": "Fine-tuning a base model on a dataset of (instruction, response) pairs across diverse tasks: summarization, coding, math, Q&A, creative writing. FLAN-T5 was tuned on 1,836 tasks. The key step that turns a next-token predictor into a useful assistant. Often combined with RLHF/DPO afterward."
+  },
+  {
+    "term": "Interpretability",
+    "says": "Understanding what's going on inside the model",
+    "means": "The study of understanding how neural networks make decisions internally. Mechanistic interpretability analyzes individual neurons, circuits, and features. Probing trains small classifiers on hidden states to test what information is encoded. Anthropic's work found features for concepts like 'Golden Gate Bridge' in Claude's activations."
+  },
+  {
+    "term": "JSON Mode",
+    "says": "Making the AI always return valid JSON",
+    "means": "A decoding constraint that forces the model to output valid JSON by restricting the token probability distribution at each step. Only tokens that maintain valid JSON syntax receive non-zero probability. Eliminates parsing failures. Supported by OpenAI, Anthropic, and most inference engines."
+  },
+  {
+    "term": "K-Fold",
+    "says": "Splitting the data k different ways",
+    "means": "A cross-validation strategy: divide data into k equally-sized folds (k=5 or k=10 is standard), train k models each using a different fold as the test set. Report mean and standard deviation of the metric across folds. Stratified k-fold preserves class proportions in each fold."
+  },
+  {
+    "term": "Kernel",
+    "says": "The filter in a CNN",
+    "means": "A small matrix of learnable weights (typically 3x3 or 5x5) that slides across the input performing element-wise multiplication and summing. Each kernel detects one type of pattern. A 3x3 kernel on a 224x224 image produces a 222x222 feature map (without padding). Also called a filter."
+  },
+  {
+    "term": "Knowledge Distillation",
+    "says": "A big model teaching a small model",
+    "means": "Training a smaller model to match a larger model's behavior, including its soft probability distributions over all classes (not just the argmax). The temperature-scaled softmax reveals the teacher's uncertainty and inter-class relationships. Loss = alpha * CE(student, hard_labels) + (1-alpha) * KL(student_soft, teacher_soft)."
+  },
+  {
+    "term": "KTO (Kahneman-Tversky Optimization)",
+    "says": "A better DPO",
+    "means": "A preference optimization method inspired by prospect theory. Unlike DPO (which needs paired preferences), KTO only needs binary feedback: thumbs up or thumbs down on individual outputs. Weights losses asymmetrically because humans are more sensitive to bad outputs than good ones. Simpler data collection than DPO."
+  },
+  {
     "term": "KV Cache",
     "says": "Makes inference faster",
-    "means": "During autoregressive generation, caching the key and value matrices from previous tokens so you don't recompute them at each step. Trades memory for speed. Essential for fast LLM inference."
+    "means": "During autoregressive generation, caching the key and value matrices from previous tokens so you don't recompute them at each step. Trades memory for speed. For a 7B model generating 2048 tokens, the KV cache can use 4-8GB of memory. Essential for fast LLM inference."
+  },
+  {
+    "term": "L1/L2 Regularization",
+    "says": "Penalizing big weights",
+    "means": "L1 adds sum of absolute weights to the loss (produces sparse weights, some go to exactly zero). L2 adds sum of squared weights (shrinks all weights toward zero but none to exactly zero). L1 is feature selection, L2 is weight decay. Lambda controls the penalty strength."
+  },
+  {
+    "term": "LangChain",
+    "says": "The framework for building LLM apps",
+    "means": "A Python/JS framework that abstracts LLM interactions into composable chains: prompt templates, LLM calls, parsers, retrievers, tools. Useful for prototyping RAG and agent pipelines. Criticized for over-abstraction and leaky abstractions. LangGraph (its agent framework) is more opinionated about state machines."
+  },
+  {
+    "term": "Latency (ML)",
+    "says": "How long the AI takes to respond",
+    "means": "The time from sending a request to receiving the first or complete response. For LLMs, two metrics matter: time to first token (TTFT, typically 100-500ms) and inter-token latency (20-80ms per token). A 200-token response at 40ms/token takes 8 seconds after the first token."
+  },
+  {
+    "term": "Latent Diffusion",
+    "says": "Diffusion in compressed space",
+    "means": "Running the diffusion process in the latent space of a pre-trained autoencoder instead of pixel space. A 512x512 image becomes a 64x64 latent (64x smaller), making diffusion 10-100x cheaper. Stable Diffusion is a latent diffusion model. The autoencoder (VAE) encodes images to latents and decodes back."
   },
   {
     "term": "Latent Space",
@@ -1953,39 +2454,174 @@ const GLOSSARY = [
     "means": "A compressed, learned representation space where similar inputs map to nearby points. Autoencoders, VAEs, and diffusion models all work in latent space. It's lower-dimensional than the input but captures the important structure."
   },
   {
+    "term": "Layer Normalization",
+    "says": "Normalizing within each example",
+    "means": "Normalizes activations across the feature dimension for each individual example (not across the batch). LayerNorm(x) = (x - mean) / sqrt(var + eps) * gamma + beta, where mean and var are computed per-example. Works with any batch size, including 1. Standard in transformers."
+  },
+  {
     "term": "Learning Rate",
     "says": "How fast the AI learns",
-    "means": "A scalar that controls step size during gradient descent. Too high: overshoots the minimum and diverges. Too low: converges too slowly or gets stuck. The single most important hyperparameter."
+    "means": "A scalar that controls step size during gradient descent. Too high: overshoots the minimum and diverges. Too low: converges too slowly or gets stuck. The single most important hyperparameter. Typical values: 1e-3 for Adam, 1e-5 for fine-tuning LLMs."
+  },
+  {
+    "term": "LIME",
+    "says": "Explaining individual predictions",
+    "means": "Local Interpretable Model-agnostic Explanations. For a single prediction, perturbs the input many times, observes how the model's output changes, and fits a simple linear model to the local region. The linear model's coefficients indicate which features drove that specific prediction. Model-agnostic: works on any black-box model."
+  },
+  {
+    "term": "Linear Regression",
+    "says": "Fitting a line to data",
+    "means": "Predicting a continuous output as a weighted sum of inputs: y = w1*x1 + w2*x2 + ... + b. Minimizes mean squared error. Has a closed-form solution: w = (X^T X)^(-1) X^T y. Assumptions: linear relationship, independent errors, constant variance. The simplest model and often a surprisingly strong baseline."
+  },
+  {
+    "term": "LlamaIndex",
+    "says": "The other LLM framework",
+    "means": "A data framework for LLM applications focused on connecting custom data to LLMs. Strengths: document loaders (PDF, HTML, databases), index structures (vector, keyword, tree, knowledge graph), and query engines. More data-centric than LangChain. Good for RAG pipelines with complex document structures."
   },
   {
     "term": "LLM (Large Language Model)",
-    "says": "AI\" or \"the brain",
-    "means": "A transformer-based neural network trained to predict the next token in a sequence, with billions of parameters, trained on internet-scale text data"
+    "says": "AI or the brain",
+    "means": "A transformer-based neural network trained to predict the next token in a sequence, with billions of parameters, trained on internet-scale text data. Training costs $1M-$100M+ in compute."
+  },
+  {
+    "term": "Logistic Regression",
+    "says": "Classification despite the name",
+    "means": "A linear model for binary classification: P(y=1|x) = sigmoid(w^T x + b). Despite the name, it's a classifier, not regression. The sigmoid squashes the linear output to [0,1]. Trained with binary cross-entropy loss. Decision boundary is a hyperplane. Fast, interpretable, and a strong baseline."
   },
   {
     "term": "LoRA (Low-Rank Adaptation)",
     "says": "Efficient fine-tuning",
-    "means": "Instead of updating all weights, insert small low-rank matrices alongside the original weights. Only these small matrices are trained, reducing memory by 10-100x"
+    "means": "Instead of updating all weights, insert small low-rank matrices (rank 8-64) alongside the original weights. Only these small matrices are trained, reducing trainable parameters by 10-100x. A rank-16 LoRA on a 7B model trains ~10M parameters instead of 7B."
   },
   {
     "term": "Loss Function",
     "says": "How wrong the AI is",
-    "means": "A function that measures the gap between predicted and actual output. Training minimizes this function. MSE for regression, cross-entropy for classification, contrastive loss for embeddings. The choice of loss function defines what \"good\" means to the model."
+    "means": "A function that measures the gap between predicted and actual output. Training minimizes this function. MSE for regression, cross-entropy for classification, contrastive loss for embeddings. The choice of loss function defines what 'good' means to the model."
   },
   {
-    "term": "Mixed Precision",
-    "says": "Training trick for speed",
-    "means": "Using float16 for forward pass and most operations (faster, less memory) but keeping float32 for gradient accumulation and weight updates (more precise). Gets 2x speedup with negligible accuracy loss."
+    "term": "Loss Landscape",
+    "says": "The hills and valleys the optimizer walks through",
+    "means": "A high-dimensional surface where each point is a set of parameter values and the height is the loss. Training navigates this landscape. Good architectures have smooth landscapes with wide minima (which generalize better). ResNets smoothed the landscape vs plain networks. Batch normalization also smooths it."
   },
   {
-    "term": "MoE (Mixture of Experts)",
-    "says": "Only part of the model runs",
-    "means": "A model with many \"expert\" subnetworks where a routing mechanism sends each input to only a few experts. The full model is huge but each forward pass is cheap because most experts are skipped. Mixtral and GPT-4 use this."
+    "term": "LSTM (Long Short-Term Memory)",
+    "says": "The old way to handle sequences",
+    "means": "A recurrent unit with three gates (forget, input, output) and a cell state that acts as a long-term memory conveyor belt. The forget gate decides what to discard, the input gate decides what to add, and the output gate decides what to expose. Solved vanishing gradients for RNNs but is 10-100x slower than transformers."
+  },
+  {
+    "term": "Majority Voting",
+    "says": "Ask the model multiple times and go with the most common answer",
+    "means": "Generate n responses (typically 5-40) at high temperature and select the most frequent answer. Self-consistency (Wang et al., 2022) showed this improves CoT accuracy by 5-15% on reasoning benchmarks. Works because correct reasoning paths are more likely to converge on the same answer."
+  },
+  {
+    "term": "Mamba",
+    "says": "The transformer killer",
+    "means": "A selective state space model (S4 variant) that achieves transformer-quality language modeling with linear (O(n)) complexity instead of quadratic (O(n^2)). Uses input-dependent selection to decide what to remember, unlike fixed SSMs. 5x faster throughput than transformer at 1M sequence length. Mamba-2 bridges SSMs and attention."
+  },
+  {
+    "term": "Masked Language Model",
+    "says": "Fill in the blank",
+    "means": "A pre-training objective where random tokens (typically 15%) are replaced with a [MASK] token, and the model predicts the original token. BERT's pre-training method. Produces bidirectional representations (unlike autoregressive models) because the model sees context from both sides. Not used for generation."
   },
   {
     "term": "MCP (Model Context Protocol)",
     "says": "A way for AI to use tools",
-    "means": "An open protocol (JSON-RPC over stdio/HTTP) that standardizes how AI applications connect to external data sources and tools, with typed schemas for tools, resources, and prompts"
+    "means": "An open protocol (JSON-RPC over stdio/HTTP) that standardizes how AI applications connect to external data sources and tools, with typed schemas for tools, resources, and prompts."
+  },
+  {
+    "term": "Mean Squared Error",
+    "says": "Average of the squared differences",
+    "means": "MSE = (1/n) * sum((y_predicted - y_actual)^2). The standard loss for regression. Squaring means large errors are penalized disproportionately. MSE of 0.01 means predictions are off by sqrt(0.01) = 0.1 on average. Sensitive to outliers because of the squaring."
+  },
+  {
+    "term": "Megatron",
+    "says": "NVIDIA's giant model training framework",
+    "means": "NVIDIA's library for training large transformers using a combination of tensor parallelism (splitting individual layers across GPUs), pipeline parallelism (splitting layers across GPUs), and data parallelism. Can scale to thousands of GPUs. The training framework behind many of the largest open models."
+  },
+  {
+    "term": "Memory (Agent)",
+    "says": "The AI remembers past conversations",
+    "means": "A storage mechanism that persists information across agent turns or sessions. Short-term: conversation history in the context window. Long-term: stored in a vector database or key-value store, retrieved when relevant. Working memory: scratchpad for current task state. Without memory, every turn starts from zero."
+  },
+  {
+    "term": "Merging (Model Merging)",
+    "says": "Combining multiple fine-tuned models into one",
+    "means": "Creating a single model from multiple fine-tuned models without additional training. Methods: linear interpolation (weighted average of weights), SLERP (spherical interpolation), TIES (resolving sign conflicts), DARE (drop and rescale). A merged model can combine a coding expert and a chat expert into one model."
+  },
+  {
+    "term": "Midjourney",
+    "says": "The pretty image generator",
+    "means": "A proprietary text-to-image model accessed through Discord (and later a web app). Known for aesthetically pleasing, artistic outputs compared to Stable Diffusion's more literal interpretations. Uses a diffusion architecture with proprietary training data and aesthetic fine-tuning. V6 introduced consistent character generation."
+  },
+  {
+    "term": "Mini-Batch",
+    "says": "A small chunk of training data",
+    "means": "A subset of the training set used for one gradient update. Full-batch (entire dataset) is slow and memory-intensive. Stochastic (one example) is noisy. Mini-batch (32-512 examples) balances noise and efficiency. The gradient from a mini-batch is an unbiased estimate of the true gradient."
+  },
+  {
+    "term": "Mixed Precision",
+    "says": "Training trick for speed",
+    "means": "Using float16/bfloat16 for forward pass and most operations (faster, less memory) but keeping float32 for gradient accumulation and weight updates (more precise). Gets 2x speedup with negligible accuracy loss. bfloat16 is preferred over float16 because it has the same exponent range as float32."
+  },
+  {
+    "term": "Mixture of Agents",
+    "says": "Multiple LLMs working together",
+    "means": "An architecture where multiple LLM instances process the same input independently, then an aggregator model synthesizes their outputs. Different from MoE (which routes within one model). Achieves higher accuracy than any individual model by leveraging diverse model strengths. Can use different model families."
+  },
+  {
+    "term": "MLOps",
+    "says": "DevOps but for ML",
+    "means": "Practices for deploying and maintaining ML models in production: versioning data and models, automated training pipelines, monitoring performance, detecting drift, A/B testing, rollbacks. Tools: MLflow (tracking), Weights & Biases (experiments), Kubeflow (pipelines), Seldon (serving). The gap between 'it works in a notebook' and 'it works in production'."
+  },
+  {
+    "term": "Model Card",
+    "says": "A README for the model",
+    "means": "A structured document describing a model's intended use, training data, performance metrics across subgroups, limitations, and ethical considerations. Proposed by Mitchell et al. (2019). Required by HuggingFace for model uploads. Should include: what it does, what it doesn't do, who it's for, and known biases."
+  },
+  {
+    "term": "Model Monitoring",
+    "says": "Watching your model in production",
+    "means": "Tracking model performance, input distributions, and output quality in real-time after deployment. Key metrics: prediction latency, error rate, feature drift (PSI > 0.2 = significant), output distribution shift, and business KPIs. Without monitoring, models silently degrade. Tools: Evidently, WhyLabs, Arize."
+  },
+  {
+    "term": "Model Registry",
+    "says": "Version control for models",
+    "means": "A centralized store for trained model artifacts with versioning, metadata, and lifecycle management (staging, production, archived). MLflow Model Registry is the most common. Tracks which model version is in production, who trained it, what data it used, and its evaluation metrics."
+  },
+  {
+    "term": "Model Serving",
+    "says": "Putting the model behind an API",
+    "means": "Running a trained model as a service that accepts requests and returns predictions. Considerations: batching (group requests for GPU efficiency), auto-scaling, model loading time, memory management, and request routing. Tools: vLLM, TGI, Triton Inference Server, TorchServe, BentoML."
+  },
+  {
+    "term": "MoE (Mixture of Experts)",
+    "says": "Only part of the model runs",
+    "means": "A model with many 'expert' subnetworks where a routing mechanism sends each input to only a few experts. The full model is huge but each forward pass is cheap because most experts are skipped. Mixtral 8x7B has 47B total parameters but only uses 13B per token."
+  },
+  {
+    "term": "Multi-Agent System",
+    "says": "A team of AI agents",
+    "means": "Multiple agents with different roles (planner, coder, reviewer, tester) collaborating on a task through message passing. Common patterns: supervisor (one agent delegates), debate (agents argue to improve answers), round-robin (sequential processing). Coordination overhead is the main challenge."
+  },
+  {
+    "term": "Multi-Head Attention",
+    "says": "Attention but with multiple perspectives",
+    "means": "Running attention in parallel across h heads, each with its own learned Q, K, V projections of dimension d_model/h. If d_model=1024 and h=16, each head operates on 64-dimensional vectors. Heads can specialize: some attend to syntax, others to semantics, others to position. Outputs are concatenated and linearly projected."
+  },
+  {
+    "term": "Multi-Query Attention (MQA)",
+    "says": "Sharing keys and values across heads",
+    "means": "All attention heads share a single set of key and value projections while each head has its own query projection. Reduces KV cache memory by num_heads times (e.g., 32x for a 32-head model). Slightly lower quality than multi-head attention but dramatically faster inference. Used in PaLM, Falcon."
+  },
+  {
+    "term": "Multiclass Classification",
+    "says": "Picking one label from many options",
+    "means": "Predicting one of k classes (k > 2). The final layer has k neurons with softmax activation, producing a probability distribution over classes. Trained with categorical cross-entropy loss. For 1000 ImageNet classes, the model outputs 1000 probabilities summing to 1."
+  },
+  {
+    "term": "Music Generation",
+    "says": "AI that makes songs",
+    "means": "Models that generate audio music from text descriptions or other conditioning. Approaches: audio-domain diffusion (Stable Audio), discrete audio tokens + language model (MusicGen, Jukebox), or MIDI generation. Challenges: long-range structure (verses, choruses), multi-instrument coherence, and copyright concerns."
   },
   {
     "term": "NaN (Not a Number)",
@@ -1993,14 +2629,39 @@ const GLOSSARY = [
     "means": "A floating-point value indicating undefined results (0/0, inf-inf). In training, NaN loss usually means: learning rate too high, exploding gradients, log of zero, or division by zero. Always the first thing to check when training fails."
   },
   {
+    "term": "NeRF (Neural Radiance Fields)",
+    "says": "AI that creates 3D from photos",
+    "means": "A neural network that maps 3D coordinates + viewing direction to color and density, enabling novel view synthesis from a set of 2D images. Trained per scene by minimizing photometric loss between rendered and real images. Produces photorealistic 3D renders but training takes hours per scene. Largely superseded by 3D Gaussian Splatting for speed."
+  },
+  {
+    "term": "Neural Architecture Search (NAS)",
+    "says": "AI that designs AI",
+    "means": "Automated search for optimal neural network architecture (number of layers, widths, connections, operations). Methods: reinforcement learning (train a controller), evolutionary algorithms, or weight-sharing (one-shot NAS). EfficientNet was discovered by NAS. Typically requires 1000-10000 GPU hours. Most practitioners still design by hand."
+  },
+  {
+    "term": "Next Token Prediction",
+    "says": "The AI just guesses the next word",
+    "means": "The training objective for autoregressive language models: given tokens [t1, t2, ..., tn], predict P(t_{n+1}). The loss is cross-entropy between the predicted distribution and the one-hot true token. This single objective, at scale, produces models capable of translation, coding, reasoning, and more."
+  },
+  {
     "term": "Normalization",
     "says": "Scaling the data",
     "means": "Adjusting values to a standard range. Batch normalization normalizes across a batch. Layer normalization normalizes across features. Both stabilize training and allow higher learning rates."
   },
   {
-    "term": "Overfitting",
-    "says": "The model memorized the data",
-    "means": "The model performs well on training data but poorly on unseen data. It learned the noise, not the signal. Fix with: more data, regularization (dropout, weight decay), early stopping, data augmentation, simpler model."
+    "term": "NPU (Neural Processing Unit)",
+    "says": "The AI chip in your phone/laptop",
+    "means": "A specialized processor designed for neural network inference at low power. Apple's Neural Engine does 15.8 TOPS in M2. Qualcomm's Hexagon does 45 TOPS. Intel's Meteor Lake has a dedicated NPU. Optimized for int8 matrix operations. 10-100x more power-efficient than running the same workload on a GPU."
+  },
+  {
+    "term": "One-Shot",
+    "says": "Give it one example and it gets it",
+    "means": "Providing exactly one input-output example in the prompt before the actual query. Sits between zero-shot (no examples) and few-shot (2+ examples). One example is often enough to establish the format and task intent for large models."
+  },
+  {
+    "term": "ONNX",
+    "says": "The universal model format",
+    "means": "Open Neural Network Exchange. A standard format for representing ML models that enables moving models between frameworks (PyTorch to TensorFlow, etc.) and deploying to optimized runtimes. ONNX Runtime applies graph optimizations (operator fusion, constant folding) and can be 2-5x faster than native PyTorch inference."
   },
   {
     "term": "Optimizer",
@@ -2008,29 +2669,89 @@ const GLOSSARY = [
     "means": "An algorithm that uses gradients to update model parameters. SGD is the simplest. Adam is the most common. Each optimizer has different properties: convergence speed, memory usage, sensitivity to hyperparameters."
   },
   {
+    "term": "Orchestrator-Worker",
+    "says": "One AI boss, many AI workers",
+    "means": "A multi-agent pattern where a central orchestrator LLM decomposes a task, delegates subtasks to specialized worker agents, collects results, and synthesizes the final output. The orchestrator maintains the plan and handles failures. Simpler than peer-to-peer agent systems but creates a single point of failure."
+  },
+  {
+    "term": "ORPO (Odds Ratio Preference Optimization)",
+    "says": "Another alignment method",
+    "means": "Combines SFT and preference optimization into a single training stage. Uses odds ratios instead of log probabilities to measure preference, which provides a clearer signal. Eliminates the need for a separate SFT phase before DPO, reducing training time and compute by roughly half."
+  },
+  {
+    "term": "Overfitting",
+    "says": "The model memorized the data",
+    "means": "The model performs well on training data but poorly on unseen data. It learned the noise, not the signal. Fix with: more data, regularization (dropout, weight decay), early stopping, data augmentation, simpler model."
+  },
+  {
+    "term": "PagedAttention",
+    "says": "Memory management for LLM serving",
+    "means": "A technique from vLLM that manages KV cache memory like OS virtual memory: allocates non-contiguous physical memory blocks and maps them to logical KV cache slots via a page table. Eliminates memory fragmentation and waste, improving serving throughput by 2-4x over naive pre-allocation."
+  },
+  {
     "term": "Parameter",
     "says": "Model size",
-    "means": "A learnable value in the model, typically a weight or bias. \"7B parameters\" means 7 billion learnable numbers. Each float32 parameter takes 4 bytes, so 7B parameters = 28GB of memory just for the weights."
+    "means": "A learnable value in the model, typically a weight or bias. '7B parameters' means 7 billion learnable numbers. Each float32 parameter takes 4 bytes, so 7B parameters = 28GB of memory just for the weights."
   },
   {
     "term": "Perplexity",
     "says": "How confused the model is",
-    "means": "The exponential of the average cross-entropy loss. Lower is better. A perplexity of 10 means the model is as uncertain as if it were choosing uniformly among 10 tokens at each step."
+    "means": "The exponential of the average cross-entropy loss. Lower is better. A perplexity of 10 means the model is as uncertain as if it were choosing uniformly among 10 tokens at each step. GPT-4 class models achieve perplexity around 5-8 on standard benchmarks."
+  },
+  {
+    "term": "Pinecone",
+    "says": "The managed vector database",
+    "means": "A cloud-native vector database as a service. Handles indexing, sharding, and replication automatically. Supports metadata filtering, sparse-dense hybrid search, and namespaces for multi-tenancy. Good for production RAG when you don't want to manage infrastructure. Pricing is per-pod or serverless per-query."
+  },
+  {
+    "term": "Pipeline Parallelism",
+    "says": "Splitting the model across GPUs layer by layer",
+    "means": "Placing different layers of the model on different GPUs. GPU 0 runs layers 0-15, GPU 1 runs layers 16-31, etc. Each GPU processes a micro-batch and passes activations to the next GPU. The pipeline bubble (idle time while waiting) reduces efficiency. Typically combined with data and tensor parallelism."
+  },
+  {
+    "term": "Plan-and-Execute",
+    "says": "Think before you act",
+    "means": "An agent architecture that separates planning from execution: first generate a full plan (list of steps), then execute each step. Unlike ReAct (interleaved reasoning and action), the plan is created upfront. Benefits: more coherent multi-step workflows. Drawbacks: plans may need revision when steps fail."
+  },
+  {
+    "term": "Pooling",
+    "says": "Making the feature map smaller",
+    "means": "A downsampling operation in CNNs that reduces spatial dimensions. Max pooling takes the maximum value in each window (e.g., 2x2). Average pooling takes the mean. Reduces computation and provides some translation invariance. Global average pooling across the entire feature map is common before the classification head."
+  },
+  {
+    "term": "Positional Encoding",
+    "says": "Telling the transformer where each token is",
+    "means": "Since attention is permutation-invariant (no inherent sense of order), position must be injected. Original method: sinusoidal functions of different frequencies added to token embeddings. PE(pos, 2i) = sin(pos / 10000^(2i/d)). Modern alternatives: learned embeddings, RoPE, ALiBi."
+  },
+  {
+    "term": "PPO (Proximal Policy Optimization)",
+    "says": "The RL algorithm used in RLHF",
+    "means": "A policy gradient RL algorithm that constrains updates to prevent catastrophic policy changes. Uses a clipped objective: min(ratio * advantage, clip(ratio, 1-eps, 1+eps) * advantage). In RLHF, the 'policy' is the language model and the 'reward' comes from a trained reward model. Complex to implement and tune."
+  },
+  {
+    "term": "Precision",
+    "says": "How many positive predictions were actually correct",
+    "means": "Precision = True Positives / (True Positives + False Positives). Of everything the model labeled positive, what fraction was actually positive? High precision means few false alarms. A spam filter with 99% precision means only 1% of flagged emails are legitimate."
+  },
+  {
+    "term": "Prefix Tuning",
+    "says": "Adding trainable tokens to the beginning",
+    "means": "Prepending a sequence of learnable 'virtual tokens' (continuous vectors, not real vocabulary tokens) to the input at every layer. Only these prefix parameters are trained; the base model is frozen. Typically adds 10-200 prefix tokens. Uses <0.1% of the model's parameters. Performance between LoRA and full fine-tuning."
   },
   {
     "term": "Prompt Engineering",
     "says": "Talking to AI the right way",
-    "means": "Designing the input text to reliably produce desired outputs — including system prompts, few-shot examples, format instructions, and chain-of-thought triggers"
+    "means": "Designing the input text to reliably produce desired outputs -- including system prompts, few-shot examples, format instructions, and chain-of-thought triggers."
   },
   {
-    "term": "RAG (Retrieval-Augmented Generation)",
-    "says": "AI that can search",
-    "means": "A pattern where you retrieve relevant documents from a knowledge base (using embedding similarity), stuff them into the prompt, and let the LLM answer based on that context"
+    "term": "Pruning",
+    "says": "Removing unnecessary parts of the model",
+    "means": "Setting weights to zero (unstructured) or removing entire neurons/heads/layers (structured) to reduce model size and computation. Magnitude pruning: remove smallest weights. Many models can be pruned 50-90% with minimal accuracy loss. Structured pruning gives actual speedups; unstructured requires sparse hardware."
   },
   {
-    "term": "RLHF (Reinforcement Learning from Human Feedback)",
-    "says": "How they make AI helpful",
-    "means": "A training pipeline: (1) collect human preferences on model outputs, (2) train a reward model on those preferences, (3) use PPO to optimize the LLM to produce higher-reward outputs"
+    "term": "QLoRA",
+    "says": "LoRA but even more memory efficient",
+    "means": "Quantizes the base model to 4-bit (NF4 format) and trains LoRA adapters in bfloat16 on top. Enables fine-tuning a 65B model on a single 48GB GPU. The 4-bit base model provides the forward pass, LoRA gradients flow through the quantized weights via a straight-through estimator. 12x less memory than full 16-bit fine-tuning."
   },
   {
     "term": "Quantization",
@@ -2038,14 +2759,144 @@ const GLOSSARY = [
     "means": "Reducing the precision of model weights from float32 (4 bytes) to int8 (1 byte) or int4 (0.5 bytes). Trades a small amount of accuracy for 4-8x less memory and faster inference. GPTQ, AWQ, and GGUF are common formats."
   },
   {
+    "term": "RAG (Retrieval-Augmented Generation)",
+    "says": "AI that can search",
+    "means": "A pattern where you retrieve relevant documents from a knowledge base (using embedding similarity), stuff them into the prompt, and let the LLM answer based on that context. Reduces hallucination and enables knowledge updates without retraining."
+  },
+  {
+    "term": "ReAct",
+    "says": "The agent that thinks then acts",
+    "means": "A prompting framework where the model alternates between Reasoning (thinking about what to do) and Acting (calling a tool). Format: Thought -> Action -> Observation -> Thought -> ... The reasoning trace makes the agent's decisions interpretable and allows error recovery."
+  },
+  {
+    "term": "Recall",
+    "says": "How many actual positives did the model catch",
+    "means": "Recall = True Positives / (True Positives + False Negatives). Of all actual positives, what fraction did the model find? High recall means few missed positives. A cancer screening with 99% recall misses only 1% of cancers. There's usually a precision-recall tradeoff."
+  },
+  {
+    "term": "Rectified Flow",
+    "says": "Straight-line diffusion",
+    "means": "A flow matching approach that learns to transport samples along straight paths from noise to data. The straighter the paths, the fewer steps needed for generation. Stable Diffusion 3 and FLUX use rectified flows. Achieves good quality in 4-8 steps compared to 20-50 for standard diffusion."
+  },
+  {
+    "term": "Red Teaming",
+    "says": "Trying to break the AI on purpose",
+    "means": "Systematically probing a model to find failures, biases, and safety vulnerabilities. Human red teamers craft adversarial prompts to elicit harmful outputs. Automated red teaming uses one LLM to generate attacks against another. Essential before deployment. Found issues lead to training data improvements and safety patches."
+  },
+  {
+    "term": "Reflection",
+    "says": "The AI checks its own work",
+    "means": "An agent pattern where the LLM reviews its previous output, identifies errors or improvements, and generates a revised version. Can be self-reflection (same model critiques itself) or cross-reflection (different model critiques). Reflexion (Shinn et al., 2023) showed this improves coding accuracy from 79% to 91% on HumanEval."
+  },
+  {
     "term": "ReLU",
     "says": "Activation function",
-    "means": "Rectified Linear Unit: f(x) = max(0, x). The simplest non-linear activation. Fast to compute, doesn't saturate for positive values. Used everywhere because it works and is cheap. Variants: LeakyReLU, GELU, SiLU."
+    "means": "Rectified Linear Unit: f(x) = max(0, x). The simplest non-linear activation. Fast to compute, doesn't saturate for positive values. Can suffer from 'dying ReLU' where neurons permanently output zero. Variants: LeakyReLU (small slope for negative), GELU, SiLU."
+  },
+  {
+    "term": "Repetition Penalty",
+    "says": "Stop the AI from repeating itself",
+    "means": "A decoding-time parameter that reduces the probability of tokens that have already appeared in the output. Applied by dividing the logit by the penalty value (typically 1.1-1.3) for previously generated tokens. Too high causes incoherent outputs as the model avoids natural word reuse."
+  },
+  {
+    "term": "Reranking",
+    "says": "Re-sorting search results with AI",
+    "means": "A second-stage retrieval step that takes the top-k candidates from initial retrieval and re-scores them with a more expensive, more accurate model. Cross-encoder rerankers (which see query and document together) are 10-100x slower than bi-encoders but significantly more accurate. Cohere Rerank and BGE-reranker are popular choices."
+  },
+  {
+    "term": "Residual Connection (Skip Connection)",
+    "says": "A shortcut around a layer",
+    "means": "Adding the input of a layer directly to its output: y = F(x) + x. The layer only needs to learn the residual (the difference). Enables training very deep networks (100+ layers) by providing gradient shortcuts during backpropagation. Introduced by ResNet. Every transformer block uses residual connections."
+  },
+  {
+    "term": "Retrieval",
+    "says": "Finding relevant documents",
+    "means": "The process of selecting documents from a corpus that are relevant to a query. Dense retrieval: embed query and documents, find nearest neighbors. Sparse retrieval: keyword matching (BM25). Retrieval quality is the bottleneck in RAG: if you retrieve irrelevant documents, the LLM will produce irrelevant answers."
+  },
+  {
+    "term": "Reward Hacking",
+    "says": "The AI found a loophole",
+    "means": "When an RL-trained agent exploits the reward function in unintended ways, achieving high reward without achieving the true objective. Example: a summarization model trained with a length-based reward learns to generate long, repetitive text. A central challenge in RLHF and alignment."
+  },
+  {
+    "term": "Reward Model",
+    "says": "The AI that grades other AI",
+    "means": "A model trained to predict human preferences: given two outputs, which would a human prefer? Trained on datasets of pairwise human comparisons (typically 50K-500K pairs). The reward model's output (a scalar score) is used as the reward signal in PPO during RLHF."
+  },
+  {
+    "term": "Ring Attention",
+    "says": "Attention distributed across GPUs",
+    "means": "Distributes the sequence across multiple devices in a ring topology, where each device computes attention on its local segment while passing KV blocks to the next device. Enables processing sequences far longer than a single GPU's memory. Used for million-token context windows."
+  },
+  {
+    "term": "RLAIF (Reinforcement Learning from AI Feedback)",
+    "says": "Using AI to train AI",
+    "means": "Replacing human evaluators with an AI model (typically a larger or differently-trained LLM) to generate preference data for RLHF. The AI critic evaluates model outputs based on principles or rubrics. Anthropic's Constitutional AI uses this. Scales better than human feedback but inherits the evaluator model's biases."
+  },
+  {
+    "term": "RLHF (Reinforcement Learning from Human Feedback)",
+    "says": "How they make AI helpful",
+    "means": "A training pipeline: (1) collect human preferences on model outputs, (2) train a reward model on those preferences, (3) use PPO to optimize the LLM to produce higher-reward outputs."
+  },
+  {
+    "term": "RMSNorm",
+    "says": "A simpler layer norm",
+    "means": "Root Mean Square Normalization: RMSNorm(x) = x / sqrt(mean(x^2) + eps) * gamma. Drops the mean subtraction from LayerNorm, making it ~10% faster. Used in LLaMA, Mistral, and most modern LLMs. Empirically matches LayerNorm performance despite being simpler."
+  },
+  {
+    "term": "ROC Curve",
+    "says": "The graph for evaluating classifiers",
+    "means": "Receiver Operating Characteristic curve plots True Positive Rate vs False Positive Rate at every classification threshold. AUC (Area Under ROC Curve) summarizes performance: 0.5 = random, 1.0 = perfect. AUC is threshold-independent, making it useful for comparing models. Misleading when classes are highly imbalanced (use precision-recall curve instead)."
+  },
+  {
+    "term": "Rotary Position Embedding (RoPE)",
+    "says": "The position encoding LLMs actually use",
+    "means": "Encodes position by rotating the query and key vectors in 2D subspaces by angles proportional to position. The dot product between rotated queries and keys naturally decays with distance. Advantages: relative position awareness, extrapolates better to longer sequences than learned embeddings. Used in LLaMA, Mistral, Qwen."
+  },
+  {
+    "term": "ROUGE",
+    "says": "The metric for summarization quality",
+    "means": "Recall-Oriented Understudy for Gisting Evaluation. Measures overlap between generated and reference summaries. ROUGE-1 (unigram), ROUGE-2 (bigram), ROUGE-L (longest common subsequence). Reports precision, recall, and F1. ROUGE-L of 0.4+ is decent for abstractive summarization. Does not measure factual accuracy."
+  },
+  {
+    "term": "RWKV",
+    "says": "A transformer without attention",
+    "means": "Receptance Weighted Key Value: a linear-time sequence model that reformulates attention as a recurrence. Can process sequences like an RNN during inference (constant memory) or in parallel like a transformer during training. Achieves GPT-quality results with O(n) complexity. Open-source with models up to 14B parameters."
+  },
+  {
+    "term": "Saliency Map",
+    "says": "Highlighting what the model looks at",
+    "means": "A visualization showing which input pixels/tokens most influence the model's output, computed by taking the gradient of the output with respect to the input. Bright regions = important for the prediction. Methods: vanilla gradients, Grad-CAM (for CNNs), integrated gradients. Useful for debugging but can be noisy."
+  },
+  {
+    "term": "Scaling Law",
+    "says": "Bigger models are better, predictably",
+    "means": "Empirical power-law relationships between model performance and scale (parameters, data, compute). Kaplan et al. (2020): loss scales as L ~ N^(-0.076) for parameters and L ~ D^(-0.095) for data. These laws let you predict a 100B model's performance from 1B model experiments, enabling compute-optimal training decisions."
+  },
+  {
+    "term": "Score Matching",
+    "says": "The math behind diffusion models",
+    "means": "A training objective where the model learns the gradient of the log probability density (the 'score') at each noise level. At inference, you follow the learned score field from noise to data. Denoising score matching: train the model to predict noise direction, which equals the negative score. The theoretical foundation for all diffusion models."
   },
   {
     "term": "Self-Attention",
     "says": "How the model decides what to focus on",
-    "means": "Each token computes query, key, and value vectors. Attention weight between two tokens = dot product of their query and key, scaled and softmaxed. Output = weighted sum of value vectors. Lets every token see every other token."
+    "means": "Each token computes query, key, and value vectors. Attention weight between two tokens = dot product of their query and key, scaled by sqrt(d_k) and softmaxed. Output = weighted sum of value vectors. Complexity: O(n^2 * d)."
+  },
+  {
+    "term": "Self-Consistency",
+    "says": "Check the answer by solving it multiple ways",
+    "means": "Sample multiple chain-of-thought reasoning paths (at temperature > 0) and select the answer that appears most frequently. Based on the intuition that correct reasoning paths are more likely to converge. Improves GSM8K accuracy for PaLM 540B from 74% (single CoT) to 83%."
+  },
+  {
+    "term": "Semantic Search",
+    "says": "Search by meaning, not keywords",
+    "means": "Retrieving documents based on the meaning of the query rather than exact keyword matches. Both query and documents are embedded into the same vector space, and retrieval is by cosine similarity or dot product. 'How to fix a flat tire' finds documents about 'puncture repair' even without shared keywords."
+  },
+  {
+    "term": "SentencePiece",
+    "says": "Google's tokenizer",
+    "means": "A language-independent tokenization library that treats the input as a raw byte stream (no pre-tokenization or language-specific rules). Supports BPE and unigram models. Used by T5, LLaMA, Mistral. Advantage over standard BPE: handles any language including CJK without whitespace assumptions."
   },
   {
     "term": "SFT (Supervised Fine-Tuning)",
@@ -2053,24 +2904,174 @@ const GLOSSARY = [
     "means": "Fine-tuning a pre-trained model on (instruction, response) pairs. The model learns to generate the response given the instruction. This is what turns a base model into a chat model."
   },
   {
+    "term": "Shadow Deployment",
+    "says": "Running the new model in secret",
+    "means": "Sending a copy of live production traffic to a new model candidate without serving its responses to users. Compare the new model's outputs against the current production model offline. Detects regressions before they affect users. Zero risk to production but requires 2x compute during the shadow period."
+  },
+  {
+    "term": "SHAP",
+    "says": "Explaining which features matter",
+    "means": "SHapley Additive exPlanations. Based on cooperative game theory: computes each feature's marginal contribution to the prediction by averaging over all possible feature subsets. SHAP values sum to the difference between the model output and the expected output. Theoretically grounded but exponentially expensive (approximations used in practice)."
+  },
+  {
+    "term": "Sigmoid",
+    "says": "Squishes numbers between 0 and 1",
+    "means": "sigmoid(x) = 1 / (1 + exp(-x)). Maps any real number to (0, 1). Used as activation in binary classification and gating mechanisms (LSTM, GRU). Saturates at extremes (gradient nearly zero for |x| > 5), causing slow learning. Largely replaced by ReLU/GELU in hidden layers."
+  },
+  {
+    "term": "SiLU/Swish",
+    "says": "A fancier ReLU",
+    "means": "SiLU(x) = x * sigmoid(x). Also called Swish. Smooth, non-monotonic, and self-gated. Unlike ReLU, allows small negative values through. Outperforms ReLU on deep networks. Used in LLaMA, Mistral, and Stable Diffusion's U-Net. The slight computational overhead is worth the accuracy gain."
+  },
+  {
+    "term": "Sliding Window Attention",
+    "says": "Each token only looks at nearby tokens",
+    "means": "Restricts attention to a fixed window of w tokens around each position instead of the full sequence. Reduces complexity from O(n^2) to O(n*w). Mistral uses a 4096-token window. Information propagates across the full sequence through multiple layers (each layer extends the effective receptive field by w tokens)."
+  },
+  {
     "term": "Softmax",
     "says": "Turns numbers into probabilities",
     "means": "softmax(x_i) = exp(x_i) / sum(exp(x_j)). Transforms a vector of arbitrary real numbers into a probability distribution (all positive, sums to 1). Used in classification heads, attention weights, and anywhere you need probabilities."
   },
   {
-    "term": "Swarm",
-    "says": "A bunch of AI agents working together like bees",
-    "means": "Multiple agents sharing state and coordinating through message passing, with emergent behavior arising from simple individual rules rather than central control"
+    "term": "Sparse Attention",
+    "says": "Not looking at everything",
+    "means": "Any attention pattern that attends to fewer than all n*n pairs. Patterns: local (sliding window), strided (every k-th token), global (selected tokens attend to all), random, or learned. Reduces O(n^2) to O(n*sqrt(n)) or O(n*log(n)). BigBird and Longformer are sparse attention models."
   },
   {
-    "term": "Token",
-    "says": "A word",
-    "means": "A subword unit (typically 3-4 characters in English) produced by a tokenizer like BPE. \"unbelievable\" might be 3 tokens: \"un\" + \"believ\" + \"able\""
+    "term": "Sparsity",
+    "says": "Most of the values are zero",
+    "means": "A model or activation tensor where a large fraction of values are exactly zero. Unstructured sparsity: individual weights are zero. Structured sparsity: entire rows/columns/heads are zero. NVIDIA's 2:4 structured sparsity (2 of every 4 elements are zero) gives 2x speedup on Ampere/Hopper GPUs."
+  },
+  {
+    "term": "Speculative Decoding",
+    "says": "Using a small model to speed up the big one",
+    "means": "A fast 'draft' model generates k candidate tokens, then the large 'target' model verifies all k tokens in a single forward pass (which is parallel). Accepted tokens are free; rejected tokens are resampled from the target. Produces the exact same distribution as the target model but 2-3x faster."
+  },
+  {
+    "term": "Stable Diffusion",
+    "says": "The open-source image generator",
+    "means": "A latent diffusion model by Stability AI. SD 1.5: 860M parameter U-Net, operates in 64x64 latent space from 512x512 images. SDXL: 2.6B parameter U-Net, 1024x1024. SD 3: replaced U-Net with a Diffusion Transformer (DiT) and uses rectified flow. Open-weights, runs on consumer GPUs (4-8GB VRAM)."
+  },
+  {
+    "term": "State Space Model (SSM)",
+    "says": "An alternative to transformers",
+    "means": "A model based on continuous-time state equations: x'(t) = Ax(t) + Bu(t), y(t) = Cx(t). Discretized for sequence modeling. S4 (Structured State Spaces) uses diagonal plus low-rank A matrices for efficiency. Linear complexity O(n) vs transformer O(n^2). Mamba adds input-dependent selection."
+  },
+  {
+    "term": "Stochastic Gradient Descent",
+    "says": "Gradient descent but random",
+    "means": "Updating weights using the gradient from a single random training example (or mini-batch) instead of the full dataset. Noisier than full-batch GD but much faster per step and can escape local minima. The noise from random sampling acts as implicit regularization."
+  },
+  {
+    "term": "Stride",
+    "says": "How far the filter moves each step",
+    "means": "The step size when sliding a convolution kernel or pooling window across the input. Stride 1: move one pixel at a time (output same size with padding). Stride 2: move two pixels (output halves in each spatial dimension). Higher stride = more aggressive downsampling = fewer computations."
+  },
+  {
+    "term": "Structured Output",
+    "says": "Making the AI return data in a specific format",
+    "means": "Constraining LLM output to conform to a predefined schema (JSON, XML, function call signatures). Methods: JSON mode (grammar-constrained decoding), function calling (model fills typed parameters), or response_format with a JSON schema. Essential for agentic workflows where outputs must be machine-parseable."
+  },
+  {
+    "term": "Supervised Learning",
+    "says": "Learning from labeled data",
+    "means": "Training on input-output pairs (x, y) where y is the ground truth label. The model learns a function f(x) that approximates y. Classification (discrete y) and regression (continuous y) are both supervised. Requires labeled data, which is expensive: ImageNet took 25,000 person-hours to annotate."
+  },
+  {
+    "term": "Swarm",
+    "says": "A bunch of AI agents working together like bees",
+    "means": "Multiple agents sharing state and coordinating through message passing, with emergent behavior arising from simple individual rules rather than central control."
+  },
+  {
+    "term": "Swarm Intelligence",
+    "says": "Group intelligence from simple agents",
+    "means": "Collective behavior emerging from many simple agents following local rules without centralized control. Inspired by ants, bees, and flocking birds. In AI: particle swarm optimization, ant colony optimization. For LLM agents: multiple models independently process a task and a consensus mechanism aggregates results."
+  },
+  {
+    "term": "Synthetic Data",
+    "says": "Fake data for training",
+    "means": "Training data generated by models rather than collected from the real world. LLM-generated text, rendered 3D scenes, GAN-generated images, or simulated sensor data. Phi-1 was trained largely on GPT-4-generated textbook-quality data. Risk: model collapse if you train on your own outputs iteratively."
+  },
+  {
+    "term": "System Prompt",
+    "says": "The hidden instructions the AI follows",
+    "means": "A special message (role='system') prepended to the conversation that sets the model's behavior, personality, constraints, and output format. Processed before user messages. Not truly hidden (prompt injection can extract it). The system prompt is the primary way to customize model behavior without fine-tuning."
+  },
+  {
+    "term": "Tanh",
+    "says": "Another squishing function",
+    "means": "tanh(x) = (exp(x) - exp(-x)) / (exp(x) + exp(-x)). Maps input to (-1, 1). Zero-centered (unlike sigmoid), which can help gradient flow. Used in LSTM gates and some normalization layers. Suffers from saturation at extremes like sigmoid."
   },
   {
     "term": "Temperature",
     "says": "Creativity setting",
     "means": "A scalar that divides logits before softmax. Temperature=1 is default. Higher = flatter distribution = more random outputs. Lower = sharper distribution = more deterministic. Temperature=0 is argmax (always pick the most likely token)."
+  },
+  {
+    "term": "Tensor Parallelism",
+    "says": "Splitting a single layer across GPUs",
+    "means": "Partitioning individual weight matrices across GPUs so each GPU computes part of a layer. For a matrix multiply Y = XW, split W column-wise across GPUs, each computes XW_i locally, then all-reduce the results. Requires fast interconnects (NVLink, 900 GB/s). Essential for layers too large for one GPU."
+  },
+  {
+    "term": "TensorRT",
+    "says": "NVIDIA's inference optimizer",
+    "means": "NVIDIA's SDK that optimizes trained models for inference on NVIDIA GPUs. Applies layer fusion, precision calibration (FP32 to FP16/INT8), kernel auto-tuning, and memory optimization. Can speed up inference 2-6x compared to vanilla PyTorch. Requires re-optimization for each GPU architecture."
+  },
+  {
+    "term": "Test-Time Compute",
+    "says": "Thinking harder at inference time",
+    "means": "Spending more compute during inference to improve quality. Methods: chain-of-thought (more reasoning tokens), self-consistency (sample multiple times), tree search (explore multiple paths), verification (check answers). OpenAI's o1 model explicitly trades inference compute for accuracy, using internal chain-of-thought that can be hundreds of tokens."
+  },
+  {
+    "term": "Text-to-Image",
+    "says": "Type words, get pictures",
+    "means": "Generating images conditioned on text descriptions using diffusion models (Stable Diffusion, DALL-E, Midjourney) or autoregressive models (Parti). Text is encoded (CLIP or T5), injected via cross-attention into the image generator. Quality depends heavily on prompt engineering and the text encoder's understanding."
+  },
+  {
+    "term": "Throughput",
+    "says": "How much the system can handle",
+    "means": "The rate of processing: requests per second, tokens per second, or images per second. For LLM serving, throughput is tokens/second across all concurrent users. An H100 running LLaMA 70B at batch 64 might achieve 4000+ tokens/sec throughput but 50 tokens/sec per-user latency."
+  },
+  {
+    "term": "Time to First Token (TTFT)",
+    "says": "How long before the AI starts responding",
+    "means": "The latency from sending a request to receiving the first output token. Dominated by the 'prefill' phase: processing all input tokens through the model. A 10K token prompt on a 70B model might take 2-5 seconds for TTFT. Critical UX metric for interactive applications."
+  },
+  {
+    "term": "Token",
+    "says": "A word",
+    "means": "A subword unit (typically 3-4 characters in English) produced by a tokenizer like BPE. 'unbelievable' might be 3 tokens: 'un' + 'believ' + 'able'. 1 token is roughly 0.75 English words."
+  },
+  {
+    "term": "Tokenizer",
+    "says": "The thing that turns text into numbers",
+    "means": "A program that splits text into tokens and maps them to integer IDs from a fixed vocabulary. BPE (GPT), SentencePiece (LLaMA), and WordPiece (BERT) are common algorithms. The tokenizer is part of the model: you must use the same tokenizer for training and inference. Vocabulary sizes: 32K-100K tokens."
+  },
+  {
+    "term": "Tokens per Second",
+    "says": "How fast the AI talks",
+    "means": "The generation speed of an LLM. Consumer GPU (RTX 4090) running a 7B model: 80-120 tokens/sec. Cloud API (GPT-4): 30-80 tokens/sec. Human reading speed is roughly 4-5 tokens/sec, so anything above 20 tokens/sec feels instant for streaming."
+  },
+  {
+    "term": "Tool Use (Function Calling)",
+    "says": "AI that can use tools",
+    "means": "The model outputs a structured call to an external function (search, calculator, API, database) instead of generating text. The runtime executes the function and returns the result to the model. Implemented as special tokens or JSON in the model's output. The foundation of all agent systems."
+  },
+  {
+    "term": "Top-k Sampling",
+    "says": "Only consider the top k words",
+    "means": "At each step, restrict sampling to the k most probable tokens and redistribute probability mass among them. k=50 is common. Prevents sampling extremely unlikely tokens (which cause nonsensical text) while maintaining diversity. Simple but the fixed k doesn't adapt to the model's confidence."
+  },
+  {
+    "term": "Top-p (Nucleus) Sampling",
+    "says": "Only consider words that add up to probability p",
+    "means": "Sample from the smallest set of tokens whose cumulative probability exceeds p (typically 0.9-0.95). Adaptive: when the model is confident, the nucleus is small (few tokens); when uncertain, it's large (many tokens). Generally preferred over top-k because it adapts to the distribution shape."
+  },
+  {
+    "term": "TPU",
+    "says": "Google's AI chip",
+    "means": "Tensor Processing Unit, Google's custom ASIC for ML. TPU v4: 275 TFLOPS BF16. TPU v5e: optimized for inference. Connected in pods of thousands via high-speed interconnects. Uses bfloat16 natively. Only available through Google Cloud. JAX is the primary framework for TPUs."
   },
   {
     "term": "Transfer Learning",
@@ -2080,7 +3081,27 @@ const GLOSSARY = [
   {
     "term": "Transformer",
     "says": "The architecture behind modern AI",
-    "means": "A neural network architecture that processes sequences using self-attention (letting every position attend to every other position) instead of recurrence, enabling massive parallelization"
+    "means": "A neural network architecture that processes sequences using self-attention (letting every position attend to every other position) instead of recurrence, enabling massive parallelization. Introduced in 'Attention Is All You Need' (Vaswani et al., 2017). Basis for GPT, BERT, T5, LLaMA, and virtually all modern LLMs."
+  },
+  {
+    "term": "Tree of Thought",
+    "says": "Chain-of-thought but branching",
+    "means": "An extension of CoT where the model explores multiple reasoning paths as a tree, evaluating intermediate states and backtracking from dead ends. Uses BFS or DFS over thought steps. Improves performance on tasks requiring exploration (Game of 24, creative writing) but is 10-100x more expensive than single-path CoT."
+  },
+  {
+    "term": "Triton Inference Server",
+    "says": "NVIDIA's model serving platform",
+    "means": "An open-source inference serving platform that supports multiple frameworks (PyTorch, TensorFlow, ONNX, TensorRT) and multiple models simultaneously. Features: dynamic batching, model ensemble pipelines, GPU/CPU scheduling, HTTP/gRPC endpoints. The standard for GPU-based production ML serving."
+  },
+  {
+    "term": "TTS (Text-to-Speech)",
+    "says": "Making AI read text aloud",
+    "means": "Converting text into natural-sounding speech audio. Modern TTS uses neural models: text encoder + audio decoder. Approaches: autoregressive (Tortoise, VALL-E), non-autoregressive (FastSpeech), and diffusion-based. Zero-shot voice cloning: generate speech in a voice from a 3-second sample."
+  },
+  {
+    "term": "U-Net",
+    "says": "The model inside Stable Diffusion",
+    "means": "An encoder-decoder architecture with skip connections between corresponding encoder and decoder layers, forming a U shape. The encoder downsamples (captures context), the decoder upsamples (recovers spatial detail), and skip connections preserve fine-grained information. Originally for medical image segmentation, adopted by diffusion models for noise prediction."
   },
   {
     "term": "Underfitting",
@@ -2088,14 +3109,54 @@ const GLOSSARY = [
     "means": "The model is too simple to capture the patterns in the data. Training loss stays high. Fix with: more parameters, more layers, longer training, lower regularization, better features."
   },
   {
+    "term": "Unsupervised Learning",
+    "says": "Learning without labels",
+    "means": "Training on data without explicit labels. The model finds structure on its own: clustering (K-means, DBSCAN), dimensionality reduction (PCA, autoencoders), density estimation, and self-supervised pre-training. LLM pre-training is technically self-supervised (labels come from the data itself)."
+  },
+  {
     "term": "VAE (Variational Autoencoder)",
     "says": "A generative model",
     "means": "An autoencoder that learns a smooth latent space by forcing the encoder output to follow a Gaussian distribution. You can sample from this distribution and decode to generate new data. The reparameterization trick makes it trainable via backpropagation."
   },
   {
+    "term": "Vanishing Gradient",
+    "says": "The gradients disappear and training stops",
+    "means": "Gradients shrink exponentially as they propagate backward through many layers, making early layers nearly impossible to train. Caused by activation functions that saturate (sigmoid, tanh) or by very deep networks. Solved by ReLU, residual connections, normalization layers, and careful initialization."
+  },
+  {
+    "term": "Variance",
+    "says": "How much the predictions jump around",
+    "means": "In the bias-variance tradeoff: variance measures how much the model's predictions change when trained on different subsets of data. High variance = overfitting (the model is too sensitive to training data). Low variance = stable predictions. Complex models (deep networks) tend toward high variance. Regularization reduces variance."
+  },
+  {
     "term": "Vector Database",
     "says": "A special database for AI",
-    "means": "A database optimized for storing vectors (dense arrays of floats) and performing fast approximate nearest-neighbor search. The core operation in similarity search, RAG, and recommendation systems."
+    "means": "A database optimized for storing vectors (dense arrays of floats) and performing fast approximate nearest-neighbor search. Core operation in similarity search, RAG, and recommendation systems. Examples: Pinecone, Weaviate, Qdrant, Milvus, Chroma, pgvector."
+  },
+  {
+    "term": "vLLM",
+    "says": "The fast LLM serving engine",
+    "means": "An open-source LLM inference and serving engine. Key innovations: PagedAttention (efficient KV cache management), continuous batching, and speculative decoding support. 3-24x higher throughput than HuggingFace Transformers for serving. Supports most popular model architectures. The standard for self-hosted LLM serving."
+  },
+  {
+    "term": "Vocabulary",
+    "says": "All the tokens the model knows",
+    "means": "The fixed set of tokens a model can process, defined during tokenizer training. GPT-2: 50,257 tokens. LLaMA: 32,000. GPT-4: ~100K. Larger vocabularies handle more languages and reduce sequence length but increase the embedding matrix size. Out-of-vocabulary words don't exist: BPE falls back to byte-level tokens."
+  },
+  {
+    "term": "Voice Cloning",
+    "says": "Making AI sound like anyone",
+    "means": "Generating speech that mimics a target speaker's voice characteristics from a small sample (3 seconds to a few minutes). Methods: speaker embedding extraction + conditional TTS, or zero-shot voice cloning (VALL-E). Raises significant ethical concerns around consent, deepfakes, and fraud. Many providers require voice owner consent."
+  },
+  {
+    "term": "Watermarking (AI)",
+    "says": "Marking AI-generated content",
+    "means": "Embedding imperceptible statistical patterns in AI-generated text or images to enable later detection. For LLM text: slightly bias token selection using a secret key (green/red list watermarking). For images: embed invisible signals in the pixel or latent space. Can be removed by paraphrasing (text) or editing (images), so not foolproof."
+  },
+  {
+    "term": "Weaviate",
+    "says": "Another vector database",
+    "means": "An open-source vector database with built-in vectorization modules (can embed data on insertion using integrated models), hybrid search (BM25 + vector), GraphQL API, and multi-tenancy. Supports HNSW indexing. Differentiator: modular architecture with pluggable vectorizers and generative modules."
   },
   {
     "term": "Weight",
@@ -2105,7 +3166,12 @@ const GLOSSARY = [
   {
     "term": "Weight Decay",
     "says": "Regularization",
-    "means": "Adding a penalty proportional to the magnitude of weights to the loss function. Equivalent to L2 regularization. Prevents weights from growing too large. Typical value: 0.01-0.1."
+    "means": "Adding a penalty proportional to the magnitude of weights to the loss function. Equivalent to L2 regularization in SGD (slightly different in Adam). Prevents weights from growing too large. Typical value: 0.01-0.1."
+  },
+  {
+    "term": "Whisper",
+    "says": "OpenAI's speech-to-text model",
+    "means": "An encoder-decoder transformer for automatic speech recognition, trained on 680K hours of multilingual audio. Whisper large-v3 supports 100 languages. Uses 80-channel log-mel spectrogram input, 30-second audio chunks. Can transcribe, translate, and detect language. Open-source weights available. Runs in real-time on consumer GPUs."
   },
   {
     "term": "Zero-Shot",


### PR DESCRIPTION
## Summary

The glossary was outdated and limited -- 64 terms covering only basics. Now 277 terms covering the full AI/ML landscape.

### New terms by category

| Category | New Terms | Examples |
|----------|-----------|---------|
| Fundamentals | ~30 | Batch Size, Cross-Validation, F1 Score, ROC Curve, SGD, L1/L2 |
| Deep Learning | ~25 | BatchNorm, RMSNorm, Residual Connection, RoPE, GRU, LSTM, U-Net |
| LLM/NLP | ~50 | BPE, Top-k/Top-p, Flash Attention, GQA, PagedAttention, Scaling Laws, QLoRA |
| Generative AI | ~20 | Stable Diffusion, ControlNet, DDPM, Flow Matching, NeRF, 3D Gaussian Splatting |
| Agents/Tools | ~20 | ReAct, Tool Use, Chunking, Hybrid Search, HNSW, Guardrails, Red Teaming |
| Infrastructure | ~20 | A100/H100/B200, FLOPS, TTFT, vLLM, TensorRT, MLOps, Data Drift |
| Modern Techniques | ~25 | SSM, Mamba, RWKV, GNN, Test-Time Compute, Tree of Thought, Synthetic Data |
| Ethics/Safety | ~15 | SHAP, LIME, Adversarial Attacks, Differential Privacy, Federated Learning |

### Format
Every entry has:
- **term**: The name
- **says**: What a non-expert or hype person would say (punchy, informal)
- **means**: Precise technical definition with numbers, formulas, or examples

All 277 entries alphabetically sorted. Validated as parseable JavaScript.

## Test plan

- [ ] Glossary page loads all 277 terms
- [ ] Search filters across all terms
- [ ] Homepage callout shows updated count
- [ ] No JavaScript errors in console