### PR TITLE
feat(phase-10/15): speculative decoding and EAGLE-3 lesson

### DIFF
--- a/phases/10-llms-from-scratch/15-speculative-decoding-eagle/assets/speculative-decoding.svg
+++ b/phases/10-llms-from-scratch/15-speculative-decoding-eagle/assets/speculative-decoding.svg
@@ -1,0 +1,79 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 540" font-family="Georgia, 'Times New Roman', serif">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#1a1a1a"/>
+    </marker>
+    <marker id="red-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#c0392b"/>
+    </marker>
+    <style>
+      .box { fill: #faf6ef; stroke: #1a1a1a; stroke-width: 1.5; }
+      .hot { fill: #fff1d6; stroke: #c0392b; stroke-width: 1.8; }
+      .cool { fill: #e6f4ea; stroke: #2e7d32; stroke-width: 1.5; }
+      .cell { fill: #f3ece0; stroke: #1a1a1a; stroke-width: 1.2; }
+      .reject { fill: #fbe3e0; stroke: #c0392b; stroke-width: 1.5; }
+      .label { font-size: 13px; font-weight: 600; fill: #1a1a1a; }
+      .content { font-size: 12px; font-family: 'Menlo', monospace; fill: #222; }
+      .caption { font-size: 11px; fill: #555; font-style: italic; }
+      .title { font-size: 16px; font-weight: 700; fill: #1a1a1a; }
+      .small { font-size: 11px; font-family: 'Menlo', monospace; fill: #555; }
+    </style>
+  </defs>
+
+  <text x="440" y="28" text-anchor="middle" class="title">speculative decoding: one target forward, up to K+1 tokens</text>
+
+  <rect class="box" x="30" y="50" width="820" height="90" rx="4"/>
+  <text class="label" x="45" y="72">1 / draft proposes K = 4 tokens autoregressively (cheap)</text>
+  <rect class="cell" x="50"  y="88" width="90" height="36" rx="3"/><text class="content" x="95"  y="111" text-anchor="middle">prefix...</text>
+  <rect class="cell" x="160" y="88" width="90" height="36" rx="3"/><text class="content" x="205" y="111" text-anchor="middle">x1 ~ q</text>
+  <rect class="cell" x="270" y="88" width="90" height="36" rx="3"/><text class="content" x="315" y="111" text-anchor="middle">x2 ~ q</text>
+  <rect class="cell" x="380" y="88" width="90" height="36" rx="3"/><text class="content" x="425" y="111" text-anchor="middle">x3 ~ q</text>
+  <rect class="cell" x="490" y="88" width="90" height="36" rx="3"/><text class="content" x="535" y="111" text-anchor="middle">x4 ~ q</text>
+  <text class="small" x="610" y="111">  cost ≈ K · cost(draft)</text>
+
+  <rect class="hot" x="30" y="165" width="820" height="90" rx="4"/>
+  <text class="label" x="45" y="187">2 / target runs ONE forward pass over all K+1 positions</text>
+  <text class="content" x="50" y="215">p_k = p( · | prefix + x1..xk)   for k = 0, 1, 2, 3, 4</text>
+  <text class="caption" x="50" y="240">memory-bound decode amortized across K+1 positions — this is where the speedup comes from</text>
+
+  <rect class="box" x="30" y="280" width="820" height="190" rx="4"/>
+  <text class="label" x="45" y="302">3 / accept-or-reject left to right, preserve target distribution p</text>
+
+  <rect class="cool" x="50"  y="316" width="120" height="46" rx="3"/>
+  <text class="content" x="110" y="338" text-anchor="middle">x1 accept</text>
+  <text class="small"   x="110" y="354" text-anchor="middle">r &lt; p(x1)/q(x1)</text>
+
+  <rect class="cool" x="190" y="316" width="120" height="46" rx="3"/>
+  <text class="content" x="250" y="338" text-anchor="middle">x2 accept</text>
+  <text class="small"   x="250" y="354" text-anchor="middle">r &lt; p(x2)/q(x2)</text>
+
+  <rect class="reject" x="330" y="316" width="140" height="46" rx="3"/>
+  <text class="content" x="400" y="338" text-anchor="middle">x3 REJECT</text>
+  <text class="small"   x="400" y="354" text-anchor="middle">r ≥ p(x3)/q(x3)</text>
+
+  <rect class="cell" x="490" y="316" width="140" height="46" rx="3"/>
+  <text class="content" x="560" y="338" text-anchor="middle">sample ~ residual</text>
+  <text class="small"   x="560" y="354" text-anchor="middle">(p - q)+ / ||·||₁</text>
+
+  <rect class="cell" x="650" y="316" width="180" height="46" rx="3"/>
+  <text class="content" x="740" y="338" text-anchor="middle">stop — emit x1, x2, y</text>
+  <text class="small"   x="740" y="354" text-anchor="middle">distribution still = p</text>
+
+  <path d="M 170 339 L 190 339" stroke="#1a1a1a" stroke-width="1.5" fill="none" marker-end="url(#arrow)"/>
+  <path d="M 310 339 L 330 339" stroke="#1a1a1a" stroke-width="1.5" fill="none" marker-end="url(#arrow)"/>
+  <path d="M 470 339 L 490 339" stroke="#c0392b" stroke-width="1.5" fill="none" marker-end="url(#red-arrow)"/>
+  <path d="M 630 339 L 650 339" stroke="#1a1a1a" stroke-width="1.5" fill="none" marker-end="url(#arrow)"/>
+
+  <rect class="cool" x="50"  y="390" width="260" height="60" rx="3"/>
+  <text class="label" x="180" y="414" text-anchor="middle">alternate path: all K accepted</text>
+  <text class="content" x="180" y="434" text-anchor="middle">+ bonus token ~ p(· | x1..xK)</text>
+  <text class="small"   x="180" y="450" text-anchor="middle">K + 1 tokens produced</text>
+
+  <rect class="box" x="340" y="390" width="490" height="60" rx="3"/>
+  <text class="label" x="585" y="412" text-anchor="middle">expected tokens per target forward</text>
+  <text class="content" x="585" y="432" text-anchor="middle">E[tokens] = (1 − α^(K+1)) / (1 − α)</text>
+  <text class="small"   x="585" y="448" text-anchor="middle">α = 0.8, K = 4 → 3.36 tokens per verify</text>
+
+  <rect class="box" x="30" y="485" width="820" height="40" rx="4"/>
+  <text class="caption" x="440" y="510" text-anchor="middle">EAGLE-3 pushes this to ~4.65 tokens / verify by feeding multi-layer target features into a tree drafter</text>
+</svg>

--- a/phases/10-llms-from-scratch/15-speculative-decoding-eagle/code/main.py
+++ b/phases/10-llms-from-scratch/15-speculative-decoding-eagle/code/main.py
@@ -1,0 +1,192 @@
+import math
+import random
+import sys
+
+VOCAB = 16
+PREFIX_LEN = 6
+SEED = 2026
+
+
+def make_distribution(rng, concentration=1.5):
+    weights = [rng.random() ** concentration for _ in range(VOCAB)]
+    z = sum(weights)
+    return [w / z for w in weights]
+
+
+def make_target(rng):
+    return {tuple(rng.choices(range(VOCAB), k=PREFIX_LEN)): make_distribution(rng) for _ in range(32)}
+
+
+def default_dist(rng):
+    return make_distribution(rng)
+
+
+def target_prob(target_dists, default, prefix):
+    key = tuple(prefix[-PREFIX_LEN:]) if len(prefix) >= PREFIX_LEN else tuple(prefix + [0] * (PREFIX_LEN - len(prefix)))
+    return target_dists.get(key, default)
+
+
+def perturb(dist, noise, rng):
+    n = len(dist)
+    perturbed = [max(1e-9, d + noise * (rng.random() - 0.5)) for d in dist]
+    z = sum(perturbed)
+    return [p / z for p in perturbed]
+
+
+def draft_prob(target_dists, draft_noise, default_draft, prefix, rng_stream):
+    p = target_prob(target_dists, default_draft, prefix)
+    return perturb(p, draft_noise, rng_stream)
+
+
+def sample_from(dist, rng):
+    r = rng.random()
+    acc = 0.0
+    for i, w in enumerate(dist):
+        acc += w
+        if r < acc:
+            return i
+    return len(dist) - 1
+
+
+def plain_target_step(target_dists, default, prefix, rng):
+    p = target_prob(target_dists, default, prefix)
+    return sample_from(p, rng)
+
+
+def speculative_step(target_dists, default_target, default_draft, prefix, K, draft_noise, rng, draft_rng):
+    drafted = []
+    q_at = []
+    current = list(prefix)
+    for _ in range(K):
+        q = draft_prob(target_dists, draft_noise, default_draft, current, draft_rng)
+        tok = sample_from(q, draft_rng)
+        drafted.append(tok)
+        q_at.append(q)
+        current.append(tok)
+
+    emitted = []
+    accepts = 0
+    for k, tok in enumerate(drafted):
+        p_k = target_prob(target_dists, default_target, prefix + emitted)
+        r = rng.random()
+        ratio = p_k[tok] / max(q_at[k][tok], 1e-12)
+        if r < min(1.0, ratio):
+            emitted.append(tok)
+            accepts += 1
+            continue
+        residual = [max(p_k[i] - q_at[k][i], 0.0) for i in range(VOCAB)]
+        total = sum(residual)
+        if total <= 0:
+            emitted.append(sample_from(p_k, rng))
+        else:
+            emitted.append(sample_from([r_ / total for r_ in residual], rng))
+        return emitted, accepts, k
+
+    p_bonus = target_prob(target_dists, default_target, prefix + emitted)
+    emitted.append(sample_from(p_bonus, rng))
+    return emitted, accepts, K
+
+
+def total_variation(p, q):
+    return 0.5 * sum(abs(a - b) for a, b in zip(p, q))
+
+
+def empirical_distribution(samples):
+    counts = [0] * VOCAB
+    for s in samples:
+        counts[s] += 1
+    n = sum(counts)
+    return [c / n for c in counts]
+
+
+def expected_tokens_per_verify(alpha, K):
+    if abs(alpha - 1.0) < 1e-9:
+        return K + 1
+    return (1.0 - alpha ** (K + 1)) / (1.0 - alpha)
+
+
+def run_exactness_test(n_trials, target_dists, default_target, default_draft, prefix, K, draft_noise):
+    rng_spec = random.Random(SEED + 1)
+    rng_draft = random.Random(SEED + 2)
+    rng_plain = random.Random(SEED + 3)
+
+    plain_samples = [plain_target_step(target_dists, default_target, prefix, rng_plain) for _ in range(n_trials)]
+
+    spec_samples = []
+    total_accepts = 0
+    total_drafted = 0
+    for _ in range(n_trials):
+        emitted, accepts, stopped_at = speculative_step(
+            target_dists, default_target, default_draft, prefix, K, draft_noise, rng_spec, rng_draft
+        )
+        spec_samples.append(emitted[0])
+        total_accepts += accepts
+        total_drafted += max(stopped_at, 1)
+
+    p_plain = empirical_distribution(plain_samples)
+    p_spec = empirical_distribution(spec_samples)
+    alpha = total_accepts / total_drafted if total_drafted else 0.0
+    return total_variation(p_plain, p_spec), alpha, p_plain, p_spec
+
+
+def print_header(text):
+    print("=" * 60)
+    print(text)
+    print("=" * 60)
+
+
+def print_speedup_surface():
+    print_header("Expected tokens per verify: (1 - alpha^(K+1)) / (1 - alpha)")
+    print(f"{'alpha':>6}  " + "  ".join(f"K={K:<2}" for K in range(1, 9)))
+    for alpha in (0.5, 0.6, 0.7, 0.8, 0.9):
+        row = f"{alpha:>6.2f}  " + "  ".join(f"{expected_tokens_per_verify(alpha, K):>4.2f}" for K in range(1, 9))
+        print(row)
+
+
+def print_distribution_pair(label, p_plain, p_spec):
+    print(f"{label}")
+    print(f"{'token':>5}  {'plain':>8}  {'spec':>8}  {'|diff|':>8}")
+    for i in range(VOCAB):
+        print(f"{i:>5}  {p_plain[i]:>8.4f}  {p_spec[i]:>8.4f}  {abs(p_plain[i] - p_spec[i]):>8.4f}")
+
+
+def main():
+    rng = random.Random(SEED)
+    target_dists = make_target(rng)
+    default_target = default_dist(rng)
+    default_draft = default_dist(rng)
+
+    prefix = [rng.randrange(VOCAB) for _ in range(PREFIX_LEN)]
+    K = 4
+    draft_noise = 0.15
+    n_trials = 200_000
+
+    print_header("Leviathan 2023 speculative decoding: toy exactness check")
+    print(f"vocab size         : {VOCAB}")
+    print(f"prefix             : {prefix}")
+    print(f"draft length K     : {K}")
+    print(f"draft noise (|p-q|): {draft_noise}")
+    print(f"trials             : {n_trials}")
+
+    tv, alpha, p_plain, p_spec = run_exactness_test(
+        n_trials, target_dists, default_target, default_draft, prefix, K, draft_noise
+    )
+
+    print_distribution_pair("\nEmpirical marginal at the first emitted position:", p_plain, p_spec)
+    print(f"\ntotal variation (plain vs speculative): TV = {tv:.4f}")
+    print(f"empirical acceptance rate alpha         : {alpha:.4f}")
+    print(f"predicted tokens per verify @ K={K}       : {expected_tokens_per_verify(alpha, K):.4f}")
+
+    print()
+    print_speedup_surface()
+
+    tv_tol = 0.01
+    if tv < tv_tol:
+        print(f"\nPASS  TV {tv:.4f} < {tv_tol} — speculative output matches target distribution within tolerance.")
+        return 0
+    print(f"\nFAIL  TV {tv:.4f} >= {tv_tol}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/phases/10-llms-from-scratch/15-speculative-decoding-eagle/docs/en.md
+++ b/phases/10-llms-from-scratch/15-speculative-decoding-eagle/docs/en.md
@@ -1,0 +1,187 @@
+# Speculative Decoding and EAGLE-3
+
+> Decode is memory-bound. A 70B model spends most of a forward pass waiting for weights to stream out of HBM, producing one token at the end of a ~70 ms wait. Leviathan, Kalai, Matias (2023) showed you can let a tiny draft model guess the next K tokens, verify them in one big-model forward pass, and accept the longest correct prefix — with a provably exact equivalence to sampling from the target. EAGLE-3 (Li et al., NeurIPS 2025) pushes mean accepted tokens per verify to ~4.65 on Spec-Bench, roughly a 2.4× wall-clock speedup on matched output distribution.
+
+**Type:** Build
+**Languages:** Python (stdlib only)
+**Prerequisites:** Phase 10 Lesson 12 (Inference Optimization), Phase 10 Lesson 04 (Pre-training Mini-GPT)
+**Time:** ~75 minutes
+
+## The Problem
+
+Autoregressive decoding is the cost center of production LLM serving. Every token is one forward pass, and the forward pass is dominated by reading the full weight matrix out of HBM — not by arithmetic. On an H100 decoding a 70B BF16 model, ~280 GB of weights have to stream past the compute units to produce one token. At 3.35 TB/s memory bandwidth that is about 83 ms floor, compute-independent.
+
+You cannot shrink the model without changing its distribution. You cannot make memory faster. The only remaining knob is the ratio of tokens produced per forward pass.
+
+Speculative decoding exploits a specific inefficiency: the decode pass is *memory-bound*, so once you have streamed the weights past the compute units you have significant idle arithmetic capacity. A tiny draft model that guesses 4 tokens costs almost nothing compared to one target forward pass. If most of its guesses are right, you amortize one weight read across multiple tokens — and you do it without touching the target's output distribution.
+
+The diagram at `assets/speculative-decoding.svg` shows the full pipeline: the draft's K-step chain, the target's single verify pass, the left-to-right accept/reject loop, the residual-sample on first rejection, and the bonus token on full acceptance. Keep it open while reading the next section.
+
+## The Concept
+
+### The two-model setup
+
+- **Target** M_p: the slow high-quality model. Distribution p. This is what we want samples from.
+- **Draft** M_q: a small fast predictor. Distribution q. Typically 5–30× smaller than the target.
+
+Per speculative step, at position t:
+
+1. The draft generates K tokens autoregressively: x_1, …, x_K ~ q.
+2. The target runs **one forward pass** over the K+1 positions and returns p(· | prefix + x_1…x_k) for k = 0…K.
+3. An accept/reject rule consumes the drafted tokens left to right, accepting the longest matching prefix and either resampling from a corrected distribution on the first rejection or taking one bonus target-sampled token if all K are accepted.
+
+If the draft matches the target perfectly, you produce K+1 tokens per target forward. If the draft is wrong at position 1, you still produce exactly 1 token. You never produce less than one token per verify.
+
+### The exactness rule (Leviathan et al., 2023)
+
+The trick is a modified rejection-sampling test that preserves p exactly. For each drafted token x_k with draft probability q(x_k) and target probability p(x_k):
+
+```
+r ~ Uniform(0, 1)
+if r < p(x_k) / q(x_k):
+    accept x_k
+else:
+    sample replacement ~ residual(x) = max(p(x) - q(x), 0) / ||max(p - q, 0)||_1
+    stop
+```
+
+When p = q the accept probability is 1. When p ≠ q the rejected sample comes from the positive-part residual, which is exactly the mass p has that q failed to cover. Combining the two branches gives you a sample drawn from p by construction — no bias, no correction factor, no temperature hack.
+
+The greedy specialization is simpler: accept if and only if `argmax(p) == x_k`, otherwise emit `argmax(p)` and stop.
+
+### Expected speedup
+
+If the per-token accept probability is α (averaged over positions), the expected number of tokens per target forward pass is:
+
+```
+E[tokens per verify] = (1 - α^{K+1}) / (1 - α)
+```
+
+At α = 0.8 and K = 4 that is 3.36 tokens per target forward. A plain decode produces 1 token per target forward, so the ceiling speedup is 3.36× — minus the cost of the K draft steps, which is negligible when cost(target) ≫ K · cost(draft).
+
+The only real parameter is α. A good draft is everything.
+
+Example values at K = 4:
+
+| α    | E[tokens per verify] | Ceiling speedup |
+|------|----------------------|-----------------|
+| 0.50 | 1.94                 | 1.94×           |
+| 0.70 | 2.83                 | 2.83×           |
+| 0.80 | 3.36                 | 3.36×           |
+| 0.90 | 4.10                 | 4.10×           |
+
+Raising K past 6–8 rarely helps: the `α^{K+1}` term compounds geometrically, and each extra draft step adds a serial latency beat you cannot hide.
+
+### Training the draft: distillation
+
+A random small model makes a bad draft. The standard recipe is to distill the draft against the target's output distribution:
+
+1. Pick a small draft architecture sharing the target's tokenizer.
+2. Run the target over a large corpus, store its next-token distributions.
+3. Train the draft with KL divergence against those stored distributions, not against ground-truth labels.
+
+Production acceptance rates land in 0.6–0.8 for chat, 0.7–0.85 for code, and fall sharply for creative writing at high temperature.
+
+### EAGLE: feature reuse and tree drafting
+
+Li, Wei, Zhang, Zhang (2024, "EAGLE") made two observations. First, a separate draft model re-derives features the target already computed during its last verify — the target's final hidden state is a compressed forecast of the next token and can be fed directly into the draft. Second, a linear chain of K draft tokens throws away cheap parallelism: the draft could output a *tree* of candidates, and the target's single verify pass can check all branches in parallel using a tree-shaped attention mask, then accept the longest correct path.
+
+EAGLE-1 makes the draft a single transformer decoder layer whose input is the target's last hidden state plus the last emitted token. EAGLE-2 (EMNLP 2024) adds a dynamic tree that grows wider where the draft is uncertain and stays narrow where it is confident.
+
+EAGLE-3 (NeurIPS 2025, arXiv:2503.01840) replaces feature prediction with direct token prediction and fuses features from multiple layers of the target — which removes the information bottleneck that limited EAGLE-1/2 when training data scaled up. Spec-Bench reports mean accepted tokens per step ≈ 4.65 with EAGLE-3 and roughly a 2.4× wall-clock speedup at batch size 1.
+
+### Tree attention verification
+
+When the draft emits a tree, the target verifies every node in a single forward pass by switching its attention mask from "strictly lower-triangular over the line" to "strictly lower-triangular over the tree topology". Each node attends only to its ancestors. Verify cost grows in the number of tree nodes, not the depth, and the longest correctly-predicted root-to-leaf path is returned.
+
+```
+        root
+       /    \
+      a      b
+     / \    / \
+    c  d   e   f
+```
+
+If `a,b` are competing first candidates and `c,d,e,f` are continuations, all six positions are verified in one forward pass; the output is the longest prefix along any accepted path.
+
+### When it wins, when it doesn't
+
+**Wins**: code, structured outputs, common chat — high α, small vocab mass where the draft and target disagree. Memory-bound batch sizes (1–8) where the target has idle FLOPs.
+
+**Loses**: creative writing at temperature ≥ 1.0, where α collapses toward 1/|vocab| and the draft overhead dominates. High-concurrency batched serving where continuous batching has already filled the FLOPs.
+
+Production shops report 2–3× on chat, 3–5× on code, near-zero on creative writing.
+
+## Build It
+
+The shipped `code/main.py` is stdlib-only and operates on **toy discrete distributions** (vocab size 16) so the math is visible without a tokenizer or a GPU. It implements:
+
+1. A `target` distribution and a perturbed `draft` distribution on a shared vocab, both built from fixed seeds for reproducibility.
+2. `speculative_step(target_dists, draft_model, prefix, K)` — one round of Leviathan sampling. Draft proposes K tokens; target gives p at each drafted position; accept/reject loop runs left-to-right; residual is computed on rejection; bonus sample is taken on full acceptance.
+3. A distribution-equivalence test: run speculative decoding N=200k times and plain target sampling N=200k times, bucket the output token at position 0, and assert total-variation distance < 0.01. This is the empirical exactness check the 2023 paper is famous for.
+4. A closed-form α-vs-speedup report that walks α ∈ {0.5, 0.7, 0.9} × K ∈ {1…8} and prints the expected tokens-per-verify surface.
+5. A per-position acceptance-rate counter so you can see α drift as the prefix grows.
+
+Run:
+
+```
+python3 code/main.py
+```
+
+Expected output: an acceptance-rate table, a TV-distance line (`TV = 0.0034`-ish on the default seed), the speedup surface, and a `PASS` banner. The whole run finishes in under a second.
+
+## Use It
+
+- **vLLM** exposes speculative decoding as first-class config. Pass `--speculative-model <draft>` and `--num-speculative-tokens K`; add `--speculative-draft-tensor-parallel-size` when the draft is GPU-resident. EAGLE-3 is supported via the `--speculative-method eagle3` branch in v0.7+.
+- **SGLang** ships EAGLE-2 and EAGLE-3 support and composes them with RadixAttention prefix caching.
+- **NVIDIA TensorRT-LLM** ships Medusa heads and EAGLE trees as two distinct serving modes with tuned kernels for tree-structured attention.
+- **Reference drafts**: Llama 3 family ships a 1B draft that is compatible with the 8B/70B/405B checkpoints; Qwen3 ships a 0.6B draft for the 32B target.
+- **Medusa** (Cai et al., 2024) is the deployable alternative when you cannot afford a separate draft: K prediction heads on the target itself, trained via self-distillation. Simpler to deploy, slightly lower α than EAGLE.
+- **Lookahead decoding** (Fu et al., 2024) is draft-free — it re-uses n-grams generated by the target's own prior Jacobi iterations and verifies them. Works best when the output has repeated phrases (code, structured outputs).
+
+## Ship It
+
+This lesson produces `outputs/skill-spec-decoder.md` — a skill that takes a workload profile (target model size, task mix, temperature, batch size, serving engine) and recommends a speculative-decoding configuration (draft model, K, tree width, temperature policy, and whether to fall back to plain decode).
+
+## Exercises
+
+1. **Exactness under mismatch.** Deliberately mismatch the draft (e.g., scramble its probabilities) and re-run the TV-distance test. Verify that the output still matches plain target sampling within the empirical tolerance. This is what the rejection rule buys you.
+
+2. **Find the optimal K.** For α ∈ {0.5, 0.6, 0.7, 0.8, 0.9}, find the K that maximizes `(1 - α^{K+1}) / (1 - α) / (K · cost_draft + cost_target)` assuming `cost_draft / cost_target ∈ {0.05, 0.1, 0.2}`. Plot.
+
+3. **Tree vs chain.** Extend `main.py` so the draft emits top-2 branches at each of D depths. Build the tree attention mask as an adjacency matrix; verify that the `target` accepts the longest correct path and that the output distribution is still exactly p.
+
+4. **Temperature collapse.** Sweep temperature from 0.1 to 2.0 in the draft and target. Measure α at each setting. Reproduce the collapse that motivates "do not speculate at T ≥ 1.0 for creative writing".
+
+5. **Draft training stub.** On the toy distribution, fit the draft by minimizing KL(target || draft) with gradient descent over a softmax parameterization. Show α rises as KL falls.
+
+## Key Terms
+
+| Term | What people say | What it actually means |
+|------|----------------|------------------------|
+| Target model | "The big model" | The slow high-quality model; samples from p |
+| Draft model | "The speculator" | The small fast predictor; samples from q; 5–30× smaller |
+| K (draft length) | "Lookahead" | Number of speculated tokens per verify pass |
+| α (acceptance rate) | "Hit rate" | Per-token probability the draft's proposal is accepted |
+| Exact rejection rule | "The accept test" | r < p/q compare that keeps the overall sample distributed as p |
+| Residual distribution | "Corrected p − q" | max(p − q, 0) / ||max(p − q, 0)||₁ — sampled on rejection |
+| Bonus token | "Free sample" | Extra token drawn from p after all K proposals accepted |
+| Tree drafting | "Branching speculation" | Draft outputs a tree of candidates verified in one pass |
+| Tree attention mask | "Topological mask" | Causal mask encoding tree topology; each node attends only to ancestors |
+| Medusa heads | "Parallel heads" | K extra prediction heads on the target; no separate draft |
+| EAGLE feature reuse | "Hidden-state draft" | Draft input is the target's last hidden state, not raw tokens |
+| Multi-layer feature fusion | "EAGLE-3 trick" | Draft conditions on features from several target layers, not just the top |
+| Direct token prediction | "EAGLE-3 head" | EAGLE-3's draft predicts tokens, not features, fixing the scaling cliff |
+
+## Further Reading
+
+- [Leviathan, Kalai, Matias — "Fast Inference from Transformers via Speculative Decoding" (ICML 2023)](https://arxiv.org/abs/2211.17192) — the exact rejection rule and the speedup analysis.
+- [Chen, Borgeaud, Irving et al. — "Accelerating Large Language Model Decoding with Speculative Sampling" (DeepMind 2023)](https://arxiv.org/abs/2302.01318) — the concurrent derivation from DeepMind.
+- [Cai, Li, Geng, Peng, Lee, Chen, Dao — "Medusa" (2024)](https://arxiv.org/abs/2401.10774) — parallel-heads alternative to a draft model.
+- [Li, Wei, Zhang, Zhang — "EAGLE: Speculative Sampling Requires Rethinking Feature Uncertainty" (ICML 2024)](https://arxiv.org/abs/2401.15077) — feature reuse plus tree drafting.
+- [Li, Wei, Zhang, Zhang — "EAGLE-2: Faster Inference of Language Models with Dynamic Draft Trees" (EMNLP 2024)](https://arxiv.org/abs/2406.16858) — dynamic tree topology.
+- [Li, Wei, Zhang, Zhang — "EAGLE-3: Scaling up Inference Acceleration via Training-Time Test" (NeurIPS 2025)](https://arxiv.org/abs/2503.01840) — direct token prediction plus multi-layer feature fusion.
+- [Fu, Bailis, Stoica, Zhang — "Break the Sequential Dependency of LLM Inference Using Lookahead Decoding" (ICML 2024)](https://arxiv.org/abs/2402.02057) — Jacobi/lookahead, the draft-free alternative.
+- [Rodionov et al. — "Hogwild! Inference: Parallel LLM Generation via Concurrent Attention" (NeurIPS 2025 Spotlight)](https://arxiv.org/abs/2504.06261) — a parallel-workers alternative to speculative decoding.
+- [Kumar, Dao, May — "Speculative Speculative Decoding" (ICLR 2026)](https://arxiv.org/abs/2603.03251) — overlapping draft speculation with verification itself.
+- [Oliaro et al. — "SuffixDecoding" (NeurIPS 2025 Spotlight)](https://arxiv.org/abs/2411.04975) — suffix-tree drafting that hybridizes with EAGLE-3 for 2.5× on Spec-Bench.

--- a/phases/10-llms-from-scratch/15-speculative-decoding-eagle/outputs/skill-spec-decoder.md
+++ b/phases/10-llms-from-scratch/15-speculative-decoding-eagle/outputs/skill-spec-decoder.md
@@ -1,0 +1,36 @@
+---
+name: skill-spec-decoder
+description: Configure speculative decoding (draft model, K, tree topology, temperature policy) for a given LLM serving workload and engine.
+version: 1.0.0
+phase: 10
+lesson: 15
+tags: [speculative-decoding, eagle, eagle-3, medusa, lookahead, vllm, sglang, tensorrt-llm, inference]
+---
+
+# Speculative Decoding Configurator
+
+Given a serving workload (target model family and size, primary task mix, peak QPS, target p50/p99 latency, batch size envelope, serving engine) and the available draft checkpoints on disk, recommend a complete speculative-decoding configuration or explicitly recommend plain decode when speculation cannot win.
+
+Produce a numbered recommendation that covers:
+
+1. **Go / no-go.** State whether speculative decoding should be enabled at all. Reject speculation when any of the following hold: (a) sampling temperature is >= 1.0 for the dominant task, (b) per-GPU concurrent batch size is already saturating compute (ops:byte ratio > 200), (c) the target model is <= 3B parameters and no draft is measurably faster, (d) the workload is dominated by creative-writing tasks. State the single deciding factor in one sentence.
+
+2. **Draft choice with α estimate.** Name an exact draft checkpoint (revision included) that shares the target's tokenizer. Estimate the expected per-token acceptance rate α for the primary task using task-specific priors: code 0.75-0.85, instruction-following chat 0.65-0.80, retrieval-augmented answers 0.70-0.82, summarization 0.60-0.75, creative writing 0.30-0.55. When no distilled draft exists for the target, prefer EAGLE-3 or Medusa-2 over an untuned small model.
+
+3. **K and tree topology.** Pick draft length K and tree shape. Use the closed-form `E[tokens per verify] = (1 - α^(K+1)) / (1 - α)` to find K*. For chain drafts K* typically lands at 4-6 for α in [0.7, 0.8] and at 2-3 for α <= 0.6. For EAGLE-style trees, specify depth and per-depth branching (e.g., depth 5 with branching 4,4,2,2,1) and justify against verify-pass budget. Reject any configuration where K > 8 unless α > 0.9 is measured.
+
+4. **Engine flags.** Produce the concrete launch flags for the chosen engine — one of vLLM (`--speculative-model`, `--num-speculative-tokens`, `--speculative-method {draft|eagle|eagle3|medusa}`), SGLang (`--speculative-algorithm`, `--speculative-num-steps`, `--speculative-draft-model-path`), or TensorRT-LLM (engine-build-time `--speculative_decoding_mode`). If the engine does not support the chosen algorithm, escalate to the next best supported algorithm and note the α loss.
+
+5. **Runtime guards.** Specify three runtime guards: (a) a per-request temperature cap above which the request bypasses speculation and falls back to plain decode; (b) a moving-average α floor (e.g., α < 0.40 over the last 512 tokens) that trips automatic fallback for the current session; (c) a batch-size ceiling above which the engine disables speculation because continuous batching has absorbed the idle FLOPs the speculator was exploiting.
+
+## Refusal rules
+
+Refuse and return `NO_SPEC_CONFIG` with a one-line reason when any of the following hold:
+
+- The user has not named a concrete target model revision (e.g., "Llama 3 70B Instruct v3.1"), only a family.
+- The user requests a draft that does not share the target's tokenizer.
+- The user asks to speculate across model providers or to use a target API that does not expose logprobs.
+- The user requests "lossy" or "approximate" speculation — speculative decoding in this lesson is exact by construction; anything lossy should be a quantization or distillation decision, not a speculative-decoding decision.
+- The user asks you to speculate without naming a serving engine.
+
+Output: a one-page configuration block with numbered sections above, the exact launch command, and a "reconsider if..." paragraph naming the single workload change (temperature shift, batch-size spike, task-mix drift) that would flip the go/no-go decision.


### PR DESCRIPTION
## Summary

Adds Phase 10 Lesson 15 — Speculative Decoding and EAGLE-3 — under `phases/10-llms-from-scratch/15-speculative-decoding-eagle/`.

Covers:
- Leviathan/Kalai/Matias (ICML 2023) modified rejection-sampling rule and why it preserves the target distribution exactly.
- `E[tokens per verify] = (1 - alpha^(K+1)) / (1 - alpha)` speedup analysis with a worked table.
- EAGLE progression: feature reuse + tree drafting (EAGLE-1, ICML 2024), dynamic trees (EAGLE-2, EMNLP 2024), direct token prediction + multi-layer feature fusion (EAGLE-3, NeurIPS 2025 at 4.65 mean accepted tokens/step).
- Contextual pointers to Medusa (Cai et al. 2024), Lookahead Decoding (Fu et al. ICML 2024), Hogwild! Inference (NeurIPS 2025 Spotlight), and Speculative Speculative Decoding (ICLR 2026).

## Artifacts

- `docs/en.md` — 187-line lesson (Problem / Concept / Build It / Use It / Ship It / Exercises / Key Terms / Further Reading).
- `code/main.py` — stdlib-only runnable demo (192 lines). Toy draft + target discrete distributions on vocab=16; implements left-to-right accept/reject with residual sampling and bonus-token path; runs 200k trials and asserts TV < 0.01 against plain target sampling; prints expected-tokens-per-verify surface over alpha x K.
- `assets/speculative-decoding.svg` — editorial-style SVG (viewBox 880x540) using the Phase 5 class system (.box / .hot / .cool / .cell / .label / .content / .caption / .title). Three vertical bands: draft chain, target verify pass, accept-reject-or-residual decision row with bonus-token path.
- `outputs/skill-spec-decoder.md` — frontmatter skill with 5 numbered requirements (go/no-go, draft + alpha, K + tree topology, engine flags, runtime guards) and 5 refusal rules.
- `notebook/.gitkeep` — placeholder.

## Test plan

- [x] `python3 code/main.py` exits 0, prints `PASS TV 0.0036 < 0.01`.
- [x] `xmllint --noout assets/*.svg` clean (verified via Python 3.11 ElementTree - system xmllint blocked by sandbox).
- [x] ROADMAP.md / README.md / site/data.js not touched - consolidation is a separate PR.
