### PR TITLE
feat(phase-10/18): multi-token prediction lesson

### DIFF
--- a/phases/10-llms-from-scratch/18-multi-token-prediction/assets/multi-token-prediction.svg
+++ b/phases/10-llms-from-scratch/18-multi-token-prediction/assets/multi-token-prediction.svg
@@ -1,0 +1,90 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 560" font-family="Georgia, 'Times New Roman', serif">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#1a1a1a"/>
+    </marker>
+    <marker id="arrow-accent" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#2e7d32"/>
+    </marker>
+    <style>
+      .box { fill: #faf6ef; stroke: #1a1a1a; stroke-width: 1.5; }
+      .trunk { fill: #fff1d6; stroke: #c0392b; stroke-width: 1.5; }
+      .head { fill: #e6f4ea; stroke: #2e7d32; stroke-width: 1.5; }
+      .seq { fill: #e3ecff; stroke: #1d4ed8; stroke-width: 1.5; }
+      .label { font-size: 13px; font-weight: 600; fill: #1a1a1a; }
+      .step { font-size: 12px; font-family: 'Menlo', monospace; fill: #222; }
+      .small { font-size: 10px; font-family: 'Menlo', monospace; fill: #555; }
+      .caption { font-size: 11px; fill: #555; font-style: italic; }
+      .title { font-size: 16px; font-weight: 700; fill: #1a1a1a; }
+      .section { font-size: 13px; font-weight: 700; fill: #1a1a1a; }
+    </style>
+  </defs>
+
+  <text x="480" y="28" text-anchor="middle" class="title">multi-token prediction — two head topologies</text>
+
+  <!-- PARALLEL variant (Gloeckle et al., 2024) -->
+  <text x="40" y="62" class="section">Parallel heads — Gloeckle et al. 2024</text>
+  <rect x="40" y="75" width="880" height="180" class="box"/>
+
+  <!-- shared trunk -->
+  <rect x="90" y="140" width="150" height="50" class="trunk"/>
+  <text x="165" y="163" text-anchor="middle" class="step">shared trunk</text>
+  <text x="165" y="180" text-anchor="middle" class="small">hidden h_t</text>
+
+  <!-- 3 parallel arrows -->
+  <line x1="240" y1="152" x2="400" y2="105" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <line x1="240" y1="165" x2="400" y2="165" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <line x1="240" y1="178" x2="400" y2="225" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <rect x="405" y="88" width="140" height="34" class="head"/>
+  <text x="475" y="109" text-anchor="middle" class="step">head 1 → x_{t+1}</text>
+  <rect x="405" y="148" width="140" height="34" class="head"/>
+  <text x="475" y="169" text-anchor="middle" class="step">head 2 → x_{t+2}</text>
+  <rect x="405" y="208" width="140" height="34" class="head"/>
+  <text x="475" y="229" text-anchor="middle" class="step">head 3 → x_{t+3}</text>
+
+  <text x="600" y="100" class="small">all heads read the same h_t</text>
+  <text x="600" y="118" class="small">draft tokens = argmax(head_i)</text>
+  <text x="600" y="146" class="small">training: sum cross-entropy over k targets</text>
+  <text x="600" y="164" class="small">inference: head 1 is the main next-token</text>
+  <text x="600" y="182" class="small">heads 2..k are speculative drafts</text>
+  <text x="600" y="212" class="small">cost: k tiny linear heads, no runtime change</text>
+  <text x="600" y="230" class="small">used in the 2024 Meta MTP paper, 7B code models</text>
+
+  <!-- SEQUENTIAL variant (DeepSeek-V3) -->
+  <text x="40" y="290" class="section">Sequential modules — DeepSeek-V3 2024</text>
+  <rect x="40" y="303" width="880" height="190" class="box"/>
+
+  <!-- main trunk -->
+  <rect x="70" y="370" width="130" height="50" class="trunk"/>
+  <text x="135" y="393" text-anchor="middle" class="step">main trunk</text>
+  <text x="135" y="410" text-anchor="middle" class="small">h_t → x_{t+1}</text>
+
+  <line x1="200" y1="395" x2="235" y2="395" stroke="#2e7d32" stroke-width="1.5" marker-end="url(#arrow-accent)"/>
+
+  <rect x="240" y="370" width="140" height="50" class="seq"/>
+  <text x="310" y="390" text-anchor="middle" class="step">MTP mod 1</text>
+  <text x="310" y="408" text-anchor="middle" class="small">h_t + emb(x_{t+1})</text>
+
+  <line x1="380" y1="395" x2="415" y2="395" stroke="#2e7d32" stroke-width="1.5" marker-end="url(#arrow-accent)"/>
+
+  <rect x="420" y="370" width="140" height="50" class="seq"/>
+  <text x="490" y="390" text-anchor="middle" class="step">MTP mod 2</text>
+  <text x="490" y="408" text-anchor="middle" class="small">prev + emb(x_{t+2})</text>
+
+  <line x1="560" y1="395" x2="595" y2="395" stroke="#2e7d32" stroke-width="1.5" marker-end="url(#arrow-accent)"/>
+
+  <rect x="600" y="370" width="140" height="50" class="seq"/>
+  <text x="670" y="390" text-anchor="middle" class="step">output → x_{t+3}</text>
+  <text x="670" y="408" text-anchor="middle" class="small">causal chain preserved</text>
+
+  <text x="70" y="445" class="small">each module conditions on the previous prediction</text>
+  <text x="70" y="463" class="small">higher per-depth acceptance than parallel heads (Hydra-style)</text>
+  <text x="70" y="481" class="small">671B trunk + 14B of MTP modules in DeepSeek-V3</text>
+
+  <!-- Acceptance rate strip -->
+  <rect x="40" y="510" width="880" height="40" class="box"/>
+  <text x="480" y="532" text-anchor="middle" class="caption">
+    effective tokens / step = 1 + P(accept depth 2) + P(accept depth 3) + ...  (caps at k)
+  </text>
+</svg>

--- a/phases/10-llms-from-scratch/18-multi-token-prediction/code/main.py
+++ b/phases/10-llms-from-scratch/18-multi-token-prediction/code/main.py
@@ -1,0 +1,200 @@
+"""Toy multi-token prediction (MTP) demo.
+
+Trains a char-level model with parallel MTP heads (k=1, 2, 3) on a short
+repeating corpus, then runs self-speculative decoding and measures
+acceptance rate of drafted tokens at depths 2 and 3.
+
+Stdlib only. The "transformer" is a trivial embedding + context-mix + linear
+classifier -- enough to learn the corpus, not a real LLM. The bookkeeping
+(MTP loss, draft generation, acceptance measurement) is faithful to
+Gloeckle et al. (2024).
+
+Run:  python main.py
+"""
+
+from __future__ import annotations
+
+import math
+import random
+
+
+CORPUS = (
+    "the quick brown fox jumps over the lazy dog. "
+    "a quick red fox runs past the sleepy dog. "
+    "the brown dog chases the quick fox. "
+    "the lazy fox jumps over the brown dog. "
+) * 6
+
+CONTEXT = 4
+HIDDEN = 20
+EPOCHS = 200
+LR = 0.05
+SEED = 7
+
+
+def build_vocab(text: str) -> tuple[list[str], dict[str, int]]:
+    chars = sorted(set(text))
+    return chars, {c: i for i, c in enumerate(chars)}
+
+
+def rand_matrix(rows: int, cols: int, scale: float, rng: random.Random) -> list[list[float]]:
+    return [[rng.gauss(0.0, scale) for _ in range(cols)] for _ in range(rows)]
+
+
+def softmax(logits: list[float]) -> list[float]:
+    m = max(logits)
+    exps = [math.exp(v - m) for v in logits]
+    s = sum(exps)
+    return [v / s for v in exps]
+
+
+def argmax(xs: list[float]) -> int:
+    best_i, best_v = 0, xs[0]
+    for i, v in enumerate(xs):
+        if v > best_v:
+            best_i, best_v = i, v
+    return best_i
+
+
+class MTPModel:
+    """Shared trunk + K parallel heads.
+
+    Trunk: embed(context tokens) -> mean-pool -> tanh(linear projection).
+    Head i: HIDDEN -> VOCAB logits, predicting token at offset i.
+    """
+
+    def __init__(self, vocab_size: int, k: int, rng: random.Random):
+        self.V, self.K, self.H, self.C = vocab_size, k, HIDDEN, CONTEXT
+        self.embed = rand_matrix(vocab_size, HIDDEN, 0.1, rng)
+        self.trunk = rand_matrix(HIDDEN, HIDDEN, 0.1, rng)
+        self.heads = [rand_matrix(HIDDEN, vocab_size, 0.1, rng) for _ in range(k)]
+
+    def hidden(self, ctx: list[int]) -> list[float]:
+        pooled = [0.0] * self.H
+        for t in ctx:
+            for j, v in enumerate(self.embed[t]):
+                pooled[j] += v
+        n = max(1, len(ctx))
+        pooled = [v / n for v in pooled]
+        out = [0.0] * self.H
+        for j in range(self.H):
+            s = sum(pooled[i] * self.trunk[i][j] for i in range(self.H))
+            out[j] = math.tanh(s)
+        return out
+
+    def head_logits(self, h: list[float], head_idx: int) -> list[float]:
+        W = self.heads[head_idx]
+        return [sum(h[i] * W[i][j] for i in range(self.H)) for j in range(self.V)]
+
+
+def train(model: MTPModel, ids: list[int]) -> None:
+    """Toy SGD: gradient descent on the head weights only.
+
+    The trunk is frozen after init -- the goal is to show the MTP bookkeeping
+    and measure head-quality as a function of depth, not to demonstrate
+    state-of-the-art representation learning.
+    """
+    N = len(ids)
+    for epoch in range(EPOCHS):
+        total = 0.0
+        steps = 0
+        for t in range(model.C, N - model.K):
+            ctx = ids[t - model.C:t]
+            h = model.hidden(ctx)
+            for i in range(1, model.K + 1):
+                target = ids[t + i - 1]
+                logits = model.head_logits(h, i - 1)
+                probs = softmax(logits)
+                total += -math.log(max(1e-12, probs[target]))
+                for v in range(model.V):
+                    grad = probs[v] - (1.0 if v == target else 0.0)
+                    col = model.heads[i - 1]
+                    for row in range(model.H):
+                        col[row][v] -= LR * grad * h[row]
+            steps += 1
+        if (epoch + 1) % 50 == 0:
+            print(f"  epoch {epoch + 1:3d}  avg NLL (summed over k={model.K} heads) = {total / max(1, steps):.3f}")
+
+
+def head_accuracy(model: MTPModel, ids: list[int]) -> list[float]:
+    correct = [0] * model.K
+    count = 0
+    for t in range(model.C, len(ids) - model.K):
+        ctx = ids[t - model.C:t]
+        h = model.hidden(ctx)
+        for i in range(1, model.K + 1):
+            pred = argmax(model.head_logits(h, i - 1))
+            if pred == ids[t + i - 1]:
+                correct[i - 1] += 1
+        count += 1
+    return [c / max(1, count) for c in correct]
+
+
+def self_speculative_decode(model: MTPModel, ids: list[int]) -> tuple[list[float], float]:
+    """Run head-1 autoregressively and verify heads 2..K drafts.
+
+    Returns acceptance rate per draft depth and effective tokens per step.
+    """
+    if model.K < 2:
+        return [], 1.0
+    accepted = [0] * (model.K - 1)
+    attempts = [0] * (model.K - 1)
+    total_tokens = 0
+    steps = 0
+    for t in range(model.C, len(ids) - model.K):
+        ctx = ids[t - model.C:t]
+        h = model.hidden(ctx)
+        tok_1 = argmax(model.head_logits(h, 0))
+        drafts = [argmax(model.head_logits(h, i)) for i in range(1, model.K)]
+        committed = [tok_1]
+        for i, d in enumerate(drafts):
+            new_ctx = (ctx + committed)[-model.C:]
+            verify_h = model.hidden(new_ctx)
+            verifier_pick = argmax(model.head_logits(verify_h, 0))
+            attempts[i] += 1
+            if d == verifier_pick:
+                accepted[i] += 1
+                committed.append(d)
+            else:
+                break
+        total_tokens += len(committed)
+        steps += 1
+    rates = [accepted[i] / max(1, attempts[i]) for i in range(model.K - 1)]
+    eff_tokens = total_tokens / max(1, steps)
+    return rates, eff_tokens
+
+
+def run_k(chars: list[str], ids: list[int], k: int) -> None:
+    print(f"\n--- MTP with k = {k} ---")
+    model = MTPModel(len(chars), k, random.Random(SEED + k))
+    train(model, ids)
+    for i, a in enumerate(head_accuracy(model, ids), start=1):
+        print(f"  head {i} top-1 accuracy (depth {i}) : {a:.3f}")
+    rates, eff = self_speculative_decode(model, ids)
+    for i, r in enumerate(rates, start=2):
+        print(f"  acceptance at depth {i}           : {r:.3f}")
+    print(f"  effective tokens / decode step   : {eff:.3f}  (ceiling = {float(k):.1f})")
+    print(f"  theoretical speedup              : {eff:.2f}x over next-token decode")
+
+
+def main() -> None:
+    print("=" * 60)
+    print("MULTI-TOKEN PREDICTION (TOY)")
+    print("=" * 60)
+    chars, stoi = build_vocab(CORPUS)
+    ids = [stoi[c] for c in CORPUS]
+    print(f"corpus length : {len(ids)} tokens")
+    print(f"vocab size    : {len(chars)}")
+    print(f"context window: {CONTEXT}")
+    print(f"hidden dim    : {HIDDEN}")
+    for k in (1, 2, 3):
+        run_k(chars, ids, k)
+    print()
+    print("The k=1 row is the next-token baseline.")
+    print("For k=2 and k=3 the acceptance rate at each deeper head")
+    print("is the probability that the draft matches head-1's argmax.")
+    print("Effective tokens/step is 1 + sum(acceptance rates), capped at k.")
+
+
+if __name__ == "__main__":
+    main()

--- a/phases/10-llms-from-scratch/18-multi-token-prediction/docs/en.md
+++ b/phases/10-llms-from-scratch/18-multi-token-prediction/docs/en.md
@@ -1,0 +1,192 @@
+# Multi-Token Prediction (MTP)
+
+> Next-token prediction trains on one label per position. Multi-token prediction trains on several future tokens at the same position, using independent or sequential heads on top of a shared trunk. You get denser training signal, mild downstream gains at scale, and a pre-built draft model you can reuse for self-speculative decoding at inference time.
+
+**Type:** Learn
+**Languages:** Python (stdlib)
+**Prerequisites:** Phase 10, Lessons 04, 12 (Pre-training mini-GPT, Inference optimization)
+**Time:** ~45 minutes
+
+## Learning Objectives
+
+- Describe the MTP training objective and contrast it with vanilla next-token prediction
+- Distinguish parallel MTP heads (Gloeckle et al., 2024) from DeepSeek-V3's sequential MTP modules
+- Explain why predicted tokens at depths k=2, 3, ... are used as speculative drafts at inference time
+- Measure acceptance rate of drafted tokens and reason about its effect on decoding speed
+
+## The Problem
+
+In Lesson 04 you trained a transformer with next-token cross-entropy. At position t the loss pulls the head toward token t+1. That is one scalar gradient signal per position. The rest of the context -- tokens t+2, t+3, which the model will have to generate next -- contribute nothing to the loss at t. You train on sequences of length 1024 and use roughly 1024 gradient signals per sequence. Half of the information in the batch is thrown away.
+
+At inference the same model decodes one token per forward pass. A 70B model that pushes 50 tokens per second is sitting on 95% of its compute budget idle -- decode is memory-bandwidth bound, not compute bound. The arithmetic units of an H100 process an entire batch of logits in the same wall-clock time as a single token. Something is wrong.
+
+Multi-token prediction attacks both problems with the same change. At each position you ask the model to predict the next k tokens, not just the next one, using k output heads on top of a shared trunk. Training signal becomes k times denser. At inference you skip the training loss and instead use the extra heads as a drop-in draft model for speculative decoding -- no second network, no distillation stage, no architecture surgery.
+
+## The Concept
+
+### The standard objective, rewritten
+
+For a sequence `x_1, ..., x_T` with trunk embedding `h_t` at position t, next-token prediction (NTP) minimizes:
+
+```
+L_NTP = - sum_t log P(x_{t+1} | h_t)
+```
+
+One head, one future token, one loss term per position.
+
+Multi-token prediction (MTP) replaces this with a sum over k future offsets:
+
+```
+L_MTP = - sum_t sum_{i=1..k} log P(x_{t+i} | h_t)
+```
+
+k heads, k future tokens, k loss terms per position. Same trunk, same compute until the final projection. The Gloeckle et al. (2024) paper calls the heads "independent" because each head predicts its depth directly from the shared hidden state `h_t`.
+
+### Parallel heads (Meta, 2024)
+
+Gloeckle et al. add k linear heads on the shared trunk. Each head i predicts `x_{t+i}` given `h_t`. During training all k heads fire at every position; during inference only head 1 is used for the autoregressive loop, and heads 2..k are optional drafts for speculative decoding.
+
+The trunk does extra work implicitly. To make head 3 accurate, the representation at position t has to encode enough about the next three tokens simultaneously. The model stops being myopic -- it learns to "plan" two or three tokens ahead because the loss forces it to.
+
+Empirically this buys:
+
+- No overhead in training time (the heads are tiny linear layers).
+- 12-17% absolute gain on HumanEval and MBPP for code models at 7B and above.
+- No improvement on small models (< ~1B parameters) -- capacity below threshold, the extra heads just smear gradients.
+
+### Sequential modules (DeepSeek-V3, 2024)
+
+DeepSeek-V3 kept the MTP objective but changed the head topology. Instead of k independent heads reading the same `h_t`, it chains k small transformer modules. Module i reads the output of module i-1 plus the embedding of the token it predicted, so the causal chain between predicted tokens is preserved.
+
+```
+depth 1: h_t         -> x_{t+1}
+depth 2: [h_t; emb(x_{t+1})] -> mini-transformer -> x_{t+2}
+depth 3: [prev;      emb(x_{t+2})] -> mini-transformer -> x_{t+3}
+```
+
+This is more parameters per MTP head (DeepSeek-V3's 14B of MTP weights sit on top of the 671B main model) and more compute per training step, but the heads' drafts are higher quality because each one conditions on the actual previous draft rather than predicting its depth cold. The distinction is the same one Hydra (Ankner et al., 2024) drew against Medusa: sequentially-dependent drafts beat sequentially-independent drafts by ~0.46 accepted tokens per step on average.
+
+At inference DeepSeek-V3 either discards the MTP modules (and runs as a normal 671B MoE) or keeps them for speculative decoding. The main model is unchanged either way.
+
+### Self-speculative decoding
+
+Vanilla speculative decoding (Leviathan et al., 2023; Chen et al., 2023) requires two models: a cheap draft model and an expensive verifier. You run k draft tokens cheap, then one verifier forward pass accepts a prefix of them in parallel. Net speedup is the acceptance rate times k, minus overhead.
+
+MTP makes the draft model free. The k-1 extra heads already predict `x_{t+2}, x_{t+3}, ...`. At decode step t:
+
+1. Run the trunk once. Head 1 emits `x_{t+1}`. Heads 2..k emit draft tokens `d_2, ..., d_k`.
+2. Feed `[x_{t+1}, d_2, ..., d_k]` into the next trunk forward pass as if they were real input.
+3. Head 1's logits at each of those positions tell you whether it agrees. Accept the longest prefix where the drafted token matches head 1's argmax (greedy) or passes the acceptance criterion (sampling).
+
+If all k-1 drafts are accepted you advanced k tokens in two forward passes instead of k. If none are accepted you get one token -- the baseline. The expected tokens per decode step is `1 + sum_{i=2..k} P(accept_i)`. This is the quantity the code in this lesson measures.
+
+### Acceptance rate, in practice
+
+The acceptance rate of draft i is the probability that `argmax(head_i) == argmax(head_1(h_{t+i-1}))`. It falls fast with depth:
+
+- Depth 2: ~0.5-0.7 for trained MTP heads. The head-2 prediction is conditioned on t's hidden state; it is a reasonable forecast for a single step.
+- Depth 3: ~0.3-0.5. Further out, accuracy drops; the trunk has to encode more distinct information.
+- Depth 4+: Diminishing. This is why Gloeckle et al. recommended k=4 and DeepSeek-V3 used a single MTP module (k=2).
+
+The acceptance rate times k is a rough cap on the speedup you can buy. Code models see higher acceptance than chat models because code has more local structure (closing brackets, keywords, repeated tokens).
+
+### What MTP is not
+
+- **Not parallel decoding.** You still run one trunk pass per accepted-block. MTP changes how much each pass contributes, not what a pass is.
+- **Not Medusa or Hydra.** Medusa (Cai et al., 2024) adds heads on top of a frozen backbone after pre-training. MTP heads are trained jointly with the trunk from scratch, so the trunk's representations are shaped by the MTP loss.
+- **Not lossless in the training-cost sense.** The Gloeckle et al. result is that MTP adds training signal without adding wall-clock time. That is because the heads are thin. DeepSeek-V3's sequential version does add meaningful training cost.
+
+### Tree attention vs linear draft
+
+When you have k-1 drafts you have a choice. The simple version -- the one in this lesson's code -- treats the drafts as a single candidate sequence and verifies them left to right. If draft 2 is wrong, drafts 3..k are discarded even if they would have been right after resampling.
+
+Medusa-style tree attention (Cai et al., 2024) instead expands each draft slot into the top-m candidates, arranging them as a tree of length (k-1) with branching factor m. One trunk forward pass verifies every root-to-leaf path at once using an attention mask that isolates each path. Expected accepted length grows because the verifier now picks the best path, not just a single guess. Tree attention and MTP are orthogonal: DeepSeek-V3's serving stack combines them.
+
+### Where the gain comes from
+
+Think about what the trunk has to learn to make head 3 accurate. The hidden state `h_t` must encode, simultaneously:
+
+- The identity of token t+1 (for head 1).
+- The identity of token t+2 (for head 2).
+- The identity of token t+3 (for head 3).
+
+Features that are useful for three offsets get reinforced. Features useful only for the immediate next token get weaker (relatively) because they show up in only one of three loss terms. The result is a representation that captures longer-range structure at the same cost. This is why MTP helps code more than chat -- code has tighter local dependencies (a `(` at position t strongly predicts `)` at t+k for some k), and the parallel-futures loss lets the trunk commit to them.
+
+### MTP as a side effect of curriculum
+
+An easy way to reason about MTP: it is next-token prediction with an auxiliary "look ahead" loss. The extra heads are regularizers. You do not ship them to production unless you want speculative decoding. The main model stays exactly the shape you would have trained anyway. This is the property that makes MTP a safe auxiliary objective: worst case, you ignore the heads at inference and you have your original model back, trained slightly better.
+
+## Build It
+
+The code in `code/main.py` is a toy end-to-end simulation. Concretely:
+
+1. A tiny character-level "transformer" (just an embedding table plus a single linear layer of context mixing -- enough to have non-trivial dynamics) trained on a short repeating corpus.
+2. An MTP training loop that instantiates k heads (k=2 and k=3), each projecting the shared hidden state to the vocabulary.
+3. An inference loop that uses head 1 autoregressively and heads 2..k as draft tokens, with greedy verification against head 1's next argmax.
+4. A metric that reports acceptance rate per depth and effective tokens per decode step.
+
+Stdlib only -- no torch, no numpy. The training is deliberately toy; the point is the MTP bookkeeping and the acceptance rate measurement, not SOTA perplexity.
+
+The core training step, stripped of plumbing, is three lines:
+
+```
+hidden = trunk(x_t)
+for i in range(1, k + 1):
+    logits_i = head_i(hidden)
+    loss += cross_entropy(logits_i, x_{t+i})
+```
+
+That is it. The trunk never knows there are multiple heads. Each head sees the same hidden state and is trained against a different future token. At inference you ignore heads 2..k unless you want drafts:
+
+```
+x_{t+1} = argmax(head_1(hidden))
+drafts  = [argmax(head_i(hidden)) for i in 2..k]
+```
+
+Then the verification step: feed `[x_{t+1}, drafts]` back through the trunk and check which drafts match head 1's new argmax at each position. The longest matching prefix is accepted in one shot.
+
+## Use It
+
+Run `python code/main.py`. The script prints the trained model's next-token accuracy, then acceptance rate at depth 2 and depth 3, then the effective tokens-per-step estimate. Try increasing the number of training steps and the context length to see acceptance rates rise as the trunk learns richer representations.
+
+Then vary k. With k=2 you buy at most 2x. With k=3 you buy at most 3x, but depth-3 acceptance is always lower than depth-2, so diminishing returns set in quickly.
+
+## Ship It
+
+This lesson produces `outputs/skill-mtp.md`. Given a production decoding setup (model family, serving stack, target workload), it recommends whether to train MTP heads, which variant (parallel vs sequential), and what acceptance-rate floor the resulting draft needs to hit before it beats vanilla speculative decoding with a separate draft model.
+
+## Exercises
+
+1. Compute the expected wall-clock speedup for k=4 with acceptance rates (0.6, 0.4, 0.25) at depths 2, 3, 4. Compare to the theoretical ceiling of 4x.
+
+2. Gloeckle et al. report no gain on models under ~1B parameters. Why would MTP hurt small models? Think about the gradient interference between heads at low capacity.
+
+3. Sequential MTP (DeepSeek-V3) gets higher acceptance than parallel MTP (Gloeckle). Why is that consistent with Hydra's result that sequentially-dependent draft heads beat sequentially-independent ones?
+
+4. Modify the code in `main.py` to add a fourth MTP head. Measure acceptance at depth 4 on the same corpus. Report whether the effective-tokens-per-step metric improved.
+
+5. A draft model trained from scratch (vanilla speculative decoding) typically has 0.5-0.7 acceptance on chat workloads. Where does the MTP self-speculation break even against it? Compare parameter cost of k-1 extra linear heads vs a 1B draft model.
+
+## Key Terms
+
+| Term | What people say | What it actually means |
+|------|----------------|----------------------|
+| MTP | "Predict multiple tokens" | Train the model with loss over the next k future tokens, not just the next one |
+| NTP | "Regular language modeling" | Standard next-token-prediction: one head, one future token, one loss per position |
+| Parallel MTP | "Gloeckle-style heads" | k independent linear heads reading the same shared hidden state |
+| Sequential MTP | "DeepSeek-V3 modules" | k chained mini-transformers where module i conditions on module i-1's prediction |
+| Depth (k) | "How far ahead we predict" | Index of the future token: depth 1 is next token, depth k is k tokens ahead |
+| Acceptance rate | "How often the draft is right" | P(drafted token at depth i matches the verifier's argmax at that position) |
+| Self-speculative decoding | "Free speculation" | Use the same model's own MTP heads as the draft; no external draft model needed |
+| Medusa | "Heads added after training" | Fine-tuned draft heads on a frozen backbone, k=4 typical |
+| Hydra | "Sequential Medusa" | Medusa with sequentially-dependent draft heads; higher acceptance |
+| Effective tokens/step | "Real-world speedup" | 1 + sum of per-depth acceptance rates; caps at k; what you actually measure on latency |
+
+## Further Reading
+
+- [Gloeckle et al., 2024 -- "Better & Faster Large Language Models via Multi-token Prediction"](https://arxiv.org/abs/2404.19737) -- the ICML 2024 paper that introduced parallel MTP heads with shared trunk
+- [DeepSeek-AI, 2024 -- "DeepSeek-V3 Technical Report"](https://arxiv.org/abs/2412.19437) -- Section 2.2 specifies the sequential MTP module variant used to train the 671B MoE
+- [Leviathan et al., 2023 -- "Fast Inference from Transformers via Speculative Decoding"](https://arxiv.org/abs/2211.17192) -- the original speculative decoding algorithm that MTP self-drafts plug into
+- [Chen et al., 2023 -- "Accelerating Large Language Model Decoding with Speculative Sampling"](https://arxiv.org/abs/2302.01318) -- the parallel DeepMind formulation of speculative decoding
+- [Cai et al., 2024 -- "Medusa: Simple LLM Inference Acceleration Framework with Multiple Decoding Heads"](https://arxiv.org/abs/2401.10774) -- post-hoc multi-head drafts on a frozen backbone
+- [Ankner et al., 2024 -- "Hydra: Sequentially-Dependent Draft Heads for Medusa Decoding"](https://arxiv.org/abs/2402.05109) -- sequentially-dependent draft heads, the idea DeepSeek-V3 adopted for sequential MTP

--- a/phases/10-llms-from-scratch/18-multi-token-prediction/outputs/skill-mtp.md
+++ b/phases/10-llms-from-scratch/18-multi-token-prediction/outputs/skill-mtp.md
@@ -1,0 +1,27 @@
+---
+name: multi-token-prediction
+description: Decide whether to add multi-token-prediction heads to a pre-training or post-training run, and whether to reuse them for self-speculative decoding at serving time.
+version: 1.0.0
+phase: 10
+lesson: 18
+tags: [mtp, multi-token-prediction, speculative-decoding, self-speculative, pre-training, deepseek-v3, gloeckle]
+---
+
+Given a model training plan (architecture family, parameter count, target domain, data volume, compute budget) and a serving plan (hardware, batch size, latency SLO, existing draft-model setup), recommend whether to train multi-token-prediction (MTP) heads and, if yes, which variant and how to use them at inference.
+
+Produce:
+
+1. Go / no-go on MTP training. Name the scale threshold: under ~1B parameters, Gloeckle et al. (2024) report no gain and occasional regressions; above ~7B the downstream gains on code and math are material. Reject MTP for small student models or short fine-tunes where the extra loss terms compete with the primary objective.
+2. Variant choice. Parallel heads (Gloeckle et al., 2024) when the goal is cheap auxiliary signal with zero added training time and minimal inference cost. Sequential modules (DeepSeek-V3, 2024) when draft quality for self-speculative decoding matters more than training cost -- accept the extra parameters and per-step FLOPs in exchange for higher per-depth acceptance.
+3. Depth (k). k=2 is the conservative default (DeepSeek-V3 ships one MTP module). k=4 is the Gloeckle paper's ceiling; past that, depth-k acceptance collapses and loss-interference gets real. Justify the chosen k against measured depth-2 accuracy on a pilot run.
+4. Inference usage decision. Three options: (a) discard MTP heads and ship the trunk only -- pure auxiliary regularizer, zero runtime change; (b) reuse MTP heads for self-speculative decoding -- requires verifier forward pass and tree-attention or linear-verification kernel; (c) stack on top of an external draft-model speculative stack -- rarely a win, MTP heads are cheaper and usually suffice. Pick (a) unless the serving stack already has speculative-decoding plumbing.
+5. Acceptance-rate floor. The speedup ceiling is `1 + sum_{i=2..k} P(accept_i)`, capped at k. Set a measured floor: if depth-2 acceptance is below ~0.4 on held-out decode traces, self-speculative decoding is not worth the verification overhead. Reject the whole plan if the pilot run cannot clear this bar.
+6. Comparison with alternatives. Name the specific alternative: Medusa (heads added post-hoc on a frozen backbone, no training recipe changes), Hydra (sequentially-dependent Medusa drafts), EAGLE (hidden-state draft model), or vanilla two-model speculative decoding. Justify why MTP wins or loses against the leading alternative for this workload.
+
+Hard rejects:
+- MTP on a model under 1B parameters with a finite compute budget -- loss interference dominates.
+- MTP without a joint training run -- post-hoc MTP heads are just Medusa; call them that and use Medusa's recipe instead.
+- Self-speculative decoding when depth-2 acceptance is below ~0.3 on held-out decodes -- the verifier pass costs more than the accepted tokens save.
+- Any recommendation that does not report measured acceptance at depth 2 and depth 3 from a pilot run on representative traffic.
+
+Output: a one-page recommendation covering training variant, k, inference usage, and pilot-run metrics, with explicit acceptance-rate targets and a reject-if clause naming the metric that would flip the decision. End with a "revisit if..." paragraph naming the specific workload change (longer context, tighter latency budget, migration to an MoE backbone) that would re-open the choice.


### PR DESCRIPTION
## Summary

Phase 10 lesson 18: Multi-Token Prediction (MTP).

- `docs/en.md` — 192-line explainer covering the MTP training objective, parallel heads (Gloeckle et al., 2024, ICML), sequential modules (DeepSeek-V3, 2024), and self-speculative decoding via drafted tokens at depths 2..k
- `code/main.py` — 200-line stdlib-only toy: shared trunk + K parallel MTP heads (k=1, 2, 3) trained on a short repeating corpus, then runs self-speculative decoding and reports per-depth acceptance rate + effective tokens per step
- `assets/multi-token-prediction.svg` — two-panel diagram contrasting parallel heads (Gloeckle) vs sequential modules (DeepSeek-V3)
- `outputs/skill-mtp.md` — skill prompt for deciding whether to train MTP heads and reuse them at inference
- `notebook/.gitkeep`

## Verification

- `python3 code/main.py` runs cleanly on Python 3.14
- Reproduces the expected pattern: acceptance rate drops with depth, effective tokens/step rises with k (1.00 → 1.59 → 1.85 on the toy corpus)
- All citations point to original arxiv papers: 2404.19737 (Gloeckle), 2412.19437 (DeepSeek-V3), 2211.17192 (Leviathan), 2302.01318 (Chen), 2401.10774 (Medusa), 2402.05109 (Hydra)

## Test plan

- [ ] Docs render on the course site
- [ ] `python3 code/main.py` completes in under 2 minutes
- [ ] SVG renders in `assets/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive learning materials for multi-token prediction (MTP) technique, including theoretical explanations and practical decision-making guidance for implementation.
  * Introduced interactive code example demonstrating MTP training and self-speculative decoding inference patterns.

* **Documentation**
  * Added lesson content covering MTP concepts, variants, and inference strategies with real-world acceptance-rate metrics and usage recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->