### PR TITLE
Fix mermaid diagrams getting clipped

### DIFF
--- a/site/lesson.html
+++ b/site/lesson.html
@@ -530,8 +530,17 @@
       justify-content: center;
     }
 
+    .lesson-article .mermaid-container pre {
+      overflow: visible;
+      background: none;
+      border: none;
+      margin: 0;
+      padding: 0;
+    }
+
     .lesson-article .mermaid-container svg {
       max-width: 100%;
+      height: auto;
     }
 
     .lesson-meta {


### PR DESCRIPTION
## Summary
- Mermaid diagram nodes were being cut off because `.lesson-article pre` has `overflow: hidden`
- Mermaid renders SVGs inside `<pre class="mermaid">` elements, which inherited the clip
- Added override: `.mermaid-container pre { overflow: visible }` plus reset background/border/padding
- Added `height: auto` to mermaid SVGs for proper scaling

## Test plan
- [ ] Open any lesson with a Mermaid diagram (e.g. Phase 0 Lesson 1)
- [ ] Verify diagram nodes are fully visible, not clipped
- [ ] Verify code blocks still have proper overflow behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined Mermaid diagram styling in lesson articles for improved visual presentation and better scaling across different display sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->