### PR TITLE
Site polish: Spline 3D + canvas fallback, favicon, logo, contrast fixes

### DIFF
--- a/site/app.js
+++ b/site/app.js
@@ -1,3 +1,90 @@
+(function() {
+  var c = document.getElementById('heroCanvas');
+  if (!c) return;
+  var ctx = c.getContext('2d');
+  var nodes = [];
+  var w, h;
+
+  function resize() {
+    var r = c.parentElement.getBoundingClientRect();
+    w = c.width = r.width * devicePixelRatio;
+    h = c.height = r.height * devicePixelRatio;
+    c.style.width = r.width + 'px';
+    c.style.height = r.height + 'px';
+    ctx.scale(devicePixelRatio, devicePixelRatio);
+    init();
+  }
+
+  function init() {
+    var rw = w / devicePixelRatio;
+    var rh = h / devicePixelRatio;
+    var count = Math.min(50, Math.floor(rw * rh / 10000));
+    nodes = [];
+    for (var i = 0; i < count; i++) {
+      nodes.push({
+        x: Math.random() * rw,
+        y: Math.random() * rh,
+        vx: (Math.random() - 0.5) * 0.4,
+        vy: (Math.random() - 0.5) * 0.4,
+        r: 2 + Math.random() * 2.5,
+        p: Math.random() * Math.PI * 2
+      });
+    }
+  }
+
+  function draw() {
+    var rw = w / devicePixelRatio;
+    var rh = h / devicePixelRatio;
+    ctx.clearRect(0, 0, rw, rh);
+    var t = Date.now() * 0.001;
+
+    for (var i = 0; i < nodes.length; i++) {
+      var n = nodes[i];
+      n.x += n.vx;
+      n.y += n.vy;
+      if (n.x < -10) n.x = rw + 10;
+      if (n.x > rw + 10) n.x = -10;
+      if (n.y < -10) n.y = rh + 10;
+      if (n.y > rh + 10) n.y = -10;
+      for (var j = i + 1; j < nodes.length; j++) {
+        var m = nodes[j];
+        var dx = n.x - m.x;
+        var dy = n.y - m.y;
+        var dist = Math.sqrt(dx * dx + dy * dy);
+        if (dist < 160) {
+          ctx.beginPath();
+          ctx.moveTo(n.x, n.y);
+          ctx.lineTo(m.x, m.y);
+          ctx.strokeStyle = 'rgba(255,107,107,' + ((1 - dist / 160) * 0.2) + ')';
+          ctx.lineWidth = 0.6;
+          ctx.stroke();
+        }
+      }
+    }
+
+    for (var k = 0; k < nodes.length; k++) {
+      var nd = nodes[k];
+      var glow = 0.4 + 0.2 * Math.sin(t * 1.5 + nd.p);
+      ctx.beginPath();
+      ctx.arc(nd.x, nd.y, nd.r * 3, 0, Math.PI * 2);
+      ctx.fillStyle = 'rgba(255,107,107,' + (glow * 0.12) + ')';
+      ctx.fill();
+      ctx.beginPath();
+      ctx.arc(nd.x, nd.y, nd.r, 0, Math.PI * 2);
+      ctx.fillStyle = 'rgba(255,107,107,' + glow + ')';
+      ctx.fill();
+    }
+
+    requestAnimationFrame(draw);
+  }
+
+  if (!matchMedia('(prefers-reduced-motion: reduce)').matches) {
+    resize();
+    draw();
+    window.addEventListener('resize', resize);
+  }
+})();
+
 (function () {
   var root = document.documentElement;
   var stored = localStorage.getItem('theme');

--- a/site/catalog.html
+++ b/site/catalog.html
@@ -203,7 +203,7 @@
   <header class="site-header">
     <div class="header-inner">
       <a href="index.html" class="logo">
-        <span class="logo-icon">&#9679;</span> AI Eng
+        <span class="logo-icon">&#9679;</span> AI from Scratch
       </a>
       <nav class="header-nav">
         <a href="index.html#phases">Phases</a>

--- a/site/catalog.html
+++ b/site/catalog.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Lesson Catalog - AI Engineering from Scratch</title>
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect width='32' height='32' rx='6' fill='%230d0d18'/><text x='4' y='23' font-size='18' font-weight='bold' font-family='system-ui' fill='%23ff6b6b'>AI</text></svg>">
   <meta name="description" content="Full catalog of 260+ AI engineering lessons. Search, filter, and sort every lesson across all 20 phases.">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/site/glossary.html
+++ b/site/glossary.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>AI Glossary - AI Engineering from Scratch</title>
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect width='32' height='32' rx='6' fill='%230d0d18'/><text x='4' y='23' font-size='18' font-weight='bold' font-family='system-ui' fill='%23ff6b6b'>AI</text></svg>">
   <meta name="description" content="AI glossary: what people say vs what things actually mean. Every term explained without hand-waving.">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/site/glossary.html
+++ b/site/glossary.html
@@ -156,7 +156,7 @@
   <header class="site-header">
     <div class="header-inner">
       <a href="index.html" class="logo">
-        <span class="logo-icon">&#9679;</span> AI Eng
+        <span class="logo-icon">&#9679;</span> AI from Scratch
       </a>
       <nav class="header-nav">
         <a href="index.html#phases">Phases</a>

--- a/site/index.html
+++ b/site/index.html
@@ -8,6 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Kalam:wght@400;700&family=Patrick+Hand&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+  <script type="module" src="https://unpkg.com/@splinetool/viewer@1.9.82/build/spline-viewer.js"></script>
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -31,6 +32,9 @@
   </header>
 
   <section class="hero" id="hero">
+    <div class="hero-scene">
+      <spline-viewer url="https://prod.spline.design/dJqTIQ-tE3ULUPMi/scene.splinecode" style="position:absolute;inset:0;width:100%;height:100%;"></spline-viewer>
+    </div>
     <canvas class="hero-canvas" id="heroCanvas"></canvas>
     <div class="hero-overlay"></div>
     <div class="hero-content">

--- a/site/index.html
+++ b/site/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>AI Engineering from Scratch</title>
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect width='32' height='32' rx='6' fill='%230d0d18'/><text x='4' y='23' font-size='18' font-weight='bold' font-family='system-ui' fill='%23ff6b6b'>AI</text></svg>">
   <meta name="description" content="260+ lessons across 20 phases. From linear algebra to autonomous agents. Build everything from scratch.">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/site/index.html
+++ b/site/index.html
@@ -8,7 +8,6 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Kalam:wght@400;700&family=Patrick+Hand&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
-  <script type="module" src="https://unpkg.com/@splinetool/viewer@1.9.82/build/spline-viewer.js"></script>
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -16,7 +15,7 @@
   <header class="site-header">
     <div class="header-inner">
       <a href="index.html" class="logo">
-        <span class="logo-icon">&#9679;</span> AI Eng
+        <span class="logo-icon">&#9679;</span> AI from Scratch
       </a>
       <nav class="header-nav">
         <a href="#phases">Phases</a>
@@ -32,16 +31,15 @@
   </header>
 
   <section class="hero" id="hero">
-    <div class="hero-scene">
-      <spline-viewer url="https://prod.spline.design/dJqTIQ-tE3ULUPMi/scene.splinecode" style="position:absolute;inset:0;width:100%;height:100%;"></spline-viewer>
-    </div>
+    <canvas class="hero-canvas" id="heroCanvas"></canvas>
     <div class="hero-overlay"></div>
     <div class="hero-content">
+      <div class="hero-badge">Open Source &middot; MIT License &middot; ~290 hours</div>
       <h1 class="hero-title">
         <span class="hero-line1">AI Engineering</span>
         <span class="hero-line2">from Scratch</span>
       </h1>
-      <p class="hero-subtitle">From linear algebra to autonomous agents. No hand-waving, no black boxes. Build every layer yourself.</p>
+      <p class="hero-subtitle">260+ lessons across 20 phases. Build neural networks, transformers, and LLMs from first principles. Python, TypeScript, Rust, Julia.</p>
       <div class="hero-stats" id="heroStats">
         <div class="stat-item">
           <span class="stat-number" data-target="lessons">0</span>
@@ -50,6 +48,10 @@
         <div class="stat-item">
           <span class="stat-number" data-target="phases">0</span>
           <span class="stat-label">Phases</span>
+        </div>
+        <div class="stat-item">
+          <span class="stat-number" data-target="4">4</span>
+          <span class="stat-label">Languages</span>
         </div>
         <div class="stat-item">
           <span class="stat-number" data-target="complete">0</span>

--- a/site/style.css
+++ b/site/style.css
@@ -178,35 +178,30 @@ a:hover {
   position: relative;
   min-height: 100vh;
   display: flex;
-  align-items: flex-end;
+  align-items: center;
   justify-content: center;
   overflow: hidden;
-  background: #0f0f1a;
+  background: linear-gradient(135deg, #0d0d18 0%, #141430 40%, #0d0d18 100%);
 }
 
 [data-theme="light"] .hero {
-  background: #0f0f1a;
+  background: linear-gradient(135deg, #0d0d18 0%, #141430 40%, #0d0d18 100%);
 }
 
-.hero-scene {
+.hero-canvas {
   position: absolute;
   inset: 0;
+  width: 100%;
+  height: 100%;
   z-index: 1;
+  pointer-events: none;
 }
 
 .hero-overlay {
   position: absolute;
   inset: 0;
   z-index: 2;
-  background: linear-gradient(
-    to bottom,
-    transparent 0%,
-    transparent 30%,
-    rgba(15, 15, 26, 0.3) 50%,
-    rgba(15, 15, 26, 0.7) 70%,
-    rgba(15, 15, 26, 0.95) 85%,
-    #0f0f1a 100%
-  );
+  background: radial-gradient(ellipse at center, transparent 0%, rgba(13,13,24,0.4) 70%);
   pointer-events: none;
 }
 
@@ -214,8 +209,21 @@ a:hover {
   position: relative;
   z-index: 3;
   text-align: center;
-  padding: 0 24px 80px;
+  padding: 80px 24px;
   max-width: 800px;
+}
+
+.hero-badge {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--accent);
+  border: 1px solid rgba(255, 107, 107, 0.3);
+  background: rgba(255, 107, 107, 0.08);
+  padding: 4px 16px;
+  border-radius: 255px 15px 225px 15px / 15px 225px 15px 255px;
+  margin-bottom: 24px;
+  letter-spacing: 0.03em;
 }
 
 .hero-title {

--- a/site/style.css
+++ b/site/style.css
@@ -188,12 +188,18 @@ a:hover {
   background: linear-gradient(135deg, #0d0d18 0%, #141430 40%, #0d0d18 100%);
 }
 
+.hero-scene {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+}
+
 .hero-canvas {
   position: absolute;
   inset: 0;
   width: 100%;
   height: 100%;
-  z-index: 1;
+  z-index: 0;
   pointer-events: none;
 }
 

--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,7 @@
   "buildCommand": "node site/build.js",
   "outputDirectory": "site",
   "framework": null,
+  "installCommand": "echo skip",
   "rewrites": [
     { "source": "/glossary", "destination": "/glossary.html" },
     { "source": "/catalog", "destination": "/catalog.html" }


### PR DESCRIPTION
## Summary

Follow-up fixes after the main redesign was merged.

### Changes

- **Spline 3D + canvas fallback**: 3D boxes scene (z-index 1) with canvas neural network behind it (z-index 0). If Spline loads, you see the interactive 3D. If it fails on external monitors, the coral neural network shows through.
- **Hero centered**: Content vertically centered instead of pushed to bottom. Added badge, 4th stat (Languages), better subtitle.
- **Favicon**: Coral "AI" on dark navy rounded square SVG -- all 3 pages.
- **Logo**: "AI from Scratch" everywhere (was "AI Eng" on glossary/catalog).
- **Dark mode contrast**: Solid coral shadows (was transparent rgba), brighter borders (#3a3a5c), brighter text (#f0ede8).
- **Phase cards**: Colored top border (green=complete, red=progress, gray=planned).
- **Section separators**: Dashed borders between sections.
- **Vercel build**: Fixed doubled path (site/site/build.js).

## Test plan

- [x] Spline 3D renders on laptop
- [x] Canvas fallback visible when Spline fails
- [x] Favicon shows in browser tab
- [x] Logo says "AI from Scratch" on all pages
- [x] Vercel build succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Animated canvas particle effect in hero section
  * Languages statistic added to hero statistics block
  * Open Source · MIT License badge displayed in hero

* **Style**
  * Hero section background updated to diagonal gradient
  * Logo branding text updated to "AI from Scratch"
  * Favicon added across all pages
  * Hero section layout and alignment refinements

* **Chores**
  * Deployment configuration updated

<!-- end of auto-generated comment: release notes by coderabbit.ai -->