### PR TITLE
feat(phase-10/17): native sparse attention lesson

### DIFF
--- a/phases/10-llms-from-scratch/17-native-sparse-attention/assets/native-sparse-attention.svg
+++ b/phases/10-llms-from-scratch/17-native-sparse-attention/assets/native-sparse-attention.svg
@@ -1,0 +1,155 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 560" font-family="Georgia, 'Times New Roman', serif">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#1a1a1a"/>
+    </marker>
+    <style>
+      .panel { fill: #faf6ef; stroke: #1a1a1a; stroke-width: 1.5; }
+      .cmp   { fill: #fff1d6; stroke: #b8770a; stroke-width: 1.5; }
+      .slc   { fill: #e6f4ea; stroke: #2e7d32; stroke-width: 1.5; }
+      .win   { fill: #e8edfb; stroke: #2d4a8a; stroke-width: 1.5; }
+      .gate  { fill: #f4e6f4; stroke: #6a2c70; stroke-width: 1.5; }
+      .tok   { fill: #ffffff; stroke: #888; stroke-width: 0.8; }
+      .toklive { fill: #1a1a1a; stroke: #1a1a1a; }
+      .title { font-size: 17px; font-weight: 700; fill: #1a1a1a; }
+      .head  { font-size: 13px; font-weight: 700; fill: #1a1a1a; }
+      .label { font-size: 12px; fill: #1a1a1a; }
+      .mono  { font-size: 11px; font-family: 'Menlo', monospace; fill: #222; }
+      .small { font-size: 10px; font-family: 'Menlo', monospace; fill: #555; }
+      .caption { font-size: 11px; fill: #555; font-style: italic; }
+    </style>
+  </defs>
+
+  <text x="480" y="28" text-anchor="middle" class="title">native sparse attention — three branches, one query</text>
+  <text x="480" y="48" text-anchor="middle" class="caption">DeepSeek NSA, ACL 2025. One query position t reads ~8% of the KV cache at 64k context.</text>
+
+  <!-- KV cache strip (top) -->
+  <text x="30" y="82" class="head">KV cache</text>
+  <g transform="translate(140, 68)">
+    <!-- 32 token squares -->
+    <g id="toks">
+      <rect x="0"   y="0" width="22" height="22" class="tok"/>
+      <rect x="24"  y="0" width="22" height="22" class="tok"/>
+      <rect x="48"  y="0" width="22" height="22" class="tok"/>
+      <rect x="72"  y="0" width="22" height="22" class="tok"/>
+      <rect x="96"  y="0" width="22" height="22" class="tok"/>
+      <rect x="120" y="0" width="22" height="22" class="tok"/>
+      <rect x="144" y="0" width="22" height="22" class="tok"/>
+      <rect x="168" y="0" width="22" height="22" class="tok"/>
+      <rect x="192" y="0" width="22" height="22" class="tok"/>
+      <rect x="216" y="0" width="22" height="22" class="tok"/>
+      <rect x="240" y="0" width="22" height="22" class="tok"/>
+      <rect x="264" y="0" width="22" height="22" class="tok"/>
+      <rect x="288" y="0" width="22" height="22" class="tok"/>
+      <rect x="312" y="0" width="22" height="22" class="tok"/>
+      <rect x="336" y="0" width="22" height="22" class="tok"/>
+      <rect x="360" y="0" width="22" height="22" class="tok"/>
+      <rect x="384" y="0" width="22" height="22" class="tok"/>
+      <rect x="408" y="0" width="22" height="22" class="tok"/>
+      <rect x="432" y="0" width="22" height="22" class="tok"/>
+      <rect x="456" y="0" width="22" height="22" class="tok"/>
+      <rect x="480" y="0" width="22" height="22" class="tok"/>
+      <rect x="504" y="0" width="22" height="22" class="tok"/>
+      <rect x="528" y="0" width="22" height="22" class="tok"/>
+      <rect x="552" y="0" width="22" height="22" class="tok"/>
+      <rect x="576" y="0" width="22" height="22" class="tok"/>
+      <rect x="600" y="0" width="22" height="22" class="tok"/>
+      <rect x="624" y="0" width="22" height="22" class="tok"/>
+      <rect x="648" y="0" width="22" height="22" class="tok"/>
+      <rect x="672" y="0" width="22" height="22" class="tok"/>
+      <rect x="696" y="0" width="22" height="22" class="tok"/>
+      <rect x="720" y="0" width="22" height="22" class="tok"/>
+      <rect x="744" y="0" width="22" height="22" class="tok"/>
+    </g>
+    <text x="0" y="36" class="small">k_0</text>
+    <text x="744" y="36" class="small">k_{t-1}</text>
+  </g>
+
+  <!-- query circle -->
+  <circle cx="900" cy="79" r="14" fill="#1a1a1a"/>
+  <text x="900" y="84" text-anchor="middle" fill="white" class="mono">q_t</text>
+
+  <!-- branch 1: compression -->
+  <rect x="30" y="140" width="280" height="130" class="cmp"/>
+  <text x="170" y="162" text-anchor="middle" class="head">1 / compression</text>
+  <text x="170" y="180" text-anchor="middle" class="caption">global reach, cheap</text>
+  <!-- block summaries -->
+  <rect x="55"  y="195" width="40" height="20" class="tok" fill="#b8770a" fill-opacity="0.35"/>
+  <rect x="100" y="195" width="40" height="20" class="tok" fill="#b8770a" fill-opacity="0.35"/>
+  <rect x="145" y="195" width="40" height="20" class="tok" fill="#b8770a" fill-opacity="0.35"/>
+  <rect x="190" y="195" width="40" height="20" class="tok" fill="#b8770a" fill-opacity="0.35"/>
+  <rect x="235" y="195" width="40" height="20" class="tok" fill="#b8770a" fill-opacity="0.35"/>
+  <text x="75"  y="210" text-anchor="middle" class="small">K̃_0</text>
+  <text x="120" y="210" text-anchor="middle" class="small">K̃_1</text>
+  <text x="165" y="210" text-anchor="middle" class="small">K̃_2</text>
+  <text x="210" y="210" text-anchor="middle" class="small">K̃_3</text>
+  <text x="255" y="210" text-anchor="middle" class="small">K̃_4</text>
+  <text x="170" y="240" text-anchor="middle" class="mono">K̃ = MLP(pool(K[id:id+l]))</text>
+  <text x="170" y="256" text-anchor="middle" class="mono">block l=32, stride d=16</text>
+
+  <!-- branch 2: selection -->
+  <rect x="340" y="140" width="280" height="130" class="slc"/>
+  <text x="480" y="162" text-anchor="middle" class="head">2 / selection</text>
+  <text x="480" y="180" text-anchor="middle" class="caption">top-n blocks at full resolution</text>
+  <!-- selected blocks (darker fills = picked) -->
+  <rect x="365" y="195" width="28" height="20" class="tok" fill="#2e7d32" fill-opacity="0.7"/>
+  <rect x="395" y="195" width="28" height="20" class="tok" fill="#2e7d32" fill-opacity="0.12"/>
+  <rect x="425" y="195" width="28" height="20" class="tok" fill="#2e7d32" fill-opacity="0.12"/>
+  <rect x="455" y="195" width="28" height="20" class="tok" fill="#2e7d32" fill-opacity="0.7"/>
+  <rect x="485" y="195" width="28" height="20" class="tok" fill="#2e7d32" fill-opacity="0.12"/>
+  <rect x="515" y="195" width="28" height="20" class="tok" fill="#2e7d32" fill-opacity="0.7"/>
+  <rect x="545" y="195" width="28" height="20" class="tok" fill="#2e7d32" fill-opacity="0.12"/>
+  <rect x="575" y="195" width="28" height="20" class="tok" fill="#2e7d32" fill-opacity="0.7"/>
+  <text x="480" y="240" text-anchor="middle" class="mono">p_slc = aggregate(p_cmp) → top-n</text>
+  <text x="480" y="256" text-anchor="middle" class="mono">l'=64, n=16 (incl 1 init, 2 local)</text>
+
+  <!-- branch 3: sliding window -->
+  <rect x="650" y="140" width="280" height="130" class="win"/>
+  <text x="790" y="162" text-anchor="middle" class="head">3 / sliding window</text>
+  <text x="790" y="180" text-anchor="middle" class="caption">local fluency, last w tokens</text>
+  <rect x="675" y="195" width="240" height="20" class="tok" fill="#2d4a8a" fill-opacity="0.25"/>
+  <text x="790" y="210" text-anchor="middle" class="small">last w = 512 tokens</text>
+  <text x="790" y="240" text-anchor="middle" class="mono">K̃_win = K[t-w : t]</text>
+  <text x="790" y="256" text-anchor="middle" class="mono">pure slice, no projection</text>
+
+  <!-- arrows from KV cache down to branches -->
+  <line x1="180" y1="104" x2="170" y2="138" stroke="#b8770a" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <line x1="460" y1="104" x2="480" y2="138" stroke="#2e7d32" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <line x1="820" y1="104" x2="790" y2="138" stroke="#2d4a8a" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- q fan-in to each branch -->
+  <path d="M900,96 C 600,120 300,120 170,138" fill="none" stroke="#888" stroke-width="0.8" stroke-dasharray="3 3"/>
+  <path d="M900,96 C 700,120 520,120 480,138" fill="none" stroke="#888" stroke-width="0.8" stroke-dasharray="3 3"/>
+  <path d="M900,96 C 850,115 800,125 790,138" fill="none" stroke="#888" stroke-width="0.8" stroke-dasharray="3 3"/>
+
+  <!-- branch outputs -->
+  <rect x="100" y="305" width="140" height="34" class="panel"/>
+  <text x="170" y="327" text-anchor="middle" class="mono">cmp_out</text>
+  <rect x="410" y="305" width="140" height="34" class="panel"/>
+  <text x="480" y="327" text-anchor="middle" class="mono">slc_out</text>
+  <rect x="720" y="305" width="140" height="34" class="panel"/>
+  <text x="790" y="327" text-anchor="middle" class="mono">win_out</text>
+
+  <line x1="170" y1="270" x2="170" y2="303" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <line x1="480" y1="270" x2="480" y2="303" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <line x1="790" y1="270" x2="790" y2="303" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- gate -->
+  <rect x="380" y="370" width="200" height="50" class="gate"/>
+  <text x="480" y="392" text-anchor="middle" class="head">gate (3 sigmoids)</text>
+  <text x="480" y="410" text-anchor="middle" class="mono">g = σ(W_gate · q_t)</text>
+
+  <line x1="170" y1="339" x2="400" y2="370" stroke="#b8770a" stroke-width="1.3" marker-end="url(#arrow)"/>
+  <line x1="480" y1="339" x2="480" y2="370" stroke="#2e7d32" stroke-width="1.3" marker-end="url(#arrow)"/>
+  <line x1="790" y1="339" x2="560" y2="370" stroke="#2d4a8a" stroke-width="1.3" marker-end="url(#arrow)"/>
+
+  <!-- fused output -->
+  <rect x="410" y="445" width="140" height="34" class="panel" stroke-width="2"/>
+  <text x="480" y="467" text-anchor="middle" class="mono">o_t = Σ g · branch</text>
+  <line x1="480" y1="420" x2="480" y2="443" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- numbers strip -->
+  <rect x="30" y="500" width="900" height="46" class="panel"/>
+  <text x="50" y="520" class="head">reads at 64k context, DeepSeek defaults:</text>
+  <text x="50" y="538" class="mono">cmp ≈ 4096 summaries  +  slc = 16 × 64 = 1024  +  win = 512  →  5632 keys  (8.6% of 65536)</text>
+</svg>

--- a/phases/10-llms-from-scratch/17-native-sparse-attention/code/main.py
+++ b/phases/10-llms-from-scratch/17-native-sparse-attention/code/main.py
@@ -1,0 +1,194 @@
+"""Native Sparse Attention from scratch.
+
+Three parallel branches over the same Q, K, V:
+
+    compression: coarse block summaries (global reach)
+    selection:   top-n full-resolution blocks (precision where it matters)
+    sliding:     last w tokens (local fluency)
+
+A learned gate fuses the three outputs. One query at a time so the math stays
+visible. Pure stdlib.
+
+Reference: Yuan et al., "Native Sparse Attention: Hardware-Aligned and
+Natively Trainable Sparse Attention", ACL 2025, arXiv:2502.11089.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+from dataclasses import dataclass
+
+
+@dataclass
+class NSAConfig:
+    d_head: int = 16
+    block_l: int = 8
+    stride_d: int = 4
+    sel_block: int = 8
+    top_n: int = 4
+    window_w: int = 16
+    num_init_blocks: int = 1
+    num_local_blocks: int = 2
+
+
+def dot(a, b):
+    return sum(x * y for x, y in zip(a, b))
+
+
+def softmax(scores):
+    m = max(scores)
+    exps = [math.exp(s - m) for s in scores]
+    z = sum(exps)
+    return [e / z for e in exps]
+
+
+def sigmoid(x):
+    return 1.0 / (1.0 + math.exp(-x))
+
+
+def attention(q, keys, values, scale):
+    if not keys:
+        return [0.0] * len(q)
+    w = softmax([dot(q, k) * scale for k in keys])
+    d = len(values[0])
+    out = [0.0] * d
+    for wi, v in zip(w, values):
+        for j in range(d):
+            out[j] += wi * v[j]
+    return out
+
+
+def compress_block(tokens, pos_bias, proj):
+    d = len(tokens[0])
+    pooled = [sum(tokens[i][j] + pos_bias[i][j] for i in range(len(tokens))) / len(tokens) for j in range(d)]
+    return [sum(row[j] * pooled[j] for j in range(d)) for row in proj]
+
+
+def build_compressed(keys, values, cfg, params):
+    ck, cv, spans = [], [], []
+    i = 0
+    while i + cfg.block_l <= len(keys):
+        ck.append(compress_block(keys[i:i + cfg.block_l], params["k_pos"], params["k_proj"]))
+        cv.append(compress_block(values[i:i + cfg.block_l], params["v_pos"], params["v_proj"]))
+        spans.append((i, i + cfg.block_l))
+        i += cfg.stride_d
+    return ck, cv, spans
+
+
+def aggregate_scores(comp_probs, spans, num_sel, sel_block):
+    scores = [0.0] * num_sel
+    for p, (start, end) in zip(comp_probs, spans):
+        for pos in range(start, end):
+            sb = pos // sel_block
+            if sb < num_sel:
+                scores[sb] += p / (end - start)
+    return scores
+
+
+def pick_top(block_scores, cfg, t_query):
+    total = len(block_scores)
+    forced = set(range(min(cfg.num_init_blocks, total)))
+    local_end = t_query // cfg.sel_block
+    for i in range(max(0, local_end - cfg.num_local_blocks + 1), min(local_end + 1, total)):
+        forced.add(i)
+    ranked = sorted(range(total), key=lambda i: block_scores[i], reverse=True)
+    chosen = list(forced)
+    for idx in ranked:
+        if len(chosen) >= cfg.top_n:
+            break
+        if idx not in forced:
+            chosen.append(idx)
+    return sorted(chosen)
+
+
+def gather_blocks(keys, values, block_ids, sel_block, t_query):
+    sk, sv = [], []
+    for b in block_ids:
+        start, end = b * sel_block, min((b + 1) * sel_block, t_query)
+        sk.extend(keys[start:end])
+        sv.extend(values[start:end])
+    return sk, sv
+
+
+def nsa_forward(q, keys, values, t, cfg, params):
+    scale = 1.0 / math.sqrt(cfg.d_head)
+
+    ck, cv, spans = build_compressed(keys[:t], values[:t], cfg, params)
+    cmp_out = attention(q, ck, cv, scale)
+    cmp_probs = softmax([dot(q, k) * scale for k in ck]) if ck else []
+
+    num_sel = max(1, math.ceil(t / cfg.sel_block))
+    sel_scores = aggregate_scores(cmp_probs, spans, num_sel, cfg.sel_block)
+    sel_blocks = pick_top(sel_scores, cfg, t)
+    sk, sv = gather_blocks(keys, values, sel_blocks, cfg.sel_block, t)
+    slc_out = attention(q, sk, sv, scale)
+
+    start = max(0, t - cfg.window_w)
+    wk, wv = keys[start:t], values[start:t]
+    win_out = attention(q, wk, wv, scale)
+
+    gates = [sigmoid(dot(row, q)) for row in params["gate_w"]]
+    fused = [gates[0] * cmp_out[j] + gates[1] * slc_out[j] + gates[2] * win_out[j] for j in range(cfg.d_head)]
+
+    return {
+        "output": fused,
+        "gates": gates,
+        "selected_blocks": sel_blocks,
+        "compressed_count": len(ck),
+        "sliding_count": len(wk),
+        "full_tokens_read": len(ck) + len(sk) + len(wk),
+    }
+
+
+def full_attention(q, keys, values, t, d):
+    return attention(q, keys[:t], values[:t], 1.0 / math.sqrt(d))
+
+
+def nsa_cost(seq_len, cfg):
+    compressed = max(0, (seq_len - cfg.block_l) // cfg.stride_d + 1)
+    selected = cfg.top_n * cfg.sel_block
+    sliding = min(cfg.window_w, seq_len)
+    return compressed + selected + sliding
+
+
+def random_matrix(rows, cols, rng):
+    return [[rng.gauss(0.0, 0.1) for _ in range(cols)] for _ in range(rows)]
+
+
+def demo():
+    rng = random.Random(42)
+    cfg = NSAConfig()
+    seq_len = 128
+
+    keys = [[rng.gauss(0, 1) for _ in range(cfg.d_head)] for _ in range(seq_len)]
+    values = [[rng.gauss(0, 1) for _ in range(cfg.d_head)] for _ in range(seq_len)]
+    query = [rng.gauss(0, 1) for _ in range(cfg.d_head)]
+
+    params = {
+        "k_pos": random_matrix(cfg.block_l, cfg.d_head, rng),
+        "v_pos": random_matrix(cfg.block_l, cfg.d_head, rng),
+        "k_proj": random_matrix(cfg.d_head, cfg.d_head, rng),
+        "v_proj": random_matrix(cfg.d_head, cfg.d_head, rng),
+        "gate_w": random_matrix(3, cfg.d_head, rng),
+    }
+
+    for t in (16, 64, 128):
+        r = nsa_forward(query, keys, values, t, cfg, params)
+        full_out = full_attention(query, keys, values, t, cfg.d_head)
+        diff = math.sqrt(sum((a - b) ** 2 for a, b in zip(r["output"], full_out)))
+        print(f"t={t}")
+        print(f"  compressed blocks: {r['compressed_count']}  selected: {r['selected_blocks']}  window: {r['sliding_count']}")
+        print(f"  keys attended:     {r['full_tokens_read']} of {t}")
+        print(f"  gate (cmp slc win): [{r['gates'][0]:.3f} {r['gates'][1]:.3f} {r['gates'][2]:.3f}]")
+        print(f"  ||nsa - full||_2:  {diff:.4f}\n")
+
+    print("asymptotic reads (DeepSeek defaults l=32 d=16 l'=64 n=16 w=512):")
+    prod = NSAConfig(d_head=128, block_l=32, stride_d=16, sel_block=64, top_n=16, window_w=512)
+    for seq in (8192, 32768, 65536):
+        r = nsa_cost(seq, prod)
+        print(f"  {seq:>6}: {r} keys  ({100 * r / seq:.2f}% of full)")
+
+
+if __name__ == "__main__":
+    demo()

--- a/phases/10-llms-from-scratch/17-native-sparse-attention/docs/en.md
+++ b/phases/10-llms-from-scratch/17-native-sparse-attention/docs/en.md
@@ -1,0 +1,217 @@
+# Native Sparse Attention
+
+> Three views of the same past: a blurry summary of everything, a sharp crop of the few blocks that matter, and the last few tokens in full detail. A gate fuses them. That is NSA.
+
+**Type:** Build
+**Languages:** Python
+**Prerequisites:** Phase 10 Lessons 07-08 (transformer attention), Lesson 12 (inference optimization, KV cache)
+**Time:** ~90 minutes
+
+## Learning Objectives
+
+- Explain why standard attention becomes the dominant cost at long context and what sparse attention actually skips
+- Implement the three parallel branches of NSA (compression, selection, sliding) from scratch in pure Python
+- Derive selection block scores from compression attention probabilities instead of a separate scorer
+- Reason about the gating mechanism that fuses the three branches and why it must be learned, not averaged
+- Compare NSA to MoBA, Gemma 3 interleaved sliding window, and the sparse attention taxonomy from the 2025 literature
+
+## The Problem
+
+A 128k-token context on a 70B model carries a KV cache of roughly 40 GB. Every decode step reads all of it. The model you deployed for long-document analysis now spends 97% of wall time moving keys and values from HBM to the matmul units and 3% doing math. You can quantize the cache, you can shrink the heads with GQA, you can evict old tokens. None of it changes the fact that full attention reads every key for every query.
+
+Sparse attention is the harder fix: stop reading most of the keys. The question is which ones. Random dropout works for training but wrecks generation. Strided patterns miss long-range facts. Eviction throws away tokens a later query will need. Every training-free scheme in the 2025 Sparse Frontier survey hits a wall around 50% sparsity on long-context QA.
+
+DeepSeek and Moonshot both landed on the same answer within 48 hours in February 2025: do not pick one pattern. Run three in parallel. Compress the whole sequence for global reach. Select a handful of full-resolution blocks for precision. Keep a sliding window for local fluency. Fuse the outputs with a learned gate. Train the model with this attention from scratch so the weights cooperate with the sparsity. That is Native Sparse Attention (NSA).
+
+NSA won the ACL 2025 Best Paper award. On a 27B backbone pretrained with 260B tokens at 64k context, it matches full attention on reasoning benchmarks while reading 8.6% of the keys.
+
+## The Concept
+
+### The three branches
+
+For every query position `t`, NSA builds three different key-value views of the prefix `1..t-1` and runs attention three times in parallel:
+
+| Branch | What it reads | Purpose |
+|--------|--------------|---------|
+| Compression | `~t/d` coarse block summaries | Global reach, cheap |
+| Selection | `top_n` blocks at full resolution | Precision where it matters |
+| Sliding | Last `w` tokens verbatim | Local syntax and fluency |
+
+A gating MLP emits three scores in `[0,1]`. The final output is a weighted sum of the three branch outputs. Every branch sees the same query but a different slice of the past.
+
+### Branch 1: compression
+
+Group consecutive keys into overlapping blocks of length `l`, striding by `d < l`. A learned MLP with intra-block positional encoding pools each block into a single key vector. Same treatment for values. You now have about `(t - l) / d + 1` compressed key-value pairs standing in for the full sequence.
+
+```
+keys:        [k_0 k_1 k_2 k_3 k_4 k_5 k_6 k_7 k_8 k_9 ...]
+block l=4:   [---- block 0 ----][---- block 2 ----]
+stride d=2:      [---- block 1 ----][---- block 3 ----]
+compressed:  [K_0]    [K_1]    [K_2]    [K_3]   ...
+```
+
+Attention over these compressed keys is cheap and covers the entire context. It cannot resolve which specific token inside block 5 mattered, but it can tell you that block 5 mattered.
+
+### Branch 2: selection
+
+This is the clever part. Instead of training a separate scorer to pick important blocks, NSA reuses the compression attention probabilities. Each compressed key came from a specific span of raw keys, so the attention weight over a compressed key is also a weight over its source span. Aggregate those weights into selection-block buckets (size `l'`), take the top `n`, and read those blocks at full resolution.
+
+```
+compression probs:   [0.01 0.02 0.41 0.03 0.31 0.04 0.01 0.17 ...]
+                            ^          ^               ^
+selection buckets:   [__bucket 0__][__bucket 1__][__bucket 2__][__bucket 3__]
+top-2 buckets:        picks 0 and 2 (highest aggregate mass)
+```
+
+No extra parameters, no extra forward passes. The selection branch is parasitic on the compression branch, which means sparsity is learned end-to-end through the same gradient signal that trains the MLP compressor.
+
+Two extras that stop the model from drifting off the anchor points:
+
+- **Initial blocks:** block 0 is always forced into the top-n. Early tokens in a document often carry global structure (system prompt, task framing).
+- **Local blocks:** the `num_local_blocks` ending at position `t` are always forced in. Sliding takes the last `w` tokens; these selection slots keep the block just before the window.
+
+For grouped-query attention, the importance scores are summed across query heads in the same group before ranking. All heads in a group read the same selected blocks, so the hardware can issue one contiguous load instead of `H` scattered ones. This is the "hardware-aligned" in the paper title.
+
+### Branch 3: sliding window
+
+Standard windowed attention over the last `w` tokens. Gemma 3 shipped this idea alone at 5:1 ratio against global layers and shaved KV cache from 60% to 15% of VRAM with no perplexity cost. NSA uses it as one of three branches per layer rather than as a whole-layer replacement.
+
+The sliding branch exists because the first two branches are biased toward older tokens. Compression pools future-facing info into block summaries, selection picks a small number of blocks by aggregate mass, and neither loves the freshest 32 tokens where syntax lives. Sliding fixes that without stealing gradient from the other branches.
+
+### The gate
+
+```
+g = sigmoid(W_gate @ q)    # shape (3,)
+o = g[0] * cmp_out + g[1] * slc_out + g[2] * win_out
+```
+
+Three independent sigmoid gates, not a softmax. The branches do not have to compete; the model can turn on all three at once when the query needs all three views. In practice the authors report gate values cluster around different regimes per layer: early layers lean on sliding, middle layers on selection, late layers blend all three.
+
+### Token flow
+
+```
+query q_t
+   |
+   +---- compress K,V into blocks ----> cmp_K, cmp_V --+-- attend --> cmp_out
+   |                                                   |
+   |                                                   +-- probs --+
+   |                                                               v
+   +---- aggregate probs into sel buckets, take top_n --> sel_K, sel_V --> slc_out
+   |
+   +---- slice last w tokens ----> win_K, win_V --> win_out
+   |
+   +---- W_gate @ q_t --> g
+                            \
+                             v
+                      o = g · (cmp_out, slc_out, win_out)
+```
+
+### Why NSA is native, not bolt-on
+
+Training-free sparse methods (H2O, StreamingLLM, Quest) run an existing dense model through a sparse pattern at inference time. The model was trained on full attention; the sparsity corrupts its distribution and accuracy drops at high sparsity. The Sparse Frontier survey (arXiv:2504.17768) confirms this: all six training-free methods degrade sharply above 0.8 sparsity.
+
+NSA trains the attention sparsity from scratch. The compression MLP, the gate, and the selection block size are part of the architecture. Gradients flow through all three branches. At 27B scale with 260B training tokens, NSA matches or beats full attention on MMLU, GSM8K, and HumanEval while reading a fraction of the keys. That is what "native" buys.
+
+## Build It
+
+Full code in `code/main.py`. Stdlib only, one query at a time, so the shapes stay legible.
+
+### Step 1: the three utilities
+
+Dot product, softmax, attention over a list of keys and values. Nothing NSA-specific yet.
+
+    def attention(q, keys, values, scale):
+        if not keys:
+            return [0.0] * len(q)
+        w = softmax([dot(q, k) * scale for k in keys])
+        d = len(values[0])
+        out = [0.0] * d
+        for wi, v in zip(w, values):
+            for j in range(d):
+                out[j] += wi * v[j]
+        return out
+
+### Step 2: compression
+
+Pool each block with positional bias, project with a learned matrix. Stride `d < l` so blocks overlap. This gives more compressed keys than non-overlapping blocks and smoother attention gradients.
+
+    def build_compressed(keys, values, cfg, params):
+        ck, cv, spans = [], [], []
+        i = 0
+        while i + cfg.block_l <= len(keys):
+            ck.append(compress_block(keys[i:i + cfg.block_l], params["k_pos"], params["k_proj"]))
+            cv.append(compress_block(values[i:i + cfg.block_l], params["v_pos"], params["v_proj"]))
+            spans.append((i, i + cfg.block_l))
+            i += cfg.stride_d
+        return ck, cv, spans
+
+### Step 3: selection scores from compression probs
+
+For each compressed key with attention probability `p`, distribute `p / span_len` to every raw position it covered, then bin by selection-block size `l'`. Top-n blocks plus forced init and local blocks become the selection set.
+
+    def aggregate_scores(comp_probs, spans, num_sel, sel_block):
+        scores = [0.0] * num_sel
+        for p, (start, end) in zip(comp_probs, spans):
+            for pos in range(start, end):
+                sb = pos // sel_block
+                if sb < num_sel:
+                    scores[sb] += p / (end - start)
+        return scores
+
+### Step 4: gather and attend, three times
+
+Gather the selected blocks at full resolution, slice the sliding window, then call `attention` on each. Three independent calls, same query.
+
+### Step 5: gate and fuse
+
+    gates = [sigmoid(dot(row, q)) for row in params["gate_w"]]
+    fused = [gates[0] * cmp_out[j] + gates[1] * slc_out[j] + gates[2] * win_out[j]
+             for j in range(cfg.d_head)]
+
+### Step 6: verify
+
+Run with seq=128, `top_n=4`, `window_w=16`. Print read counts, gates, and the L2 distance to full attention. Scale the config to the DeepSeek production defaults (`l=32, d=16, l'=64, n=16, w=512`) and print asymptotic read counts at 8k, 32k, 64k context. The expected pattern: NSA reads drop from ~25% of full at 8k to ~8.6% at 64k. Sparsity grows with context length, exactly what you want for long-context serving.
+
+## Use It
+
+### What the DeepSeek kernel does that this code does not
+
+- **Triton-fused branches.** The three branches run in one kernel with shared q-tile loads instead of three sequential attentions.
+- **GQA head grouping.** All heads in a group read the same selected blocks, so the scatter cost is amortized. This file runs a single head; add an outer loop and a sum-of-probs across heads in the group before ranking to match the paper.
+- **Block-aligned sizes.** `l = 32`, `l' = 64`, `d = 16`. The compression stride is half the block length; the selection block is twice the compression block. This alignment lets the aggregate-scores step reduce to a simple reshape instead of a loop.
+
+### Comparison with neighboring ideas
+
+- **MoBA (Moonshot, arXiv:2502.13189).** Same week as NSA. One branch, parameter-less top-k gating over blocks. Simpler to drop in but requires continued training on existing checkpoints and has no coarse branch to guide selection. Deployed in Kimi at 1M context with 6.5x speedup.
+- **Gemma 3 interleaved sliding window (arXiv:2503.19786).** 5:1 local-to-global layer ratio, window 1024. Same sliding idea as the NSA branch but used as whole-layer replacement instead of per-layer branch. Cheaper and simpler, no selection mechanism.
+- **DeepSeek Sparse Attention (DSA).** The production successor in DeepSeek V4, built on NSA with further hardware tuning.
+
+The Sparse Frontier survey groups methods along four axes: which tokens to score (query-to-key vs block-to-block), where to apply sparsity (prefill vs decode), what budget policy to use (fixed vs adaptive), and whether the model was trained with the sparsity. NSA is block-to-block, both prefill and decode, fixed budget, natively trained. That combination is the reason it holds up at 0.9+ sparsity.
+
+## Ship It
+
+This lesson's artifact is a skill at `outputs/skill-sparse-attn.md` that walks the decision of whether to reach for NSA, MoBA, Gemma-style sliding, or plain full attention on a concrete deployment. The skill forces you to name the context length, the batch size, the target sparsity, and the training budget before recommending anything.
+
+## Exercises
+
+1. **Easy.** Change the gate from three sigmoids to a softmax. Rerun the demo. Why does the paper prefer independent sigmoids?
+2. **Medium.** Add a second head and aggregate selection scores across heads (GQA-style). Confirm all heads in the group read the same block ids.
+3. **Hard.** Replace the compression MLP with simple mean pooling. Retrain the gate on a toy copy task where the answer is buried 200 tokens back. Show that removing the MLP costs accuracy even when selection is still on.
+
+## Key Terms
+
+| Term | What people say | What it actually means |
+|------|----------------|----------------------|
+| Sparse attention | "Skip some tokens" | Read a deterministic fraction of the KV cache chosen by a learned or fixed pattern |
+| Native sparse attention | "Sparse attention that is fast" | Sparse attention whose parameters were trained jointly with the model, not bolted on at inference |
+| Compression branch | "A pooling trick" | Overlapping-block MLP that produces cheap surrogate keys whose attention probs drive selection |
+| Selection branch | "Top-k KV eviction" | Reads top-n full-resolution blocks picked by aggregating compression probabilities; no extra scorer |
+| Sliding branch | "Local attention" | Fixed window over the last `w` tokens, guaranteeing fresh tokens always participate |
+| Gate | "Softmax over branches" | Three independent sigmoids so branches can all fire at once |
+
+## Further Reading
+
+- [Native Sparse Attention (Yuan et al., ACL 2025)](https://arxiv.org/abs/2502.11089) — the paper this lesson implements. Read sections 3 and 4 for the full equations.
+- [MoBA: Mixture of Block Attention (Lu et al., 2025)](https://arxiv.org/abs/2502.13189) — the Moonshot parallel, same week, different design choice. Good contrast.
+- [The Sparse Frontier (Nawrot et al., 2025)](https://arxiv.org/abs/2504.17768) — the taxonomy and evaluation survey. Read before picking a method for production.
+- [Gemma 3 Technical Report (Team Gemma, 2025)](https://arxiv.org/abs/2503.19786) — interleaved sliding window, what NSA's window branch looks like as a whole-layer strategy.

--- a/phases/10-llms-from-scratch/17-native-sparse-attention/outputs/skill-sparse-attn.md
+++ b/phases/10-llms-from-scratch/17-native-sparse-attention/outputs/skill-sparse-attn.md
@@ -1,0 +1,38 @@
+---
+name: sparse-attn
+description: Pick a sparse attention strategy for a long-context LLM deployment. Rejects choices that need training budget the team does not have.
+version: 1.0.0
+phase: 10
+lesson: 17
+tags: [sparse-attention, nsa, moba, sliding-window, long-context, kv-cache, inference]
+---
+
+Given a long-context serving target (model family, parameter count, target context length in tokens, peak concurrent batch size, GPU type and count, accuracy floor on the target task, training budget available for architecture changes) and a task profile (chat, code, multi-document retrieval, needle-in-haystack, math reasoning), recommend a sparse attention strategy with explicit reasoning. Never invent model-specific speedup numbers.
+
+Produce:
+
+1. Current cost profile. Compute full-attention KV cache bytes at target context and batch size. Compute reads per decode step under full attention. Reject the entire exercise if KV cache comfortably fits in HBM and decode throughput already meets target (sparsity adds complexity for no gain at short context).
+
+2. Strategy shortlist. Three candidates from the four options below, each with the one-line reason it made the list:
+   - Native Sparse Attention (NSA). Three-branch compression plus selection plus sliding window with a learned gate. Requires training from scratch or extensive continued pretraining.
+   - MoBA. Single-branch block-sparse with parameter-less top-k gating. Requires continued training on existing checkpoint; no separate coarse branch.
+   - Interleaved sliding window (Gemma 3 style). 5:1 local-to-global layer ratio, window 1024. Training-free for the sliding layers, continued training for the interleave pattern.
+   - Training-free sparse (H2O, StreamingLLM, Quest). Drop-in at inference; accuracy degrades above 0.8 sparsity on retrieval-heavy tasks.
+
+3. Training budget check. For each shortlisted option, state the minimum training regime required: pretrain-from-scratch (NSA), continued-pretrain at 50-100B tokens (MoBA, Gemma-style interleave), or zero (training-free). Cross off anything the team cannot afford.
+
+4. Accuracy floor check. For the top candidate, cite whether the task profile is represented in the paper's evaluation (reasoning, long-context QA, code). If the paper evaluated only language modeling perplexity and the task is needle retrieval, halt and demand a small-scale validation run before recommending.
+
+5. Read-count sanity check. At the target context length, compute approximate keys read per decode step under the recommended strategy. Reject the recommendation if the sparsity ratio is below 40% of full attention at that context, because the KV-cache I/O savings will not cover the kernel complexity cost.
+
+6. Fallback. Name the next-best option if the top candidate fails training-budget or accuracy-floor checks. Always name one.
+
+Hard rejects:
+
+- NSA on a team that cannot pretrain from scratch or afford 200B+ continued training tokens.
+- Any training-free sparse method at 128k+ context with retrieval-critical tasks, unless the team has validated it on their own eval.
+- Recommending sparse attention as a fix for OOM during prefill; sparse attention helps decode, not prefill compute.
+- Bolting sparse attention onto a model trained with full attention without continued training and claiming the paper's speedup numbers.
+- Sliding-window-only at long context if the task needs any information from tokens older than the window.
+
+Output: a one-page recommendation listing strategy, training regime, expected read-count reduction at target context, and the accuracy evidence cited. End with a "worth reconsidering if..." paragraph naming the specific deployment parameter (context length extension, task shift, new paper) that would flip the choice.


### PR DESCRIPTION
## Summary

New Phase 10 Lesson 17: Native Sparse Attention (NSA).

Builds the three-branch NSA mechanism from DeepSeek's ACL 2025 Best Paper (arXiv:2502.11089) from scratch in stdlib-only Python. Three parallel branches — compression (coarse block summaries), selection (top-n full-resolution blocks), sliding (last w tokens) — fused by a learned gate.

- `docs/en.md` (217 lines) — problem, concept, build steps, comparison with MoBA and Gemma 3, exercises
- `code/main.py` (194 lines, stdlib only) — full token flow for one query, prints gate values, selected blocks, read counts, and asymptotic sparsity at 8k/32k/64k
- `assets/native-sparse-attention.svg` — editorial-style diagram showing KV cache → three branches → gate → output
- `outputs/skill-sparse-attn.md` — deployment-choice skill comparing NSA, MoBA, interleaved sliding, training-free sparse
- `notebook/.gitkeep`

Citations limited to original papers: DeepSeek NSA (arXiv:2502.11089), Moonshot MoBA (arXiv:2502.13189), Sparse Frontier survey (arXiv:2504.17768), Gemma 3 Technical Report (arXiv:2503.19786).

## Verification

- `python3 code/main.py` runs clean; reproduces expected sparsity (8.59% of keys at 64k context with DeepSeek defaults l=32, d=16, l'=64, n=16, w=512)
- SVG balances opens/closes; 32 text tags, 2 groups, single svg/defs
- Docs line count 217 (target 180-260); code 194 (target 100-200)

## Test plan

- [ ] Run `python3 phases/10-llms-from-scratch/17-native-sparse-attention/code/main.py` — verify output shows three branches, gates, and asymptotic read counts
- [ ] Open `assets/native-sparse-attention.svg` in a browser — verify editorial style renders (Georgia serif, three color-coded branch panels)
- [ ] Spot-check docs render on the site build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Native Sparse Attention implementation with configurable blocks, compression, and sliding-window branches.
  * Includes demo comparing sparse vs. full attention performance and KV-cache efficiency metrics.

* **Documentation**
  * Comprehensive guide explaining sparse attention architecture and three-branch design.
  * Decision framework for selecting and deploying sparse attention strategies in production deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->