### PR TITLE
Add FUNDING.yml for GitHub sponsor button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [rohitg00]


### PR DESCRIPTION
Adds the Sponsor button on the repo page linking to github.com/sponsors/rohitg00.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added GitHub Sponsors funding configuration, enabling users to support the project financially through GitHub's sponsorship platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->