### PR TITLE
fix(site): live star count in hero (no more hardcoded '1,000+ stars this week')

### DIFF
--- a/site/header.js
+++ b/site/header.js
@@ -14,7 +14,7 @@
   }
 
   function paint(n) {
-    var els = document.querySelectorAll('.header-github .star-count');
+    var els = document.querySelectorAll('.header-github .star-count, #starCount');
     for (var i = 0; i < els.length; i++) {
       els[i].textContent = format(n);
       els[i].removeAttribute('data-loading');

--- a/site/index.html
+++ b/site/index.html
@@ -84,7 +84,7 @@
       <div class="hero-stars">
         <a href="https://github.com/rohitg00/ai-engineering-from-scratch/stargazers" target="_blank" rel="noopener" class="star-badge">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="#ffb800" style="display:inline;vertical-align:middle;margin-right:4px;"><path d="M12 .587l3.668 7.568 8.332 1.151-6.064 5.828 1.48 8.279L12 19.896l-7.416 3.517 1.48-8.279L0 9.306l8.332-1.151z"/></svg>
-          <span id="starCount">1,000+</span> stars this week
+          <span id="starCount" data-loading>—</span> stars on GitHub
         </a>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Hero badge on aiengineeringfromscratch.com displayed \`1,000+ stars this week\` — hardcoded evergreen slop. Stat ages, overstates weekly delta, and disagrees with live total (repo is at 4.7k).

## Changes

- \`site/header.js\`: extend the paint() selector from \`.header-github .star-count\` to also include \`#starCount\`. Same GitHub API fetch already running in the header now wires up to the hero.
- \`site/index.html\`: hero \`#starCount\` gets \`data-loading\` attribute + em-dash placeholder, copy changes from "stars this week" to "stars on GitHub" (accurate — API returns total, not weekly delta).

No new network calls. Existing 10-minute localStorage cache covers the hero too. Graceful fallback on API failure (placeholder stays, link still works).

## Test plan

- [ ] Open aiengineeringfromscratch.com, hero shows live count (e.g., \`4.7k\`) instead of \`1,000+\`
- [ ] Disconnect network, reload: hero shows em-dash placeholder, link still works
- [ ] Check header badge still works (unchanged behavior)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * GitHub stars badge now displays a loading state while fetching current data instead of showing static counts
  * Updated badge label from "stars this week" to "stars on GitHub" for clarity
  * Enhanced star count display consistency across the site

<!-- end of auto-generated comment: release notes by coderabbit.ai -->