### PR TITLE
chore: contributor DX — PR/issue templates, scaffolder, CHANGELOG

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Something in a lesson or on the site is wrong
+title: "[bug] "
+labels: bug
+---
+
+## Where
+
+- Phase / lesson: <!-- e.g. Phase 4 · 06-object-detection-yolo -->
+- File / URL: <!-- e.g. phases/04-computer-vision/06-object-detection-yolo/code/main.py or aiengineeringfromscratch.com/lesson.html?path=... -->
+
+## What's wrong
+
+<!-- One-paragraph description. What did you expect vs. what you saw. -->
+
+## Reproduce
+
+1.
+2.
+3.
+
+## Environment
+
+- OS:
+- Python / Node / other runtime version:
+- How you ran it (local, Colab, Docker, etc.):
+
+## Screenshot or logs
+
+<!-- Drop a screenshot or paste the traceback if you have one. -->

--- a/.github/ISSUE_TEMPLATE/new_lesson_proposal.md
+++ b/.github/ISSUE_TEMPLATE/new_lesson_proposal.md
@@ -1,0 +1,46 @@
+---
+name: New lesson proposal
+about: Pitch a lesson before writing it
+title: "[lesson] Phase NN · "
+labels: new-lesson
+---
+
+## Lesson
+
+- Phase: <!-- e.g. Phase 5 (NLP) -->
+- Proposed number: <!-- e.g. 03 (lessons are numbered within a phase) -->
+- Working title:
+- Type: Build | Learn
+- Languages: <!-- Python, TypeScript, Rust, Julia -->
+- Estimated time: <!-- e.g. ~75 min -->
+
+## Why it belongs
+
+<!-- Two or three sentences. What can't a learner do without this lesson? Why here in the sequence? -->
+
+## Prerequisites
+
+<!-- Which prior lessons does this depend on? -->
+
+## What the learner ships
+
+<!-- Every lesson produces a reusable artifact. Which one? -->
+
+- [ ] Prompt
+- [ ] Skill
+- [ ] Agent
+- [ ] MCP server
+- [ ] Tool / script
+
+## Outline
+
+1. **The Problem** — what pain does this solve?
+2. **The Concept** — core mental model, no code yet
+3. **Build It** — from-scratch implementation plan
+4. **Use It** — which framework / library to show after
+5. **Ship It** — the artifact to produce
+6. **Exercises** — 3 proposed
+
+## Open questions
+
+<!-- Anything you want input on before starting. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+<!-- Thanks for contributing. Fill out what applies. Delete sections that don't. -->
+
+## What this PR does
+
+<!-- One-sentence summary. -->
+
+## Kind of change
+
+- [ ] New lesson
+- [ ] Fix to an existing lesson
+- [ ] Translation
+- [ ] New output (prompt, skill, agent, MCP server)
+- [ ] Docs / website / tooling
+
+## Checklist
+
+- [ ] Code runs without errors with the listed dependencies
+- [ ] No comments in code files (docs explain, code is self-explanatory)
+- [ ] Built from scratch first, then shown with a framework (for new lessons)
+- [ ] Lesson folder matches `LESSON_TEMPLATE.md` structure
+- [ ] ROADMAP.md row for the lesson is a markdown link (`[Name](phases/...)`), not bare text
+- [ ] One lesson per commit (atomic per-lesson rule)
+- [ ] Tested locally / code output matches what `docs/en.md` claims
+
+## Phase / lesson
+
+<!-- e.g. Phase 5 · 03-tokenizers -->
+
+## Notes for reviewer
+
+<!-- Anything surprising, any deviations from the template, open questions. -->

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ mlruns/
 *.safetensors
 *.bin
 *.h5
+.gstack/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,46 @@
+# Changelog
+
+What's new in the curriculum. Most recent first.
+
+Format loosely follows [Keep a Changelog](https://keepachangelog.com/). Each entry names the phase, lesson, and what changed, so learners can jump straight to the delta.
+
+## [Unreleased]
+
+### Added
+- `scripts/scaffold-lesson.sh` — scaffolder that creates `phases/NN-phase/NN-lesson/` with the full folder structure and a `docs/en.md` skeleton prefilled from `LESSON_TEMPLATE.md`.
+- `.github/PULL_REQUEST_TEMPLATE.md` — contributor checklist (code runs, no code comments, built-from-scratch-first, atomic per-lesson commit, markdown-link ROADMAP row).
+- `.github/ISSUE_TEMPLATE/bug_report.md` and `new_lesson_proposal.md` — structured intake for bug reports and lesson pitches.
+- This `CHANGELOG.md`.
+
+## 2026-04 — Phase 4: Computer Vision complete
+
+### Added
+- All 28 Phase 4 lessons, covering image fundamentals through multi-modal vision (VLMs, 3D, video, self-supervised).
+- Phase 4 rows in `ROADMAP.md` linked as markdown to the lesson folders, so the website surfaces them.
+
+### Fixed
+- Phase 4 precision pass across 15+ lessons:
+  - `phase-4/02`: shape calculator specifies RF/stride handling for adaptive pool, flatten, and linear.
+  - `phase-4/03`: backbone selector description lists all covered families; head guidance added for OCR, medical, industrial.
+  - `phase-4/04`: classification diagnostics use quantitative thresholds per failure mode; `n/a` declared for undefined metrics; guard for fewer than 3 classes.
+  - `phase-4/06`: detection metric reader uses `AP@0.5` (not `mAP@0.5`); per-class recall declared optional; anchor designer clarifies stride truncation and single-anchor-per-level path.
+  - `phase-4/10`: sampler picker declares `unet_forward_ms` as an input; ControlNet guard promoted to rule 0.
+  - `phase-4/14`: ViT inspector aligned with refusal rule — port attempts are audited, not endorsed.
+  - `phase-4/24`: open-vocab stack picker has explicit rule precedence and license-filter semantics; concept designer resolves step-5/rule-80 conflict.
+  - `phase-4/25`: VLM docs `_merge` raises descriptive `ValueError` on placeholder mismatch; CMER normalises internally.
+  - `phase-4/27`: `synthetic_frames` clips GT boxes to frame H/W.
+  - `phase-4/28`: `rope_3d` validates dim split; dropped unused `F` import from DiT block example.
+
+## 2026-Q1 and earlier
+
+### Added
+- Phase 0 (Setup & Tooling): all 12 lessons.
+- Phase 1 (Math Foundations): all 22 lessons.
+- Phase 2 (ML Fundamentals): all 18 lessons.
+- Phase 3 (Deep Learning Core): core lessons through perceptron, backprop, optimizers.
+- Built-in Claude Code skills: `find-your-level` (placement quiz) and `check-understanding` (per-phase quiz).
+- Website at `aiengineeringfromscratch.com`: catalog, per-lesson pages, roadmap, 277-term glossary.
+- Initial scaffolding for all 20 phases (`phases/00-*` through `phases/19-*`).
+- `LESSON_TEMPLATE.md`, `CONTRIBUTING.md`, `ROADMAP.md`, `README.md`.
+
+[Unreleased]: https://github.com/rohitg00/ai-engineering-from-scratch/compare/HEAD...HEAD

--- a/scripts/scaffold-lesson.sh
+++ b/scripts/scaffold-lesson.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  cat <<'USAGE' >&2
+Usage: scripts/scaffold-lesson.sh <phase-dir> <lesson-slug> [title]
+
+Examples:
+  scripts/scaffold-lesson.sh 05-nlp-foundations-to-advanced 03-tokenizers
+  scripts/scaffold-lesson.sh 05-nlp-foundations-to-advanced 03-tokenizers "Tokenizers from Scratch"
+
+Creates phases/<phase-dir>/<lesson-slug>/ with code/, notebook/, docs/, outputs/
+and a docs/en.md skeleton prefilled from LESSON_TEMPLATE.md.
+USAGE
+  exit 2
+fi
+
+PHASE="$1"
+LESSON="$2"
+TITLE="${3:-}"
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+if [[ -z "$REPO_ROOT" ]]; then
+  echo "error: run this from inside the ai-engineering-from-scratch git repo" >&2
+  exit 1
+fi
+
+PHASE_DIR="$REPO_ROOT/phases/$PHASE"
+LESSON_DIR="$PHASE_DIR/$LESSON"
+
+if [[ ! -d "$PHASE_DIR" ]]; then
+  echo "error: phase dir not found: phases/$PHASE" >&2
+  echo "       run: ls phases/ to see valid phases" >&2
+  exit 1
+fi
+
+if [[ -e "$LESSON_DIR" ]]; then
+  echo "error: lesson already exists: phases/$PHASE/$LESSON" >&2
+  exit 1
+fi
+
+if [[ ! "$LESSON" =~ ^[0-9]{2}-[a-z0-9-]+$ ]]; then
+  echo "error: lesson slug must match NN-kebab-case (e.g. 03-tokenizers)" >&2
+  exit 1
+fi
+
+mkdir -p "$LESSON_DIR/code" "$LESSON_DIR/notebook" "$LESSON_DIR/docs" "$LESSON_DIR/outputs"
+
+PRETTY_TITLE="$TITLE"
+if [[ -z "$PRETTY_TITLE" ]]; then
+  PRETTY_TITLE="$(echo "${LESSON#[0-9][0-9]-}" | tr '-' ' ' | awk '{for (i=1; i<=NF; i++) $i=toupper(substr($i,1,1)) substr($i,2);}1')"
+fi
+
+PHASE_NUM="${PHASE%%-*}"
+LESSON_NUM="${LESSON%%-*}"
+
+cat >"$LESSON_DIR/docs/en.md" <<EOF
+# $PRETTY_TITLE
+
+> [One-line motto. The core idea that sticks.]
+
+**Type:** Build
+**Languages:** Python
+**Prerequisites:** [prior lessons]
+**Time:** ~75 minutes
+
+## The Problem
+
+[2-3 paragraphs. What can't a learner do without this? Make it concrete.]
+
+## The Concept
+
+[Intuition first. Diagrams, tables, mental models. No code yet.]
+
+## Build It
+
+### Step 1: [name]
+
+[explanation]
+
+\`\`\`python
+# code here
+\`\`\`
+
+### Step 2: [name]
+
+[explanation]
+
+\`\`\`python
+# code here
+\`\`\`
+
+## Use It
+
+[How a real framework solves the same thing. Compare your version.]
+
+## Ship It
+
+[The reusable artifact this lesson produces. Save in outputs/.]
+
+## Exercises
+
+1. [Easy — reinforce core concept]
+2. [Medium — apply to a different problem]
+3. [Hard — extend or combine with prior lessons]
+
+## Key Terms
+
+| Term | What people say | What it actually means |
+|------|----------------|----------------------|
+|      |                |                      |
+
+## Further Reading
+
+- []() — []
+EOF
+
+cat >"$LESSON_DIR/code/main.py" <<'EOF'
+def main():
+    raise NotImplementedError("implement the lesson")
+
+
+if __name__ == "__main__":
+    main()
+EOF
+
+touch "$LESSON_DIR/notebook/.gitkeep"
+touch "$LESSON_DIR/outputs/.gitkeep"
+
+echo "created phases/$PHASE/$LESSON/"
+echo ""
+echo "next:"
+echo "  1. edit phases/$PHASE/$LESSON/docs/en.md"
+echo "  2. write phases/$PHASE/$LESSON/code/main.py"
+echo "  3. add a markdown-link row to ROADMAP.md under Phase $PHASE_NUM:"
+echo "     | $LESSON_NUM | [$PRETTY_TITLE](phases/$PHASE/$LESSON) | ✅ | ~75 min |"
+echo "  4. atomic commit: git add phases/$PHASE/$LESSON ROADMAP.md && git commit -m \"feat(phase-$PHASE_NUM/$LESSON_NUM): $PRETTY_TITLE\""


### PR DESCRIPTION
## Summary

Four atomic DX improvements that ship before the per-lesson reviewer gate (see separate planning artifact) lands. Each is independent and reversible.

## Commits (4 atomic)

1. **PR + issue templates** (`.github/PULL_REQUEST_TEMPLATE.md`, `.github/ISSUE_TEMPLATE/bug_report.md`, `new_lesson_proposal.md`) — structured intake. PR template enforces atomic per-lesson commits, markdown-link ROADMAP rows, no code comments, built-from-scratch-first.
2. **`scripts/scaffold-lesson.sh`** — generates a lesson directory skeleton. Enforces `NN-kebab-case` slug. Prints the exact ROADMAP markdown-link row + atomic commit command so contributors cannot accidentally skip either.
3. **`CHANGELOG.md`** — Keep-a-Changelog format. Seeds with phase 4 completion + 15+ post-merge precision fixes.
4. **`.gitignore` `.gstack/`** — per-developer session artifacts stay local.

## Why now

Phase 5 work is starting. External PRs arrive with no structural guidance today. The scaffolder + PR template + issue templates together reduce time-to-first-contribution and make the upcoming reviewer gate's messages actionable.

## Test plan

- [ ] `./scripts/scaffold-lesson.sh` with no args prints usage and exits 2
- [ ] `./scripts/scaffold-lesson.sh 05-nlp-foundations-to-advanced 99-test "Test Lesson"` creates the full dir skeleton
- [ ] Re-running the same command fails cleanly (no overwrite)
- [ ] Invalid slug `./scripts/scaffold-lesson.sh 05-nlp-foundations-to-advanced bad_name` rejected with guidance
- [ ] Invalid phase `./scripts/scaffold-lesson.sh 99-nonexistent 01-foo` rejected
- [ ] `gh pr create` opens the PR using `PULL_REQUEST_TEMPLATE.md`
- [ ] `gh issue create` prompts to pick between bug_report and new_lesson_proposal

## Not in this PR

- The lesson reviewer tool itself (separate planning in progress).
- `.github/workflows/lesson-review.yml` (waits for reviewer).
- Any changes to existing lessons.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive CHANGELOG documenting curriculum updates, Phase 4 completion, and lesson improvements.
  * Introduced standardized GitHub issue templates for bug reports and lesson proposals.
  * Added pull request template with contribution guidelines and verification checklist.

* **New Features**
  * Added lesson scaffolding utility to streamline curriculum development workflow.

* **Chores**
  * Updated version control configuration to exclude additional directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->