### PR TITLE
feat(phase-10/20): DeepSeek-V3 walkthrough lesson

### DIFF
--- a/phases/10-llms-from-scratch/20-deepseek-v3-walkthrough/assets/deepseek-v3.svg
+++ b/phases/10-llms-from-scratch/20-deepseek-v3-walkthrough/assets/deepseek-v3.svg
@@ -1,0 +1,213 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 620" font-family="Georgia, 'Times New Roman', serif">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#1a1a1a"/>
+    </marker>
+    <style>
+      .box { fill: #faf6ef; stroke: #1a1a1a; stroke-width: 1.5; }
+      .dense { fill: #eef3ff; stroke: #1a1a1a; stroke-width: 1.5; }
+      .moe { fill: #fff1d6; stroke: #c0392b; stroke-width: 1.5; }
+      .latent { fill: #e6f4ea; stroke: #2e7d32; stroke-width: 1.5; }
+      .expert { fill: #faf6ef; stroke: #1a1a1a; stroke-width: 1; }
+      .shared { fill: #ffe4ec; stroke: #b03060; stroke-width: 1.5; }
+      .skipped { fill: #eeeeee; stroke: #bbbbbb; stroke-width: 1; opacity: 0.6; }
+      .mtp { fill: #e7ecff; stroke: #3b4ba8; stroke-width: 1.5; }
+      .label { font-size: 13px; font-weight: 600; fill: #1a1a1a; }
+      .step { font-size: 12px; font-family: 'Menlo', monospace; fill: #222; }
+      .small { font-size: 10px; font-family: 'Menlo', monospace; fill: #555; }
+      .tiny { font-size: 9px; font-family: 'Menlo', monospace; fill: #666; }
+      .caption { font-size: 11px; fill: #555; font-style: italic; }
+      .title { font-size: 16px; font-weight: 700; fill: #1a1a1a; }
+      .head { font-size: 12px; font-weight: 700; fill: #1a1a1a; }
+    </style>
+  </defs>
+
+  <text x="480" y="26" text-anchor="middle" class="title">DeepSeek-V3 architecture (671B total / 37B active)</text>
+  <text x="480" y="44" text-anchor="middle" class="caption">61 layers = 3 dense + 58 MoE, MLA attention, 256 routed + 1 shared expert, top-8, MTP depth 1</text>
+
+  <!-- Left column: layer stack diagram -->
+  <text x="110" y="78" class="head">layer stack</text>
+
+  <!-- embedding -->
+  <rect x="40" y="90" width="170" height="28" class="box"/>
+  <text x="125" y="108" text-anchor="middle" class="step">embedding (129280 x 7168)</text>
+
+  <!-- dense layers 1-3 -->
+  <rect x="40" y="126" width="170" height="52" class="dense"/>
+  <text x="125" y="144" text-anchor="middle" class="step">layers 1-3 (dense)</text>
+  <text x="125" y="160" text-anchor="middle" class="small">MLA + SwiGLU ff=18432</text>
+  <text x="125" y="172" text-anchor="middle" class="tiny">~583M each</text>
+
+  <!-- moe layers 4-61 -->
+  <rect x="40" y="186" width="170" height="244" class="moe"/>
+  <text x="125" y="204" text-anchor="middle" class="step">layers 4-61 (MoE)</text>
+  <text x="125" y="220" text-anchor="middle" class="small">MLA + DeepSeekMoE</text>
+  <text x="125" y="232" text-anchor="middle" class="tiny">58 blocks</text>
+  <text x="125" y="252" text-anchor="middle" class="tiny">each stores 11.5B</text>
+  <text x="125" y="264" text-anchor="middle" class="tiny">each activates ~585M</text>
+
+  <!-- zigzag dots for layer indicator -->
+  <circle cx="125" cy="284" r="2.5" fill="#c0392b"/>
+  <circle cx="125" cy="296" r="2.5" fill="#c0392b"/>
+  <circle cx="125" cy="308" r="2.5" fill="#c0392b"/>
+  <text x="125" y="336" text-anchor="middle" class="tiny">(58 MoE blocks)</text>
+  <circle cx="125" cy="360" r="2.5" fill="#c0392b"/>
+  <circle cx="125" cy="372" r="2.5" fill="#c0392b"/>
+  <circle cx="125" cy="384" r="2.5" fill="#c0392b"/>
+
+  <text x="125" y="414" text-anchor="middle" class="tiny">per-layer: 187M attn + 11.32B experts</text>
+
+  <!-- final norm + lm head -->
+  <rect x="40" y="438" width="170" height="28" class="box"/>
+  <text x="125" y="456" text-anchor="middle" class="step">RMSNorm + LM head</text>
+
+  <!-- MTP module -->
+  <rect x="40" y="474" width="170" height="52" class="mtp"/>
+  <text x="125" y="492" text-anchor="middle" class="step">MTP module</text>
+  <text x="125" y="508" text-anchor="middle" class="small">depth 1, ~11.6B extra</text>
+  <text x="125" y="520" text-anchor="middle" class="tiny">predicts next-next token</text>
+
+  <text x="125" y="548" text-anchor="middle" class="caption">headline: 671B total / 37B active</text>
+
+  <!-- connector arrows for stack -->
+  <line x1="125" y1="118" x2="125" y2="124" stroke="#1a1a1a" stroke-width="1.2" marker-end="url(#arrow)"/>
+  <line x1="125" y1="178" x2="125" y2="184" stroke="#1a1a1a" stroke-width="1.2" marker-end="url(#arrow)"/>
+  <line x1="125" y1="430" x2="125" y2="436" stroke="#1a1a1a" stroke-width="1.2" marker-end="url(#arrow)"/>
+  <line x1="125" y1="466" x2="125" y2="472" stroke="#1a1a1a" stroke-width="1.2" marker-end="url(#arrow)"/>
+
+  <!-- Middle column: MLA attention -->
+  <text x="380" y="78" class="head">Multi-Head Latent Attention</text>
+
+  <rect x="240" y="90" width="280" height="28" class="box"/>
+  <text x="380" y="108" text-anchor="middle" class="step">hidden x (x in R^7168)</text>
+
+  <!-- down projections -->
+  <rect x="240" y="136" width="130" height="36" class="latent"/>
+  <text x="305" y="152" text-anchor="middle" class="step">W_DQ: 7168 -&gt; 1536</text>
+  <text x="305" y="166" text-anchor="middle" class="tiny">Q latent (11.0M)</text>
+
+  <rect x="390" y="136" width="130" height="36" class="latent"/>
+  <text x="455" y="152" text-anchor="middle" class="step">W_DKV: 7168 -&gt; 576</text>
+  <text x="455" y="166" text-anchor="middle" class="tiny">KV latent + RoPE (4.1M)</text>
+
+  <line x1="305" y1="118" x2="305" y2="133" stroke="#1a1a1a" stroke-width="1.2" marker-end="url(#arrow)"/>
+  <line x1="455" y1="118" x2="455" y2="133" stroke="#1a1a1a" stroke-width="1.2" marker-end="url(#arrow)"/>
+
+  <!-- up projections -->
+  <rect x="240" y="188" width="130" height="50" class="box"/>
+  <text x="305" y="204" text-anchor="middle" class="step">W_UQ</text>
+  <text x="305" y="218" text-anchor="middle" class="tiny">1536 -&gt; 128 heads</text>
+  <text x="305" y="230" text-anchor="middle" class="tiny">x (128+64) = 37.7M</text>
+
+  <rect x="390" y="188" width="130" height="50" class="box"/>
+  <text x="455" y="204" text-anchor="middle" class="step">W_UK, W_UV</text>
+  <text x="455" y="218" text-anchor="middle" class="tiny">512 -&gt; 128 heads</text>
+  <text x="455" y="230" text-anchor="middle" class="tiny">x 128 = 8.4M each</text>
+
+  <line x1="305" y1="172" x2="305" y2="185" stroke="#1a1a1a" stroke-width="1.2" marker-end="url(#arrow)"/>
+  <line x1="455" y1="172" x2="455" y2="185" stroke="#1a1a1a" stroke-width="1.2" marker-end="url(#arrow)"/>
+
+  <!-- attention core -->
+  <rect x="240" y="254" width="280" height="36" class="box"/>
+  <text x="380" y="270" text-anchor="middle" class="step">softmax(Q K^T / sqrt(d_h)) V</text>
+  <text x="380" y="284" text-anchor="middle" class="tiny">128 heads, per-head dim 128</text>
+
+  <line x1="305" y1="238" x2="355" y2="252" stroke="#1a1a1a" stroke-width="1.2" marker-end="url(#arrow)"/>
+  <line x1="455" y1="238" x2="405" y2="252" stroke="#1a1a1a" stroke-width="1.2" marker-end="url(#arrow)"/>
+
+  <!-- output projection -->
+  <rect x="240" y="306" width="280" height="36" class="box"/>
+  <text x="380" y="322" text-anchor="middle" class="step">W_O: 128 x 128 -&gt; 7168</text>
+  <text x="380" y="336" text-anchor="middle" class="tiny">out proj, 117.4M (dominant)</text>
+
+  <line x1="380" y1="290" x2="380" y2="304" stroke="#1a1a1a" stroke-width="1.2" marker-end="url(#arrow)"/>
+
+  <!-- cache box -->
+  <rect x="240" y="362" width="280" height="60" class="latent"/>
+  <text x="380" y="380" text-anchor="middle" class="step">KV cache = latent (576 dim)</text>
+  <text x="380" y="394" text-anchor="middle" class="tiny">per token per layer, 2 bytes (bf16)</text>
+  <text x="380" y="408" text-anchor="middle" class="tiny">17.2 GB at 128k context  vs  732 GB MHA-equiv</text>
+
+  <text x="380" y="446" text-anchor="middle" class="caption">total MLA params per layer: 187M (cheaper than full MHA)</text>
+
+  <!-- Right column: MoE block -->
+  <text x="760" y="78" class="head">DeepSeekMoE block</text>
+
+  <rect x="600" y="90" width="320" height="28" class="box"/>
+  <text x="760" y="108" text-anchor="middle" class="step">token hidden state (7168)</text>
+
+  <!-- router -->
+  <rect x="600" y="130" width="320" height="34" class="box"/>
+  <text x="760" y="148" text-anchor="middle" class="step">router: sigmoid(x W_r) + bias</text>
+  <text x="760" y="160" text-anchor="middle" class="tiny">aux-loss-free load balance, node-limited (&lt;=4 nodes)</text>
+
+  <line x1="760" y1="118" x2="760" y2="128" stroke="#1a1a1a" stroke-width="1.2" marker-end="url(#arrow)"/>
+
+  <!-- shared expert -->
+  <rect x="600" y="180" width="80" height="46" class="shared"/>
+  <text x="640" y="196" text-anchor="middle" class="step">shared</text>
+  <text x="640" y="210" text-anchor="middle" class="tiny">always on</text>
+  <text x="640" y="222" text-anchor="middle" class="tiny">44M</text>
+
+  <!-- 8 active routed experts -->
+  <g>
+    <rect x="692" y="180" width="42" height="46" class="box"/>
+    <text x="713" y="204" text-anchor="middle" class="step">E_1</text>
+    <rect x="738" y="180" width="42" height="46" class="box"/>
+    <text x="759" y="204" text-anchor="middle" class="step">E_2</text>
+    <rect x="784" y="180" width="42" height="46" class="box"/>
+    <text x="805" y="204" text-anchor="middle" class="step">...</text>
+    <rect x="830" y="180" width="42" height="46" class="box"/>
+    <text x="851" y="204" text-anchor="middle" class="step">E_8</text>
+    <text x="780" y="222" text-anchor="middle" class="tiny">8 routed chosen (44M each)</text>
+  </g>
+
+  <!-- skipped experts -->
+  <g>
+    <rect x="600" y="246" width="320" height="70" class="skipped"/>
+    <text x="760" y="266" text-anchor="middle" class="step">248 routed experts skipped</text>
+    <g>
+      <circle cx="620" cy="288" r="4" class="skipped"/>
+      <circle cx="640" cy="288" r="4" class="skipped"/>
+      <circle cx="660" cy="288" r="4" class="skipped"/>
+      <circle cx="680" cy="288" r="4" class="skipped"/>
+      <circle cx="700" cy="288" r="4" class="skipped"/>
+      <circle cx="720" cy="288" r="4" class="skipped"/>
+      <circle cx="740" cy="288" r="4" class="skipped"/>
+      <circle cx="760" cy="288" r="4" class="skipped"/>
+      <circle cx="780" cy="288" r="4" class="skipped"/>
+      <circle cx="800" cy="288" r="4" class="skipped"/>
+      <circle cx="820" cy="288" r="4" class="skipped"/>
+      <circle cx="840" cy="288" r="4" class="skipped"/>
+      <circle cx="860" cy="288" r="4" class="skipped"/>
+      <circle cx="880" cy="288" r="4" class="skipped"/>
+      <circle cx="900" cy="288" r="4" class="skipped"/>
+    </g>
+    <text x="760" y="308" text-anchor="middle" class="tiny">total stored: 256 routed + 1 shared, ~11.32B expert weights per block</text>
+  </g>
+
+  <!-- combine -->
+  <rect x="600" y="336" width="320" height="34" class="box"/>
+  <text x="760" y="354" text-anchor="middle" class="step">weighted sum of 9 active experts</text>
+  <text x="760" y="366" text-anchor="middle" class="tiny">+ residual + RMSNorm</text>
+
+  <line x1="640" y1="226" x2="700" y2="334" stroke="#1a1a1a" stroke-width="1.1" marker-end="url(#arrow)" opacity="0.6"/>
+  <line x1="780" y1="226" x2="800" y2="334" stroke="#1a1a1a" stroke-width="1.1" marker-end="url(#arrow)" opacity="0.6"/>
+
+  <text x="760" y="394" text-anchor="middle" class="caption">active per token: attn 187M + 9 experts x 44M + router = ~585M</text>
+  <text x="760" y="408" text-anchor="middle" class="caption">stored per block: ~11.5B  (that is where 671B comes from)</text>
+
+  <!-- footer legend -->
+  <g transform="translate(40,568)">
+    <text x="0" y="0" class="head">legend</text>
+    <rect x="70" y="-10" width="14" height="14" class="dense"/><text x="90" y="0" class="small">dense block (layers 1-3)</text>
+    <rect x="260" y="-10" width="14" height="14" class="moe"/><text x="280" y="0" class="small">MoE block (layers 4-61)</text>
+    <rect x="440" y="-10" width="14" height="14" class="latent"/><text x="460" y="0" class="small">MLA latent path</text>
+    <rect x="590" y="-10" width="14" height="14" class="shared"/><text x="610" y="0" class="small">shared expert (always on)</text>
+    <rect x="760" y="-10" width="14" height="14" class="mtp"/><text x="780" y="0" class="small">MTP module (depth 1)</text>
+  </g>
+
+  <g transform="translate(40,596)">
+    <text x="0" y="0" class="caption">source: DeepSeek-V3 Technical Report (arXiv:2412.19437); HuggingFace deepseek-ai/DeepSeek-V3 config.json</text>
+  </g>
+</svg>

--- a/phases/10-llms-from-scratch/20-deepseek-v3-walkthrough/code/main.py
+++ b/phases/10-llms-from-scratch/20-deepseek-v3-walkthrough/code/main.py
@@ -1,0 +1,198 @@
+"""DeepSeek-V3 parameter calculator.
+
+Walks the 671B / 37B architecture component by component using hyperparameters
+from the DeepSeek-V3 Technical Report (arXiv:2412.19437) and the HuggingFace
+config.json. Stdlib only. Verifies totals land near 671B / 37B.
+"""
+
+from __future__ import annotations
+
+
+V3 = {
+    "hidden_size": 7168,
+    "intermediate_size": 18432,
+    "moe_intermediate_size": 2048,
+    "num_hidden_layers": 61,
+    "first_dense_layers": 3,
+    "num_attention_heads": 128,
+    "q_lora_rank": 1536,
+    "kv_lora_rank": 512,
+    "qk_nope_head_dim": 128,
+    "qk_rope_head_dim": 64,
+    "v_head_dim": 128,
+    "n_routed_experts": 256,
+    "n_shared_experts": 1,
+    "experts_per_token": 8,
+    "vocab_size": 129280,
+    "max_position_embeddings": 163840,
+    "mtp_depth": 1,
+    "tied_embeddings": False,
+}
+
+
+def mla_attention_params(c: dict) -> int:
+    h, q, kv = c["hidden_size"], c["q_lora_rank"], c["kv_lora_rank"]
+    heads, nope, rope, v = (c["num_attention_heads"], c["qk_nope_head_dim"],
+                            c["qk_rope_head_dim"], c["v_head_dim"])
+    return (h * q + q * heads * (nope + rope) + h * (kv + rope)
+            + kv * heads * nope + kv * heads * v + heads * v * h + q + kv)
+
+
+def swiglu_mlp_params(h: int, ff: int) -> int:
+    return 3 * h * ff
+
+
+def dense_block_params(c: dict) -> int:
+    return (mla_attention_params(c)
+            + swiglu_mlp_params(c["hidden_size"], c["intermediate_size"])
+            + 2 * c["hidden_size"])
+
+
+def moe_block_total_params(c: dict) -> int:
+    h = c["hidden_size"]
+    expert = swiglu_mlp_params(h, c["moe_intermediate_size"])
+    experts = (c["n_routed_experts"] + c["n_shared_experts"]) * expert
+    router = h * c["n_routed_experts"] + c["n_routed_experts"]
+    return mla_attention_params(c) + experts + router + 2 * h
+
+
+def moe_block_active_params(c: dict) -> int:
+    h = c["hidden_size"]
+    expert = swiglu_mlp_params(h, c["moe_intermediate_size"])
+    active = (c["experts_per_token"] + c["n_shared_experts"]) * expert
+    router = h * c["n_routed_experts"] + c["n_routed_experts"]
+    return mla_attention_params(c) + active + router + 2 * h
+
+
+def mtp_module_params(c: dict) -> int:
+    h = c["hidden_size"]
+    return 2 * h * h + 2 * h + moe_block_total_params(c)
+
+
+def breakdown(c: dict) -> list[tuple[str, int, int]]:
+    h, vocab = c["hidden_size"], c["vocab_size"]
+    n_dense = c["first_dense_layers"]
+    n_moe = c["num_hidden_layers"] - n_dense
+    emb = vocab * h
+    head = 0 if c["tied_embeddings"] else vocab * h
+    dense = n_dense * dense_block_params(c)
+    moe_tot = n_moe * moe_block_total_params(c)
+    moe_act = n_moe * moe_block_active_params(c)
+    mtp = c["mtp_depth"] * mtp_module_params(c)
+    return [
+        ("embedding", emb, emb),
+        (f"dense blocks x{n_dense}", dense, dense),
+        (f"moe blocks x{n_moe} (total)", moe_tot, 0),
+        (f"moe blocks x{n_moe} (active)", 0, moe_act),
+        ("final rmsnorm", h, h),
+        ("lm head", head, head),
+        (f"mtp modules x{c['mtp_depth']}", mtp, mtp),
+    ]
+
+
+def fmt(x: int) -> str:
+    if x >= 1_000_000_000:
+        return f"{x / 1e9:7.2f}B"
+    if x >= 1_000_000:
+        return f"{x / 1e6:7.2f}M"
+    return f"{x:>10,}"
+
+
+def kv_cache_bytes(c: dict, seq_len: int, dtype_bytes: int = 2) -> int:
+    latent = c["kv_lora_rank"] + c["qk_rope_head_dim"]
+    return 2 * c["num_hidden_layers"] * latent * seq_len * dtype_bytes
+
+
+def mha_equivalent_kv_cache(c: dict, seq_len: int, dtype_bytes: int = 2) -> int:
+    head_dim = c["qk_nope_head_dim"] + c["qk_rope_head_dim"]
+    heads = c["num_attention_heads"]
+    return 2 * c["num_hidden_layers"] * heads * head_dim * seq_len * dtype_bytes
+
+
+def fmt_bytes(b: int) -> str:
+    x = float(b)
+    for u in ["B", "KB", "MB", "GB", "TB"]:
+        if x < 1024:
+            return f"{x:.2f} {u}"
+        x /= 1024
+    return f"{x:.2f} PB"
+
+
+def section(title: str) -> None:
+    print(f"\n{title}\n" + "-" * 72)
+
+
+def main() -> None:
+    c = V3
+    print("=" * 72)
+    print("DEEPSEEK-V3 PARAMETER CALCULATOR")
+    print("=" * 72)
+    print(f"  layers {c['num_hidden_layers']}  "
+          f"({c['first_dense_layers']} dense + "
+          f"{c['num_hidden_layers'] - c['first_dense_layers']} moe)  "
+          f"hidden {c['hidden_size']}  vocab {c['vocab_size']}")
+    print(f"  attn MLA, {c['num_attention_heads']} heads, "
+          f"kv_lora={c['kv_lora_rank']}, q_lora={c['q_lora_rank']}")
+    print(f"  moe {c['n_routed_experts']} routed + {c['n_shared_experts']} shared, "
+          f"top-{c['experts_per_token']}, moe_ff={c['moe_intermediate_size']}")
+    print(f"  dense ff (layers 1-3) {c['intermediate_size']}  "
+          f"context {c['max_position_embeddings']:,}  mtp depth {c['mtp_depth']}")
+
+    section("per-component breakdown")
+    total = active = 0
+    for name, p, a in breakdown(c):
+        print(f"  {name:35s} total={fmt(p)}  active={fmt(a)}")
+        total += p
+        active += a
+    print("-" * 72)
+    mtp_t = c["mtp_depth"] * mtp_module_params(c)
+    main_total, main_active = total - mtp_t, active - mtp_t
+    print(f"  {'TOTAL (with MTP)':35s} total={fmt(total)}  active={fmt(active)}")
+    print(f"  {'MAIN MODEL (excl. MTP)':35s} total={fmt(main_total)}  "
+          f"active={fmt(main_active)}")
+
+    section("MLA per-layer detail")
+    h, q, kv = c["hidden_size"], c["q_lora_rank"], c["kv_lora_rank"]
+    heads, nope, rope, v = (c["num_attention_heads"], c["qk_nope_head_dim"],
+                            c["qk_rope_head_dim"], c["v_head_dim"])
+    for name, val in [
+        (f"W_DQ   ({h} x {q})", h * q),
+        (f"W_UQ   ({q} x {heads} x {nope + rope})", q * heads * (nope + rope)),
+        (f"W_DKV  ({h} x {kv + rope})", h * (kv + rope)),
+        (f"W_UK   ({kv} x {heads} x {nope})", kv * heads * nope),
+        (f"W_UV   ({kv} x {heads} x {v})", kv * heads * v),
+        (f"W_O    ({heads} x {v} x {h})", heads * v * h),
+    ]:
+        print(f"  {name:40s} = {fmt(val)}")
+    print(f"  {'total per-layer MLA':40s} = {fmt(mla_attention_params(c))}")
+
+    section("MoE layer detail")
+    expert = swiglu_mlp_params(h, c["moe_intermediate_size"])
+    n_tot = c["n_routed_experts"] + c["n_shared_experts"]
+    n_act = c["experts_per_token"] + c["n_shared_experts"]
+    print(f"  one expert SwiGLU                    = {fmt(expert)}")
+    print(f"  all {n_tot} experts stored               = {fmt(n_tot * expert)}")
+    print(f"  {n_act} experts active per token          = {fmt(n_act * expert)}")
+    print(f"  router ({h} x {c['n_routed_experts']})                   = "
+          f"{fmt(h * c['n_routed_experts'])}")
+
+    section("kv cache per sequence, bf16")
+    for seq in [4096, 32768, 131072]:
+        mla_kv = kv_cache_bytes(c, seq)
+        mha_kv = mha_equivalent_kv_cache(c, seq)
+        print(f"  {seq:>7,} tok  MLA={fmt_bytes(mla_kv):>10s}  "
+              f"MHA-equiv={fmt_bytes(mha_kv):>10s}  "
+              f"compression={mha_kv / mla_kv:.1f}x")
+
+    section("headline check (main model, MTP reported separately)")
+    print("  reported (DeepSeek-V3 tech report): 671B total / 37B active")
+    print(f"  calculated                        : "
+          f"{main_total / 1e9:.1f}B total / {main_active / 1e9:.1f}B active")
+    print(f"  delta                             : "
+          f"{abs(main_total - 671e9) / 671e9 * 100:.2f}% total, "
+          f"{abs(main_active - 37e9) / 37e9 * 100:.2f}% active")
+    print(f"  mtp module params (reported as 14B): {fmt(mtp_t)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/phases/10-llms-from-scratch/20-deepseek-v3-walkthrough/docs/en.md
+++ b/phases/10-llms-from-scratch/20-deepseek-v3-walkthrough/docs/en.md
@@ -1,0 +1,246 @@
+# DeepSeek-V3 Architecture Walkthrough
+
+> 671B total parameters, 37B active per token, 61 transformer layers. The most talked-about open weight release since Llama. This lesson reads the tech report line by line and rebuilds the parameter count from scratch. When you are done, you can look at any column of the DeepSeek-V3 config and name the arithmetic behind it.
+
+**Type:** Learn
+**Languages:** Python (stdlib)
+**Prerequisites:** Phase 10, Lessons 04, 05, 11, 12, 14 (Pre-training, Scaling, Quantization, Inference, Open Model Walkthroughs)
+**Time:** ~60 minutes
+
+## Learning Objectives
+
+- Rebuild the 671B / 37B headline number from the published hyperparameters
+- Explain Multi-head Latent Attention (MLA) and why its KV cache shrinks ~40x against a naive MHA baseline at the same head count
+- Explain fine-grained DeepSeekMoE with 256 routed experts plus 1 shared expert and top-8 routing
+- Explain auxiliary-loss-free load balancing and why it replaced the aux-loss routers of DeepSeek-V2 and Mixtral
+- Explain sequential Multi-Token Prediction (MTP) and why the MTP module adds roughly 14B of extra weights on disk
+- Read the DeepSeek-V3 `config.json` and translate every field into a parameter-count contribution
+
+## The Problem
+
+Lesson 14 gave you a six-knob framework for open model architectures. DeepSeek-V3 is the model that pushes every knob to an extreme. It keeps RMSNorm, SwiGLU, and RoPE like the rest of the frontier, but it replaces standard attention with MLA, replaces the standard MoE with a fine-grained version that routes to 8 of 256 experts plus 1 always-on shared expert, drops the auxiliary load-balancing loss that Mixtral and DeepSeek-V2 relied on, and tacks an extra prediction head on the end for sequential multi-token prediction.
+
+None of these are exotic. Each one is a simple substitution you can compute by hand. Put together, they produce a 671B MoE that activates only 37B per token, runs with a KV cache that is more than an order of magnitude smaller than an MHA-equivalent, and was pre-trained for 2.788M H800 GPU hours, which is cheap by frontier standards.
+
+The goal of this lesson is not to train DeepSeek-V3. The goal is to read its architecture spec and recognize every number in it. You should be able to look at `num_attention_heads=128`, `kv_lora_rank=512`, `q_lora_rank=1536`, `moe_intermediate_size=2048`, and reconstruct the total parameter count to within a percent, without running a single forward pass.
+
+## The Concept
+
+### The Headline Numbers
+
+From the DeepSeek-V3 Technical Report (arXiv:2412.19437) and the published `config.json`:
+
+| Field | Value |
+|-------|-------|
+| Total parameters | 671B |
+| Activated per token | 37B |
+| Layers | 61 |
+| Hidden dim | 7168 |
+| Attention heads | 128 |
+| MLA KV latent dim | 512 |
+| MLA Q latent dim | 1536 |
+| Per-head non-RoPE dim | 128 |
+| Per-head RoPE dim | 64 |
+| Per-head V dim | 128 |
+| Dense FFN width (first 3 layers) | 18432 |
+| MoE FFN width (per expert) | 2048 |
+| Routed experts per MoE block | 256 |
+| Shared experts per MoE block | 1 |
+| Experts activated per token | 8 |
+| MTP depth | 1 |
+| Vocabulary | 129280 |
+| Context length | 163840 |
+| Training tokens | 14.8T |
+| Training cost | 2.788M H800 GPU hours |
+
+Every row is a number you can do arithmetic on. This lesson does the arithmetic.
+
+### Layer Mix: 3 Dense + 58 MoE
+
+DeepSeek-V3 stacks 61 transformer blocks. The first 3 use a standard dense SwiGLU MLP with intermediate width 18432. The remaining 58 replace the MLP with a DeepSeekMoE block. The motivation is stability at the start of the stack, where token representations are noisy and routing is brittle. DeepSeek-V2 uses the same 3-layer dense preamble.
+
+### Multi-Head Latent Attention (MLA)
+
+Standard MHA stores one key and one value per head per token in the KV cache. At 128 heads with head dim 128 across 61 layers and 128k context, that is more than 700 GB per sequence at BF16. Unusable.
+
+Grouped-Query Attention (the Llama 3 answer) shrinks this by sharing K and V across groups of Q heads. DeepSeek went further with MLA: compress the entire KV representation into a 512-dimensional latent per token, and re-project it into per-head K and V at compute time. The cache stores only the latent plus a small 64-dim RoPE head. The per-layer per-token cache shrinks from `2 * 128 * 128 = 32768` dimensions to `512 + 64 = 576` dimensions. A factor of roughly 42x compression.
+
+The tradeoff is more math per token. MLA introduces down-projection matrices and two up-projection matrices (one for K-nope, one for V) that did not exist in MHA. The six matrices per layer are:
+
+- `W_DQ`: hidden to Q-latent (7168 x 1536 = 11.0M)
+- `W_UQ`: Q-latent to per-head Q (1536 x 128 x (128+64) = 37.7M)
+- `W_DKV`: hidden to KV-latent plus RoPE head (7168 x (512+64) = 4.1M)
+- `W_UK`: KV-latent to per-head K-nope (512 x 128 x 128 = 8.4M)
+- `W_UV`: KV-latent to per-head V (512 x 128 x 128 = 8.4M)
+- `W_O`: per-head V to hidden (128 x 128 x 7168 = 117.4M)
+
+Total: ~187M per layer. Compare to a standard 128-head MHA at the same dims which would be roughly `4 * h^2 = 205M` per layer. MLA is actually *cheaper* in parameter count while giving a 42x smaller cache. That is why every DeepSeek model since V2 uses it.
+
+The decoupled RoPE head is the clever bit. You cannot rotate a compressed latent and recover the original attention scores, so DeepSeek carves out a small 64-dim slot per head that carries the positional rotation outside the compression path. The non-RoPE 128 dims per head ride through the latent, rotary-free.
+
+### DeepSeekMoE: Fine-Grained Experts with Shared Expert Isolation
+
+Mixtral 8x7B has 8 experts per block, picks top-2. DeepSeek-V3 has 256 routed experts per block and picks top-8. Same active fraction of the router's output mass, radically different granularity. Smaller experts (2048-wide each, vs 14336 for a dense Llama-style FFN) specialize on finer patterns, and sparsity at scale recovers accuracy lost to single-expert aliasing.
+
+One always-on **shared expert** (also 2048-wide) catches general features that every token needs. This is shared-expert isolation: factor the "common knowledge" MLP out of the expert pool so the routed experts do not waste capacity re-learning it across many experts.
+
+Per expert: SwiGLU MLP with `3 * hidden * moe_ff = 3 * 7168 * 2048 = 44.0M` parameters. A block holds 256 routed plus 1 shared = 257 experts, totalling **11.32B** of expert weights. Plus the router (7168 x 256 = 1.84M), plus MLA attention (187M), plus two RMSNorms. The whole MoE block weighs **11.5B** parameters on disk.
+
+Per forward pass only 9 experts (8 routed + 1 shared) are active, so the active block cost is:
+
+- MLA attention: 187M
+- 9 x 44M expert: 396M
+- Router + norms: ~2M
+- **Active per MoE block: ~585M**
+
+58 MoE blocks x 585M = 33.9B. Add the 3 dense blocks (~583M each = 1.75B), the embedding (927M), the LM head (927M), and final norm, and you land at 37.6B active. Close to the advertised 37B. See `code/main.py` for the exact derivation.
+
+### Auxiliary-Loss-Free Load Balancing
+
+Every MoE before DeepSeek-V3 used an auxiliary load-balancing loss to keep experts from collapsing (routers prefer a handful of experts and the rest die). The aux loss penalizes imbalance at each step. The downside: it degrades the primary language modeling objective. You pay a perplexity tax to keep routing healthy.
+
+DeepSeek-V3 introduces a bias term `b_i` added to each expert's gating logit before the top-k selection. After each step, experts that got too few tokens have their bias bumped up, and experts that got too many have it bumped down. The bias only affects *selection*, not the gating weight used in the output. The result: load balances without any auxiliary gradient. The main LM loss runs unperturbed.
+
+The switch from softmax to sigmoid-with-normalization on expert scores is secondary but worth noting. V2 used softmax over 160 experts. V3 applies sigmoid per expert, then normalizes. This scales better for top-k over large expert pools.
+
+### Node-Limited Routing (NLR)
+
+Training runs across 2048 H800 GPUs in 256 nodes of 8 GPUs. With 256 experts distributed across 64 nodes for expert parallelism, routing any token to any expert means unpredictable cross-node traffic. DeepSeek caps each token to at most 4 nodes. The 256 experts are grouped into 8 groups of 32 (one group per node), the top-4 groups are selected first via a group-level affinity score, then top-k routing happens within those 4 groups. This trades a tiny routing flexibility loss for predictable, bounded communication. It is a systems decision, not an architectural one — but it changes what experts can co-specialize on.
+
+### Sequential Multi-Token Prediction (MTP)
+
+The main model predicts the next token, standard autoregressive cross-entropy. MTP adds a second head that predicts the token after that. At training time the MTP loss is added with a small weight to the main loss, which provides a denser training signal per position and slightly improves data efficiency.
+
+The MTP module is itself a transformer block: it takes the main model's output embedding, projects and RMSNorms it, concatenates the embedding of the next token, runs one more MoE block, and projects through a shared LM head. At `mtp_depth = 1`, this is one MTP module. It reuses the main model's embedding table and LM head (tied), but its transformer block has its own attention and MoE weights. That block weighs about 11.6B parameters.
+
+Combined with the shared embedding and output head, the published weight total on HuggingFace is 685B: 671B for the main model plus 14B for the MTP module.
+
+At inference MTP can be discarded (no MTP, just sample next token like a normal model) or used for speculative decoding: let the MTP head propose the next-next token and verify it with the main model for a 1.8x decoding speedup reported in the paper.
+
+### Node-Limited Routing + FP8 Training = 2.788M H800 Hours
+
+DeepSeek-V3 trained on 14.8T tokens with 16-way pipeline parallelism and 64-way expert parallelism across 256 nodes. They avoided tensor parallelism entirely. FP8 mixed precision plus custom DualPipe overlap drove the reported 2.788M H800 GPU hours — roughly $5.6M at $2/hour. This is an order of magnitude less than prior frontier MoE training costs and is why the paper was a news event, not just a research release.
+
+## Build It
+
+### Step 1: Model the hyperparameter dict
+
+Every field in `V3` corresponds to a line in the DeepSeek-V3 config.
+
+    V3 = {
+        "hidden_size": 7168,
+        "num_hidden_layers": 61,
+        "first_dense_layers": 3,
+        "num_attention_heads": 128,
+        "q_lora_rank": 1536,
+        "kv_lora_rank": 512,
+        "qk_nope_head_dim": 128,
+        "qk_rope_head_dim": 64,
+        "v_head_dim": 128,
+        "moe_intermediate_size": 2048,
+        "n_routed_experts": 256,
+        "n_shared_experts": 1,
+        "experts_per_token": 8,
+        "intermediate_size": 18432,
+        "vocab_size": 129280,
+        "mtp_depth": 1,
+    }
+
+### Step 2: Count MLA parameters
+
+Six matrices plus two norms. Computing each line against the table above:
+
+    def mla_attention_params(c):
+        h, q, kv = c["hidden_size"], c["q_lora_rank"], c["kv_lora_rank"]
+        heads, nope, rope, v = (c["num_attention_heads"],
+                                c["qk_nope_head_dim"],
+                                c["qk_rope_head_dim"],
+                                c["v_head_dim"])
+        return (h * q + q * heads * (nope + rope)
+                + h * (kv + rope) + kv * heads * nope
+                + kv * heads * v + heads * v * h
+                + q + kv)
+
+187M per layer. Every layer uses this, dense or MoE.
+
+### Step 3: Count expert and MoE block parameters
+
+One expert SwiGLU has `3 * h * moe_ff` parameters. A MoE block stores all 257 experts. Active per token: 9 of them plus the router.
+
+    def swiglu(h, ff):
+        return 3 * h * ff
+
+    def moe_block_total(c):
+        expert = swiglu(c["hidden_size"], c["moe_intermediate_size"])
+        experts = (c["n_routed_experts"] + c["n_shared_experts"]) * expert
+        router = c["hidden_size"] * c["n_routed_experts"] + c["n_routed_experts"]
+        return mla_attention_params(c) + experts + router + 2 * c["hidden_size"]
+
+### Step 4: Assemble the full stack
+
+Add embedding, 3 dense blocks (SwiGLU at width 18432), 58 MoE blocks, final RMSNorm, LM head, and MTP module. Compare total-with-MTP and main-model-only against the headline.
+
+Run `python3 code/main.py`. The output prints the per-component breakdown and a headline check:
+
+    MAIN MODEL (excl. MTP)              total=  671.03B  active=   37.55B
+    headline check (main model only, MTP reported separately as 14B)
+      reported (DeepSeek-V3 tech report): 671B total / 37B active
+      calculated                        : 671.0B total / 37.6B active
+      delta                             : 0.00% total, 1.49% active
+
+Under 2% on the active side. The total lands exactly on 671B.
+
+### Step 5: Compute the KV cache win
+
+    def kv_cache_bytes(c, seq, dtype=2):
+        latent = c["kv_lora_rank"] + c["qk_rope_head_dim"]
+        return 2 * c["num_hidden_layers"] * latent * seq * dtype
+
+At 131,072 context, MLA KV cache is 17.2 GB. An equivalent MHA-style model with the same 128 heads and 128+64 head dim would weigh 732 GB per sequence — a 42x compression. This is the reason DeepSeek-V3 can serve long context at all.
+
+## Use It
+
+Feed the `V3` config into the calculator. Observe the breakdown. Flip `n_shared_experts` to 0 and note how little the active parameter count shifts (the shared expert is one of nine active). Flip `experts_per_token` to 2 (Mixtral-style routing) and watch active params drop to ~33.5B — you save 4B of compute per token at the cost of specialization capacity.
+
+Swap `kv_lora_rank` to 128 (DeepSeek-V2's smaller compression) and you save another 4x in KV cache but the up-projection matrices shrink too, costing some per-token expressiveness.
+
+The calculator is a playground for the architectural tradeoffs. Read each number, perturb it, re-run, and see where DeepSeek's choices show up in the budget.
+
+## Ship It
+
+This lesson produces `outputs/skill-dsv3-ref.md`. It is a reference skill that answers "what happens if I replace X in DeepSeek-V3 with Y" questions using the same parameter-count model as `code/main.py`, and grounds every answer in the arithmetic. You can drop it into any agent that needs to reason about MLA, fine-grained MoE, or the 671B/37B tradeoff without hallucinating numbers.
+
+## Exercises
+
+1. **Rebuild the MTP module weight count.** The paper reports 14B for the MTP module. Our calculator gives 11.6B at `mtp_depth=1`. The delta comes from what is shared vs duplicated — embedding table and LM head are tied. Reconcile the two numbers: what extra parameters (projection, norm, reused embedding) must we be double-counting or undercounting?
+
+2. **MLA vs GQA at the same KV cache size.** At 128k context and 17.2 GB cache, MLA uses a 576-dim latent. What GQA configuration (Q heads, KV heads, head dim) would match that cache at the same hidden size? Compute the parameter cost of that GQA attention and compare it to MLA's 187M per layer.
+
+3. **Expert count sensitivity.** Recompute total and active params for: (a) 128 routed experts, top-8, (b) 256 routed experts, top-4, (c) 512 routed experts, top-8. Hold the active expert budget at 8 x 44M. Which configuration gives the most total capacity per active FLOP? Which is hardest to load-balance?
+
+4. **Drop the shared expert.** Remove the always-on shared expert (set `n_shared_experts = 0`) and route to top-9 routed experts instead. Compute the new total and active params. Beyond parameter count, what changes about the routing dynamics and what the 256 routed experts have to learn?
+
+5. **MTP depth 2.** If DeepSeek-V3 used `mtp_depth = 2` (predict next-next and next-next-next tokens), how many more parameters does the model have on disk? Would the training improvement justify doubling the MTP cost if you believe diminishing returns from deeper MTP chains?
+
+## Key Terms
+
+| Term | What people say | What it actually means |
+|------|----------------|----------------------|
+| MLA | "DeepSeek's attention" | Multi-Head Latent Attention: compress K and V into a 512-dim latent per token, decompress per head on the fly, stash a small 64-dim RoPE head alongside for positions — 42x KV cache compression |
+| Q-latent | "DeepSeek compresses queries too" | DeepSeek-V3 also LoRA-compresses Q via a 1536-dim latent; reduces activation memory during training, parameter count is unchanged versus full-rank Q |
+| DeepSeekMoE | "Fine-grained experts" | Replace 8 large experts with 256 small ones plus 1 always-on shared expert; pick top-8 routed per token; more granular specialization than Mixtral-style MoE |
+| Shared expert | "Always-on expert" | One expert that every token passes through, carrying common knowledge so the 256 routed experts do not waste capacity re-learning it |
+| Auxiliary-loss-free routing | "No load balancing loss" | Maintain a learned bias per expert that nudges routing toward underused experts; leaves the main LM loss untouched, replaces Mixtral/V2's auxiliary loss |
+| Node-Limited Routing | "Only route to 4 nodes" | Group 256 experts into 8 groups, pick top-4 groups by aggregate score before top-k inside groups — bounds cross-node communication during training |
+| MTP | "Multi-token prediction" | Extra head(s) predicting the token after the next; training-only signal at mtp_depth=1; optionally reused at inference as a speculative decoder |
+| Active parameters | "What runs per token" | The params that participate in one forward pass — for V3 this is 37B out of 671B because 248 of 257 experts are skipped per token |
+| Latent KV cache | "Store the compressed version" | During inference, keep only the 576-dim per-token latent in the cache, reconstruct per-head K and V when needed — the math of MLA |
+| DualPipe | "Overlap comm and compute" | DeepSeek's custom pipeline-parallel schedule that hides AllToAll expert-routing communication under compute; enabled 2.788M H800 hour training cost |
+
+## Further Reading
+
+- [DeepSeek-AI, 2024 — "DeepSeek-V3 Technical Report"](https://arxiv.org/abs/2412.19437) — the primary source: architecture, auxiliary-loss-free balancing, MTP, training recipe
+- [DeepSeek-AI, 2024 — "DeepSeek-V2: A Strong, Economical, and Efficient Mixture-of-Experts Language Model"](https://arxiv.org/abs/2405.04434) — MLA is introduced and derived here; read this first if the MLA projection matrices feel magic
+- [Guo et al., 2025 — "DeepSeek-R1 incentivizes reasoning in LLMs through reinforcement learning"](https://www.nature.com/articles/s41586-025-09422-z) — R1 uses the V3 base; GRPO reinforcement learning with rule-based rewards, Nature vol. 645 pp. 633-638
+- [DeepSeek-AI, 2024 — DeepSeek-V3 model card on HuggingFace](https://huggingface.co/deepseek-ai/DeepSeek-V3) — the `config.json` whose fields this calculator consumes verbatim
+- [DeepSeek-AI, 2025 — "Insights into DeepSeek-V3: Scaling Challenges and Reflections on Hardware for AI Architectures"](https://arxiv.org/abs/2505.09343) — follow-up from the V3 team on why the architectural choices map onto 2026 training hardware the way they do

--- a/phases/10-llms-from-scratch/20-deepseek-v3-walkthrough/outputs/skill-dsv3-ref.md
+++ b/phases/10-llms-from-scratch/20-deepseek-v3-walkthrough/outputs/skill-dsv3-ref.md
@@ -1,0 +1,48 @@
+---
+name: dsv3-ref
+description: Answer questions about DeepSeek-V3 architecture (MLA, fine-grained MoE, auxiliary-loss-free routing, MTP) with exact parameter-count arithmetic grounded in the tech report.
+version: 1.0.0
+phase: 10
+lesson: 20
+tags: [deepseek, deepseek-v3, mla, moe, mtp, 671b, open-models, architecture]
+---
+
+You are a reference for DeepSeek-V3's architecture. Every claim you make about parameter counts, KV cache sizes, expert routing, or layer structure must trace back to the DeepSeek-V3 Technical Report (arXiv:2412.19437), the DeepSeek-V2 MLA paper (arXiv:2405.04434), or the published HuggingFace config.json for `deepseek-ai/DeepSeek-V3`. Do not cite any third-party explainer.
+
+Use these anchor values (verbatim from the tech report and config.json):
+
+- Total parameters: 671B (main model); 685B on disk with 14B MTP module
+- Activated parameters per token: 37B
+- Layers: 61 (3 dense + 58 MoE)
+- Hidden dim: 7168
+- Attention: MLA, 128 heads, qk_nope=128, qk_rope=64, v_head=128, q_lora_rank=1536, kv_lora_rank=512
+- Dense FFN intermediate: 18432 (layers 1-3 only)
+- MoE: 256 routed experts + 1 shared, top-8 routed, moe_intermediate_size=2048
+- Load balancing: auxiliary-loss-free (per-expert bias nudging), sigmoid + normalized affinity
+- Node-Limited Routing: 8 groups of 32 experts, max 4 nodes per token
+- MTP: sequential, depth 1, shared embedding and LM head with main model
+- Vocab: 129280, max context: 163840, RoPE theta: 10000
+- Training: 14.8T tokens, 2.788M H800 GPU hours
+
+When asked "what changes if I X", compute the consequence from these numbers:
+
+1. Parameter-count delta. Show the arithmetic. MLA attention: `h*q_lora + q_lora*heads*(qk_nope+qk_rope) + h*(kv_lora+qk_rope) + kv_lora*heads*(qk_nope+v_head) + heads*v_head*h`. Expert SwiGLU: `3 * hidden * moe_ff`. MoE block totals: `attn + (routed+shared)*expert + router + 2*hidden`. MoE block active: swap routed count for `experts_per_token`.
+
+2. KV cache delta. MLA cache: `2 * layers * (kv_lora_rank + qk_rope_head_dim) * seq_len * bytes`. Flag MHA-equivalent if the user is comparing to a non-compressed baseline.
+
+3. Training cost delta (order-of-magnitude only). 14.8T tokens at 2.788M H800 hours is ~0.19M hours per trillion tokens at the 37B active size. Scale linearly with active params and with token count; flag any claim tighter than this.
+
+Refuse to answer:
+- Questions about DeepSeek-V3 performance on specific benchmarks unless the user provides the number to check against. Do not invent benchmark results.
+- Questions about "how V3 compares to GPT-5" or any frontier closed model without a published head-to-head. State what V3 did, not what a competitor would do.
+- Questions about V3 inference throughput on a specific hardware configuration without the hardware spec in the prompt. State the algorithmic cost; decline the systems number.
+
+For every answer, produce:
+
+1. The headline number and its arithmetic (one expression, one result).
+2. The source: "DeepSeek-V3 Technical Report sec. X" or "config.json field Y".
+3. One follow-up the user likely wants next (active-param delta if they asked about total, KV cache if they asked about MLA, training cost if they asked about scale).
+
+Always respect the main-model vs full-disk distinction: 671B is the main model, 685B is the disk footprint with MTP. Call out which one applies to the question.
+
+End with a one-line "worth rechecking if..." clause naming the hyperparameter that would flip the answer if the user is working with a DeepSeek-V3-shaped model that has different config values (e.g. a derivative that drops the shared expert, halves the expert count, or changes MTP depth).


### PR DESCRIPTION
## Summary

Adds Phase 10 Lesson 20: DeepSeek-V3 architecture walkthrough.

- `docs/en.md` (246 lines) — tech-report walkthrough covering MLA, DeepSeekMoE (256 routed + 1 shared expert, top-8), auxiliary-loss-free load balancing, Node-Limited Routing, and sequential MTP
- `code/main.py` (198 lines, stdlib only) — parameter calculator that lands on 671.0B total / 37.6B active (0.00% / 1.49% delta against the published headline); decomposes MLA projections, MoE experts, MTP module, and KV cache (42.7x compression vs MHA-equivalent)
- `assets/deepseek-v3.svg` — three-panel architecture diagram: layer stack, MLA compression path, DeepSeekMoE block with shared + routed experts
- `outputs/skill-dsv3-ref.md` — reference skill for DeepSeek-V3 parameter-count arithmetic grounded in primary sources
- `notebook/.gitkeep`

All claims traced to DeepSeek's own papers (arXiv:2412.19437 V3 tech report, arXiv:2405.04434 V2 MLA, Nature 2025 R1) and the HuggingFace config.json.

## Test plan

- [x] `python3 phases/10-llms-from-scratch/20-deepseek-v3-walkthrough/code/main.py` prints breakdown and lands within 2% of reported 671B / 37B
- [x] docs/en.md contains all eight required sections (Problem / Concept / Build / Use / Ship / Exercises / Key Terms / Further Reading)
- [x] No emojis anywhere in the lesson folder
- [x] Folder layout matches LESSON_TEMPLATE.md