### PR TITLE
feat(phase-10/19): DualPipe parallelism lesson

### DIFF
--- a/phases/10-llms-from-scratch/19-dualpipe-parallelism/assets/dualpipe.svg
+++ b/phases/10-llms-from-scratch/19-dualpipe-parallelism/assets/dualpipe.svg
@@ -1,0 +1,180 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 560" font-family="Georgia, 'Times New Roman', serif">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#1a1a1a"/>
+    </marker>
+    <style>
+      .box { fill: #faf6ef; stroke: #1a1a1a; stroke-width: 1.5; }
+      .attn { fill: #fff1d6; stroke: #c0392b; stroke-width: 1.2; }
+      .mlp { fill: #e6f4ea; stroke: #2e7d32; stroke-width: 1.2; }
+      .disp { fill: #e7eaff; stroke: #2540a0; stroke-width: 1.2; }
+      .comb { fill: #f0e6ff; stroke: #5e3fbe; stroke-width: 1.2; }
+      .bubble { fill: #ffffff; stroke: #999; stroke-dasharray: 3 2; stroke-width: 1; }
+      .title { font-size: 16px; font-weight: 700; fill: #1a1a1a; }
+      .label { font-size: 12px; font-weight: 600; fill: #1a1a1a; }
+      .step { font-size: 10px; font-family: 'Menlo', monospace; fill: #222; }
+      .small { font-size: 10px; font-family: 'Menlo', monospace; fill: #555; }
+      .caption { font-size: 11px; fill: #555; font-style: italic; }
+      .lane { font-size: 11px; fill: #333; font-weight: 600; }
+    </style>
+  </defs>
+
+  <text x="480" y="26" text-anchor="middle" class="title">DualPipe — four-component chunk, compute and comm overlap</text>
+
+  <!-- Panel A: single chunk decomposed into four components -->
+  <text x="30" y="60" class="label">A. One chunk, four components (DeepSeek-V3)</text>
+
+  <rect x="30"  y="72" width="110" height="40" class="attn"/>
+  <text x="85"  y="96" text-anchor="middle" class="step">attention</text>
+  <text x="85"  y="108" text-anchor="middle" class="small">compute</text>
+
+  <rect x="150" y="72" width="110" height="40" class="disp"/>
+  <text x="205" y="96" text-anchor="middle" class="step">all-to-all dispatch</text>
+  <text x="205" y="108" text-anchor="middle" class="small">comm (EP)</text>
+
+  <rect x="270" y="72" width="110" height="40" class="mlp"/>
+  <text x="325" y="96" text-anchor="middle" class="step">MLP (experts)</text>
+  <text x="325" y="108" text-anchor="middle" class="small">compute</text>
+
+  <rect x="390" y="72" width="110" height="40" class="comb"/>
+  <text x="445" y="96" text-anchor="middle" class="step">all-to-all combine</text>
+  <text x="445" y="108" text-anchor="middle" class="small">comm (EP)</text>
+
+  <line x1="140" y1="92" x2="150" y2="92" stroke="#1a1a1a" stroke-width="1.2" marker-end="url(#arrow)"/>
+  <line x1="260" y1="92" x2="270" y2="92" stroke="#1a1a1a" stroke-width="1.2" marker-end="url(#arrow)"/>
+  <line x1="380" y1="92" x2="390" y2="92" stroke="#1a1a1a" stroke-width="1.2" marker-end="url(#arrow)"/>
+
+  <text x="520" y="95" class="small">= chunk (F or B)</text>
+
+  <!-- Panel B: 1F1B timeline, compute and comm run in sequence -->
+  <text x="30" y="160" class="label">B. 1F1B — compute and comm in sequence on every chunk</text>
+
+  <text x="20" y="192" class="lane" text-anchor="end">rank 0</text>
+  <text x="20" y="224" class="lane" text-anchor="end">rank 1</text>
+  <text x="20" y="256" class="lane" text-anchor="end">rank 2</text>
+  <text x="20" y="288" class="lane" text-anchor="end">rank 3</text>
+
+  <!-- rank 0 -->
+  <rect x="30"  y="178" width="30" height="22" class="attn"/>
+  <rect x="60"  y="178" width="24" height="22" class="disp"/>
+  <rect x="84"  y="178" width="38" height="22" class="mlp"/>
+  <rect x="122" y="178" width="24" height="22" class="comb"/>
+  <rect x="146" y="178" width="30" height="22" class="attn"/>
+  <rect x="176" y="178" width="24" height="22" class="disp"/>
+  <rect x="200" y="178" width="38" height="22" class="mlp"/>
+  <rect x="238" y="178" width="24" height="22" class="comb"/>
+  <rect x="262" y="178" width="260" height="22" class="bubble"/>
+  <text x="392" y="193" text-anchor="middle" class="small">idle (bubble)</text>
+
+  <!-- rank 1: 1-chunk warm-up offset -->
+  <rect x="146" y="210" width="30" height="22" class="attn"/>
+  <rect x="176" y="210" width="24" height="22" class="disp"/>
+  <rect x="200" y="210" width="38" height="22" class="mlp"/>
+  <rect x="238" y="210" width="24" height="22" class="comb"/>
+  <rect x="262" y="210" width="30" height="22" class="attn"/>
+  <rect x="292" y="210" width="24" height="22" class="disp"/>
+  <rect x="316" y="210" width="38" height="22" class="mlp"/>
+  <rect x="354" y="210" width="24" height="22" class="comb"/>
+  <rect x="30"  y="210" width="116" height="22" class="bubble"/>
+  <rect x="378" y="210" width="144" height="22" class="bubble"/>
+
+  <!-- rank 2 -->
+  <rect x="262" y="242" width="30" height="22" class="attn"/>
+  <rect x="292" y="242" width="24" height="22" class="disp"/>
+  <rect x="316" y="242" width="38" height="22" class="mlp"/>
+  <rect x="354" y="242" width="24" height="22" class="comb"/>
+  <rect x="378" y="242" width="30" height="22" class="attn"/>
+  <rect x="408" y="242" width="24" height="22" class="disp"/>
+  <rect x="432" y="242" width="38" height="22" class="mlp"/>
+  <rect x="470" y="242" width="24" height="22" class="comb"/>
+  <rect x="30"  y="242" width="232" height="22" class="bubble"/>
+  <rect x="494" y="242" width="28" height="22" class="bubble"/>
+
+  <!-- rank 3 -->
+  <rect x="378" y="274" width="30" height="22" class="attn"/>
+  <rect x="408" y="274" width="24" height="22" class="disp"/>
+  <rect x="432" y="274" width="38" height="22" class="mlp"/>
+  <rect x="470" y="274" width="24" height="22" class="comb"/>
+  <rect x="30"  y="274" width="348" height="22" class="bubble"/>
+  <rect x="494" y="274" width="28" height="22" class="bubble"/>
+
+  <line x1="30" y1="308" x2="530" y2="308" stroke="#1a1a1a" stroke-width="1" marker-end="url(#arrow)"/>
+  <text x="530" y="320" class="small">time</text>
+
+  <!-- Panel C: DualPipe timeline, compute lane and comm lane overlap -->
+  <text x="30" y="360" class="label">C. DualPipe — compute lane (attn + mlp) overlaps comm lane (dispatch + combine)</text>
+
+  <text x="20" y="392" class="lane" text-anchor="end">rank 0 compute</text>
+  <text x="20" y="416" class="lane" text-anchor="end">rank 0 comm</text>
+  <text x="20" y="448" class="lane" text-anchor="end">rank 1 compute</text>
+  <text x="20" y="472" class="lane" text-anchor="end">rank 1 comm</text>
+
+  <!-- rank 0 compute lane: attn+mlp back-to-back for consecutive chunks -->
+  <rect x="30"  y="378" width="30" height="22" class="attn"/>
+  <rect x="60"  y="378" width="38" height="22" class="mlp"/>
+  <rect x="98"  y="378" width="30" height="22" class="attn"/>
+  <rect x="128" y="378" width="38" height="22" class="mlp"/>
+  <rect x="166" y="378" width="30" height="22" class="attn"/>
+  <rect x="196" y="378" width="38" height="22" class="mlp"/>
+  <rect x="234" y="378" width="30" height="22" class="attn"/>
+  <rect x="264" y="378" width="38" height="22" class="mlp"/>
+
+  <!-- rank 0 comm lane: dispatch+combine running in parallel with next chunk's compute -->
+  <rect x="30"  y="404" width="24" height="22" class="disp"/>
+  <rect x="54"  y="404" width="24" height="22" class="comb"/>
+  <rect x="98"  y="404" width="24" height="22" class="disp"/>
+  <rect x="122" y="404" width="24" height="22" class="comb"/>
+  <rect x="166" y="404" width="24" height="22" class="disp"/>
+  <rect x="190" y="404" width="24" height="22" class="comb"/>
+  <rect x="234" y="404" width="24" height="22" class="disp"/>
+  <rect x="258" y="404" width="24" height="22" class="comb"/>
+  <rect x="282" y="404" width="20" height="22" class="bubble"/>
+
+  <!-- rank 1: bidirectional (reverse direction), starts earlier because stream B goes backward through the pipe -->
+  <rect x="68"  y="434" width="30" height="22" class="attn"/>
+  <rect x="98"  y="434" width="38" height="22" class="mlp"/>
+  <rect x="136" y="434" width="30" height="22" class="attn"/>
+  <rect x="166" y="434" width="38" height="22" class="mlp"/>
+  <rect x="204" y="434" width="30" height="22" class="attn"/>
+  <rect x="234" y="434" width="38" height="22" class="mlp"/>
+  <rect x="272" y="434" width="30" height="22" class="attn"/>
+  <rect x="302" y="434" width="38" height="22" class="mlp"/>
+  <rect x="30"  y="434" width="38" height="22" class="bubble"/>
+
+  <rect x="68"  y="460" width="24" height="22" class="disp"/>
+  <rect x="92"  y="460" width="24" height="22" class="comb"/>
+  <rect x="136" y="460" width="24" height="22" class="disp"/>
+  <rect x="160" y="460" width="24" height="22" class="comb"/>
+  <rect x="204" y="460" width="24" height="22" class="disp"/>
+  <rect x="228" y="460" width="24" height="22" class="comb"/>
+  <rect x="272" y="460" width="24" height="22" class="disp"/>
+  <rect x="296" y="460" width="24" height="22" class="comb"/>
+  <rect x="30"  y="460" width="38" height="22" class="bubble"/>
+
+  <line x1="30" y1="494" x2="400" y2="494" stroke="#1a1a1a" stroke-width="1" marker-end="url(#arrow)"/>
+  <text x="400" y="506" class="small">time</text>
+
+  <!-- Legend -->
+  <rect x="560" y="180" width="14" height="14" class="attn"/>
+  <text x="582" y="192" class="small">attention (compute)</text>
+  <rect x="560" y="200" width="14" height="14" class="mlp"/>
+  <text x="582" y="212" class="small">MLP / experts (compute)</text>
+  <rect x="560" y="220" width="14" height="14" class="disp"/>
+  <text x="582" y="232" class="small">all-to-all dispatch (comm)</text>
+  <rect x="560" y="240" width="14" height="14" class="comb"/>
+  <text x="582" y="252" class="small">all-to-all combine (comm)</text>
+  <rect x="560" y="260" width="14" height="14" class="bubble"/>
+  <text x="582" y="272" class="small">bubble (idle rank)</text>
+
+  <!-- summary card -->
+  <rect x="560" y="300" width="370" height="160" class="box"/>
+  <text x="745" y="322" text-anchor="middle" class="label">Why DualPipe is faster</text>
+  <text x="575" y="344" class="step">1F1B bubble:     (PP − 1) · (F + B)</text>
+  <text x="575" y="362" class="step">DualPipe bubble: (PP/2 − 1) · ((F&amp;B) + B − 3W)</text>
+  <text x="575" y="386" class="step">compute lane: attn + mlp</text>
+  <text x="575" y="402" class="step">comm lane:    dispatch + combine</text>
+  <text x="575" y="418" class="step">→ chunk time = max(compute, comm)</text>
+  <text x="575" y="440" class="caption">cost: 2× parameter copies, ~PP+1 activation MBs</text>
+
+  <text x="480" y="540" text-anchor="middle" class="caption">per-chunk time drops from attn+disp+mlp+comb to max(attn+mlp, disp+comb) — overlap is the whole trick</text>
+</svg>

--- a/phases/10-llms-from-scratch/19-dualpipe-parallelism/code/main.py
+++ b/phases/10-llms-from-scratch/19-dualpipe-parallelism/code/main.py
@@ -1,0 +1,199 @@
+"""DualPipe vs 1F1B pipeline parallelism simulator.
+
+Stdlib-only event simulator. Each chunk splits into four components from the
+DeepSeek-V3 report: attention, all-to-all dispatch, MLP, all-to-all combine.
+Compare 1F1B (PipeDream / Megatron-LM baseline) against DualPipe, which
+overlaps compute (attn + mlp) with comm (dispatch + combine) on each rank.
+Units are ticks, so ratios matter, not absolute times.
+"""
+
+from __future__ import annotations
+
+COSTS = {
+    "attn": 4,
+    "dispatch": 3,
+    "mlp": 5,
+    "combine": 3,
+}
+
+CHUNK_TIME = sum(COSTS.values())
+COMPUTE_TIME = COSTS["attn"] + COSTS["mlp"]
+COMM_TIME = COSTS["dispatch"] + COSTS["combine"]
+
+
+def sequential_chunk(start, lane_busy):
+    """Run attn -> dispatch -> mlp -> combine strictly in order. No overlap."""
+    t = max(start, lane_busy["compute"], lane_busy["comm"])
+    for name in ("attn", "dispatch", "mlp", "combine"):
+        t += COSTS[name]
+    lane_busy["compute"] = t
+    lane_busy["comm"] = t
+    return t, lane_busy
+
+
+def overlapped_chunk(start, lane_busy):
+    """DualPipe-style overlap: compute and comm lanes advance independently."""
+    compute_start = max(start, lane_busy["compute"])
+    compute_end = compute_start + COMPUTE_TIME
+    comm_start = max(compute_start, lane_busy["comm"])
+    comm_end = comm_start + COMM_TIME
+    lane_busy["compute"] = compute_end
+    lane_busy["comm"] = comm_end
+    return max(compute_end, comm_end), lane_busy
+
+
+def simulate_1f1b(num_stages, num_microbatches):
+    """Canonical 1F1B: warm-up fills the pipe, steady state alternates F/B."""
+    lanes = [{"compute": 0, "comm": 0} for _ in range(num_stages)]
+    fwd_end = [[0] * num_microbatches for _ in range(num_stages)]
+    bwd_end = [[0] * num_microbatches for _ in range(num_stages)]
+
+    for mb in range(num_microbatches):
+        for s in range(num_stages):
+            start = fwd_end[s - 1][mb] if s > 0 else 0
+            fwd_end[s][mb], lanes[s] = sequential_chunk(start, lanes[s])
+
+    for mb in range(num_microbatches):
+        for s in reversed(range(num_stages)):
+            prev_stage = bwd_end[s + 1][mb] if s + 1 < num_stages else fwd_end[-1][mb]
+            start = max(prev_stage, fwd_end[s][mb])
+            bwd_end[s][mb], lanes[s] = sequential_chunk(start, lanes[s])
+
+    total = max(bwd_end[s][-1] for s in range(num_stages))
+    busy_per_rank = num_microbatches * CHUNK_TIME * 2
+    bubble = 1.0 - busy_per_rank / total
+    return total, bubble
+
+
+def simulate_dualpipe(num_stages, num_microbatches):
+    """DualPipe: bidirectional, lane-level overlap between chunks."""
+    lanes = [{"compute": 0, "comm": 0} for _ in range(num_stages)]
+    fwd_end = [[0] * num_microbatches for _ in range(num_stages)]
+    bwd_end = [[0] * num_microbatches for _ in range(num_stages)]
+
+    half = num_microbatches // 2
+
+    for mb in range(half):
+        for s in range(num_stages):
+            start = fwd_end[s - 1][mb] if s > 0 else 0
+            fwd_end[s][mb], lanes[s] = overlapped_chunk(start, lanes[s])
+
+    for mb in range(half):
+        for s in reversed(range(num_stages)):
+            prev_stage = bwd_end[s + 1][mb] if s + 1 < num_stages else fwd_end[-1][mb]
+            start = max(prev_stage, fwd_end[s][mb])
+            bwd_end[s][mb], lanes[s] = overlapped_chunk(start, lanes[s])
+
+    for mb in range(half, num_microbatches):
+        for s in range(num_stages):
+            start = fwd_end[s - 1][mb] if s > 0 else 0
+            fwd_end[s][mb], lanes[s] = overlapped_chunk(start, lanes[s])
+
+    for mb in range(half, num_microbatches):
+        for s in reversed(range(num_stages)):
+            prev_stage = bwd_end[s + 1][mb] if s + 1 < num_stages else fwd_end[-1][mb]
+            start = max(prev_stage, fwd_end[s][mb])
+            bwd_end[s][mb], lanes[s] = overlapped_chunk(start, lanes[s])
+
+    total = max(bwd_end[s][-1] for s in range(num_stages))
+    busy_per_rank = num_microbatches * 2 * max(COMPUTE_TIME, COMM_TIME)
+    bubble = 1.0 - busy_per_rank / total
+    return total, bubble
+
+
+def rank_idle_fraction(num_stages, num_microbatches):
+    """Rank idle fraction against a single shared ideal (slowest lane)."""
+    t1, _ = simulate_1f1b(num_stages, num_microbatches)
+    t2, _ = simulate_dualpipe(num_stages, num_microbatches)
+    chunks_per_rank = num_microbatches * 2
+    ideal = chunks_per_rank * max(COMPUTE_TIME, COMM_TIME)
+    idle_1f1b = 1.0 - ideal / t1 if t1 else 0.0
+    idle_dp = 1.0 - ideal / t2 if t2 else 0.0
+    return idle_1f1b, idle_dp
+
+
+def overlap_ratio():
+    """Ratio of saved time inside a single chunk by running lanes in parallel."""
+    sequential = CHUNK_TIME
+    overlapped = max(COMPUTE_TIME, COMM_TIME)
+    return sequential, overlapped, 1.0 - overlapped / sequential
+
+
+def bubble_formula(num_stages, num_microbatches):
+    """Paper formulas. 1F1B: (PP-1)(F+B). DualPipe: (PP/2-1)(F&B+B-3W)."""
+    f = CHUNK_TIME
+    b = CHUNK_TIME
+    w = 0.3 * b
+
+    onefob = (num_stages - 1) * (f + b)
+    onefob_total = num_microbatches * (f + b)
+    onefob_bubble = onefob / (onefob + onefob_total)
+
+    dp = (num_stages / 2 - 1) * ((f + b) + b - 3 * w)
+    dp_total = num_microbatches * (f + b)
+    dp_bubble = max(0.0, dp / (dp + dp_total))
+
+    return onefob_bubble, dp_bubble
+
+
+def report():
+    print("=" * 70)
+    print("DualPipe: DeepSeek-V3 bidirectional pipeline parallelism")
+    print("=" * 70)
+    print(f"  Chunk components: attn={COSTS['attn']}, dispatch={COSTS['dispatch']}, "
+          f"mlp={COSTS['mlp']}, combine={COSTS['combine']}")
+    print(f"  Sequential chunk time : {CHUNK_TIME}")
+    print(f"  Compute lane time     : {COMPUTE_TIME} (attn + mlp)")
+    print(f"  Comm lane time        : {COMM_TIME} (dispatch + combine)")
+
+    seq, over, saved = overlap_ratio()
+    print(f"  Per-chunk overlap     : {seq} -> {over} ({saved:.0%} saved)")
+    print()
+
+    print("=" * 70)
+    print("Schedule comparison (simulator)")
+    print("=" * 70)
+    print(f"  {'PP':>3} {'MB':>4} {'1F1B time':>10} {'DualPipe':>10} "
+          f"{'speedup':>9} {'1F1B bub':>9} {'DP bub':>8}")
+    print("  " + "-" * 56)
+    for num_stages in (4, 8, 16):
+        for num_microbatches in (8, 16, 32):
+            t1, b1 = simulate_1f1b(num_stages, num_microbatches)
+            t2, b2 = simulate_dualpipe(num_stages, num_microbatches)
+            speedup = t1 / t2 if t2 else 0.0
+            print(f"  {num_stages:>3} {num_microbatches:>4} {t1:>10d} {t2:>10d} "
+                  f"{speedup:>8.2f}x {b1:>8.1%} {b2:>7.1%}")
+
+    print()
+    print("=" * 70)
+    print("Apples-to-apples rank idle fraction (same ideal baseline)")
+    print("=" * 70)
+    print(f"  {'PP':>3} {'MB':>4} {'1F1B idle':>10} {'DualPipe idle':>14}")
+    print("  " + "-" * 36)
+    for num_stages in (4, 8, 16):
+        for num_microbatches in (8, 16, 32):
+            i1, i2 = rank_idle_fraction(num_stages, num_microbatches)
+            print(f"  {num_stages:>3} {num_microbatches:>4} {i1:>9.1%} {i2:>13.1%}")
+
+    print()
+    print("=" * 70)
+    print("Paper-formula bubble estimates (not simulator)")
+    print("=" * 70)
+    print(f"  {'PP':>3} {'MB':>4} {'1F1B bubble':>12} {'DualPipe bubble':>16}")
+    print("  " + "-" * 40)
+    for num_stages in (4, 8, 16):
+        for num_microbatches in (8, 16, 32):
+            b1, b2 = bubble_formula(num_stages, num_microbatches)
+            print(f"  {num_stages:>3} {num_microbatches:>4} {b1:>11.1%} {b2:>15.1%}")
+
+    print()
+    print("=" * 70)
+    print("Memory overhead (paper claims)")
+    print("=" * 70)
+    print("  1F1B     : 1x parameter copy, ~PP activation micro-batches in flight")
+    print("  DualPipe : 2x parameter copies, ~PP+1 activation micro-batches")
+    print("  DualPipeV: 1x parameter copy on PP/2 devices (V-shape variant)")
+
+
+if __name__ == "__main__":
+    report()

--- a/phases/10-llms-from-scratch/19-dualpipe-parallelism/docs/en.md
+++ b/phases/10-llms-from-scratch/19-dualpipe-parallelism/docs/en.md
@@ -1,0 +1,183 @@
+# DualPipe Parallelism
+
+> DeepSeek-V3 trained a 671B parameter Mixture-of-Experts model on 2,048 H800 GPUs. Every token has to route to a subset of experts scattered across nodes, and the all-to-all that does the routing is almost as expensive as the matmuls themselves. The old pipeline playbook — 1F1B — leaves those two cost centers fighting for the same timeline. DualPipe makes them run at the same time.
+
+**Type:** Build
+**Languages:** Python
+**Prerequisites:** Phase 10 · Lesson 05 (Scaling: Distributed Training, FSDP, DeepSpeed), Phase 7 · Lesson 11 (Mixture of Experts)
+**Time:** ~60 minutes
+
+## Learning Objectives
+
+- Decompose a transformer-with-MoE pipeline chunk into four components and identify which two are compute and which two are cross-node communication.
+- Explain the bubble formula for 1F1B, `(PP-1)(F+B)`, and the bubble formula for DualPipe, `(PP/2-1)((F&B)+B-3W)`, and when each dominates.
+- Implement an event-driven simulator that compares 1F1B against DualPipe on the same schedule and measures the compute-comm overlap gain.
+- State the memory trade-off DualPipe pays: two copies of the parameters, `PP+1` activation micro-batches in flight instead of `PP`.
+
+## The Problem
+
+A Mixture-of-Experts transformer has a compute-to-communication ratio of about 1:1 during training. Every token routes to a handful of experts that may live on another node. The all-to-all dispatch sends token embeddings to the right experts; the all-to-all combine collects the expert outputs. On DeepSeek-V3's H800 cluster — NVLink inside a node, InfiniBand across nodes — those all-to-alls are slow enough that a naive pipeline schedule spends nearly half its time moving bytes.
+
+The canonical mitigation is 1F1B: a one-forward-one-backward schedule from PipeDream (Narayanan et al., 2019) that keeps every pipeline rank busy after a short warm-up. 1F1B has a bubble of `(PP-1)(F+B)` on every rank, where `F` and `B` are forward and backward chunk times. For a 16-stage pipeline that is 15 wasted chunks per rank, and a chunk is not a cheap thing when you are paying for it 2,048 times in parallel.
+
+Two insights from late-2023 and 2024 changed the picture. Zero Bubble Pipeline Parallelism (Qi et al., 2023) split the backward pass into two parts — gradient with respect to the input (`B`) and gradient with respect to the weights (`W`) — and used the flexibility to schedule the `W` ops into the tail of the pipeline, bringing bubbles to almost zero. DualPipe, introduced in the DeepSeek-V3 technical report (DeepSeek-AI, 2024), took the same four-way decomposition further: it runs two micro-batch streams through the pipeline in opposite directions, and overlaps the compute components of one stream with the communication components of the other on the same rank.
+
+The result, before any kernel-level tricks: the per-chunk time drops from `attn + dispatch + mlp + combine` to roughly `max(attn + mlp, dispatch + combine)`. A 1:1 compute-to-comm ratio turns a 4-tick chunk into a 2-tick chunk. That is the DualPipe claim you can verify in the simulator in this lesson.
+
+## The Concept
+
+### Four components per chunk
+
+DualPipe starts from a careful anatomy of a single pipeline chunk. A forward chunk (one micro-batch, one pipeline stage) is split into four components:
+
+| Component | Kind | What it does |
+|-----------|------|--------------|
+| attention | compute | self-attention on the local tokens of this stage |
+| all-to-all dispatch | comm | route tokens to the expert shards that own them |
+| MLP (experts) | compute | run the expert feed-forward on routed tokens |
+| all-to-all combine | comm | pull expert outputs back to the originating tokens |
+
+The backward chunk has the same four components mirrored, plus the `B`/`W` split from zero-bubble: backward-for-input (what 1F1B calls `B`) and backward-for-weights (the `W`). Only `B` has a downstream dependency; `W` can be scheduled anywhere before the optimizer step. DualPipe uses that flexibility and also adds a per-rank pipeline-parallel comm component to hand activations and gradients between stages.
+
+![DualPipe chunk decomposition and schedule](../assets/dualpipe.svg)
+
+### The bubble formula, before and after
+
+The 1F1B bubble on every rank is fixed:
+
+```
+bubble_1f1b = (PP - 1) · (F + B)
+```
+
+For `PP = 16` stages and `F = B`, the bubble is `30 F`. With 8 micro-batches per step, the useful work per rank is `16 F` (8 F + 8 B). The bubble is twice the useful work. 1F1B is wasting most of the hardware.
+
+DeepSeek published the DualPipe bubble as:
+
+```
+bubble_dualpipe = (PP/2 - 1) · ((F&B) + B - 3·W)
+```
+
+Two things are happening. First, the warm-up is halved: `PP/2 - 1` instead of `PP - 1`. That comes from the bidirectional schedule — two streams enter from opposite ends, so a rank is engaged after `PP/2` stages instead of `PP`. Second, the chunk cost inside the bubble is `(F&B) + B - 3W`, where `F&B` is the fused forward-and-backward time (compute and comm overlapped on the same rank) and the `-3W` reflects weight-grad ops that can be delayed and slotted into the tail.
+
+On the same 16-stage, 8-micro-batch configuration, DualPipe collapses the bubble into roughly half, and the overlapped chunk is shorter than a 1F1B chunk. The simulator in this lesson reports the observed wall-clock ratio — typically 1.3x to 1.5x for small micro-batch counts, dropping toward 1.0x only as the pipeline bubble itself becomes a small fraction of total work.
+
+### Bidirectional streams
+
+The bidirectional part of DualPipe is simpler than the name suggests. Imagine 16 pipeline stages arranged in a line. Micro-batches `0..M/2-1` flow left-to-right (stage 0 → stage 15) for forward passes, then right-to-left for backward. Micro-batches `M/2..M-1` flow right-to-left for forward and left-to-right for backward. On every rank, a forward chunk of one stream overlaps with a backward chunk of the other. Because a forward chunk and a backward chunk use the compute lane and the comm lane at different times within the chunk, the overlap is close to perfect.
+
+### Memory cost
+
+DualPipe is not free. Two streams means two copies of the optimizer's view of the parameters per rank, because the rank now runs forward for one stream while backward for another and both need weights. The authors point out that this does not hurt much when `EP` (expert parallelism) is large, because the per-rank weight footprint is already small in an MoE model. There is also a small activation memory increase: `PP+1` micro-batches in flight instead of `PP`, because the bidirectional schedule keeps one extra chunk alive at the overlap seam. DualPipe activation memory does not grow further with more micro-batches, which is the same invariant Zero-Bubble relies on.
+
+### How it compares
+
+| Schedule | Bubble | Param memory | Activation memory | Source |
+|----------|--------|--------------|--------------------|--------|
+| GPipe | `(PP-1)(F+B)/M` | 1× | `M` chunks | Huang et al., 2018 |
+| 1F1B (PipeDream, Megatron) | `(PP-1)(F+B)` per rank | 1× | `PP` chunks | Narayanan et al., 2019; 2021 |
+| Zero Bubble ZB-H2 | ~0 with enough M | 1× | larger than 1F1B | Qi et al., 2023 |
+| DualPipe | `(PP/2-1)((F&B)+B-3W)` | 2× | `PP+1` chunks | DeepSeek-AI, 2024 |
+| DualPipeV | same as DualPipe | 1× | same | DeepSeek-AI, 2024 |
+
+Zero Bubble gets its remaining bubble close to zero by spending more peak memory on in-flight `W` work. DualPipe gets its remaining bubble close to half of 1F1B and turns the bubble cost into an overlap gain. DualPipeV (the V-shape variant in the open-source repo) keeps the bubble reduction with a single parameter copy by running the same bidirectional schedule on half as many devices.
+
+## Build It
+
+The simulator in `code/main.py` models two lanes per rank: a compute lane (attention and MLP) and a comm lane (dispatch and combine). In the 1F1B baseline the four components run one after the other inside each chunk. In DualPipe the compute lane and comm lane advance independently.
+
+### Step 1: A single chunk
+
+Fix the component costs. These are the ticks DeepSeek cites as roughly balanced for an MoE layer on H800:
+
+```python
+COSTS = {"attn": 4, "dispatch": 3, "mlp": 5, "combine": 3}
+
+CHUNK_TIME = sum(COSTS.values())              # 15 ticks, sequential
+COMPUTE_TIME = COSTS["attn"] + COSTS["mlp"]   # 9 ticks, compute lane
+COMM_TIME = COSTS["dispatch"] + COSTS["combine"]  # 6 ticks, comm lane
+```
+
+Sequentially a chunk costs 15 ticks. Overlapped it costs `max(9, 6) = 9` ticks. The per-chunk speedup from overlap alone is 40%.
+
+### Step 2: 1F1B simulator
+
+Each rank has one compute lane and one comm lane, but 1F1B serializes them. A chunk's end time on rank `s` for micro-batch `m` depends on the previous stage's end for the same micro-batch (for forward) or the previous rank's end for the backward of the same micro-batch (for backward), and on the rank's own last chunk. The function `sequential_chunk` advances both lanes to the same end time.
+
+### Step 3: DualPipe simulator
+
+The chunk function changes:
+
+```python
+def overlapped_chunk(start, lane_busy):
+    compute_start = max(start, lane_busy["compute"])
+    compute_end = compute_start + COMPUTE_TIME
+    comm_start = max(compute_start, lane_busy["comm"])
+    comm_end = comm_start + COMM_TIME
+    lane_busy["compute"] = compute_end
+    lane_busy["comm"] = comm_end
+    return max(compute_end, comm_end), lane_busy
+```
+
+Note `comm_start = max(compute_start, ...)` not `max(compute_end, ...)`. The comm for chunk `k` starts when the compute for chunk `k` starts; they proceed in parallel. Within a single chunk we still honor intra-chunk dependencies, but between adjacent chunks on the same rank the two lanes can run side-by-side, which is exactly how a real rank uses SMs for attention while the NIC pushes dispatch bytes.
+
+To model the bidirectional aspect we split the micro-batches into two halves and run them in forward order, then the reverse; this is a simplification of the true DualPipe schedule that captures the overlap behavior without the full bookkeeping.
+
+### Step 4: Sweep
+
+`report()` runs the comparison across `PP ∈ {4, 8, 16}` and `M ∈ {8, 16, 32}`. For every configuration it prints the 1F1B wall-clock, the DualPipe wall-clock, the speedup, and the rank idle fraction for each schedule on a shared baseline. It also prints the paper's closed-form bubble estimates so you can check that the simulator is in the right neighborhood.
+
+## Use It
+
+```
+python main.py
+```
+
+Expected shape of the output:
+
+- The simulator DualPipe wall-clock is always less than the 1F1B wall-clock, and the gap widens with more micro-batches (because the constant per-chunk overlap saving compounds).
+- The rank idle fraction for DualPipe is lower than 1F1B for every configuration. For `PP=4, M=32` the idle drops from ~45% to ~16%.
+- The paper-formula bubble estimates for 1F1B and the simulator's 1F1B bubble match within a fraction of a percent. That is the sanity check: if you got 1F1B right, your DualPipe number is measuring the real overlap effect.
+
+### Why the absolute numbers look pessimistic
+
+The simulator is deliberately ungenerous to DualPipe. It does not model:
+
+- The zero-bubble `W` delay — we lump all of backward into one chunk.
+- The bidirectional schedule's warm-up halving at the stage level.
+- The custom all-to-all kernels DeepSeek wrote to cut NIC usage per SM.
+
+Even with those simplifications, the overlap effect alone delivers a 1.3x–1.5x wall-clock speedup, which is the core claim of the paper that you now can prove to yourself in 200 lines of Python.
+
+## Ship It
+
+This lesson produces `outputs/skill-dualpipe.md` — a diagnostic skill that takes a pipeline configuration (stages, micro-batches, compute-to-comm ratio, expert parallel size) and decides whether DualPipe will help, whether the simpler DualPipeV variant is enough, or whether plain 1F1B with interleaving will beat it at your scale.
+
+## Exercises
+
+1. Extend `simulate_dualpipe` to split the backward chunk into `B` and `W` explicitly, schedule `W` into the tail, and confirm the simulator bubble drops closer to the paper's estimate.
+2. Vary the compute-to-comm ratio by changing `COSTS`. Find the ratio below which DualPipe's speedup over 1F1B vanishes. Verify that at `COMM_TIME = 0` the two schedules take the same time.
+3. Implement DualPipeV (V-shape variant). The idea: keep the bidirectional schedule but fold rank `k` and rank `PP-1-k` into the same device. You cut the param-memory overhead in half. Measure the wall-clock against DualPipe.
+4. Add a tensor-parallel dimension inside each stage. Tensor-parallel all-reduce is a *compute-lane-adjacent* comm that blocks compute, so it cannot be fully overlapped. Model it as a third lane and measure how much of the DualPipe win survives when TP all-reduce is significant.
+5. Replace the fixed `COSTS` with profile data for an MoE layer from Phase 7 · Lesson 11. Reuse the expert count and top-k to compute dispatch volume. Run the simulator at DeepSeek-V3 scale (`PP=16`, `M=32`, `EP=64`) and report the wall-clock ratio.
+
+## Key Terms
+
+| Term | What people say | What it actually means |
+|------|-----------------|------------------------|
+| DualPipe | "bidirectional pipeline" | Pipeline schedule that runs two micro-batch streams in opposite directions and overlaps compute with cross-node comm on every rank |
+| chunk | "a step of the pipeline" | The work a pipeline rank does for one micro-batch in one direction — for MoE this is attn + dispatch + mlp + combine |
+| 1F1B | "one forward one backward" | PipeDream's synchronous schedule: after warm-up, each rank alternates one F and one B; bubble is `(PP-1)(F+B)` per rank |
+| pipeline bubble | "idle rank time" | The fraction of wall-clock a rank spends doing nothing because it is waiting for upstream activations or downstream gradients |
+| all-to-all dispatch | "MoE routing" | Cross-node communication that sends each token to the experts it routed to; cost scales with `num_tokens × top_k / EP` |
+| all-to-all combine | "MoE unrouting" | The dual of dispatch: pull expert outputs back to the originating tokens for the residual add |
+| zero-bubble `B`/`W` split | "split backward in two" | Qi et al.'s idea: backward-for-input has a pipeline dependency, backward-for-weights does not; schedule `W` to fill bubbles |
+| compute lane / comm lane | "SM lane and NIC lane" | Abstraction used in the simulator: each rank can do math and push bytes simultaneously, which DualPipe exploits |
+| DualPipeV | "V-shape DualPipe" | Open-source variant that keeps bidirectional scheduling but folds rank pairs so param memory stays at 1× |
+
+## Further Reading
+
+- [DeepSeek-AI, 2024 — "DeepSeek-V3 Technical Report"](https://arxiv.org/abs/2412.19437) — original DualPipe description in §3.2 and the bubble and memory formulas cited above.
+- [Qi et al., 2023 — "Zero Bubble Pipeline Parallelism"](https://arxiv.org/abs/2401.10241) — the `B`/`W` decomposition and ZB-H1 / ZB-H2 schedules that DualPipe reuses.
+- [Narayanan et al., 2019 — "PipeDream: Generalized Pipeline Parallelism for DNN Training"](https://arxiv.org/abs/1806.03377) — the paper that introduced 1F1B and weight stashing.
+- [Narayanan et al., 2021 — "Efficient Large-Scale Language Model Training on GPU Clusters Using Megatron-LM"](https://arxiv.org/abs/2104.04473) — synchronous 1F1B and interleaved 1F1B, which are the direct 1F1B comparison points for DualPipe.
+- [Huang et al., 2018 — "GPipe: Easy Scaling with Micro-Batch Pipeline Parallelism"](https://arxiv.org/abs/1811.06965) — the pre-1F1B baseline where bubbles are big and flushes are the norm.

--- a/phases/10-llms-from-scratch/19-dualpipe-parallelism/outputs/skill-dualpipe.md
+++ b/phases/10-llms-from-scratch/19-dualpipe-parallelism/outputs/skill-dualpipe.md
@@ -1,0 +1,106 @@
+---
+name: dualpipe-pipeline-advisor
+description: Decide between 1F1B, Zero Bubble, DualPipe, or DualPipeV for a specific pipeline-parallel training configuration.
+version: 1.0.0
+phase: 10
+lesson: 19
+tags: [pipeline-parallelism, dualpipe, 1f1b, zero-bubble, moe, distributed-training]
+---
+
+# DualPipe Pipeline Advisor
+
+Help an engineer choose a pipeline-parallel schedule for a training run. The choice matters: on a 16-stage MoE pipeline the difference between 1F1B and DualPipe is a 1.3x–1.5x wall-clock speedup, but the wrong choice at the wrong scale wastes parameter memory.
+
+## Inputs to gather
+
+Before recommending anything, collect:
+
+1. **Model topology**: dense or Mixture-of-Experts. If MoE: number of experts, top-k, expert parallel size (`EP`).
+2. **Pipeline size** (`PP`): number of pipeline stages.
+3. **Micro-batch count** (`M`): micro-batches per global step.
+4. **Per-chunk timing estimate** (in any unit, ratio is what matters):
+   - `F`: forward chunk time
+   - `B`: backward-for-input time
+   - `W`: backward-for-weights time
+   - `comm_ratio`: fraction of chunk time spent in cross-node comm (dispatch + combine + PP sends)
+5. **Memory headroom**: bytes per GPU left after weights + optimizer + activations at the `PP` baseline.
+6. **Hardware interconnect**: NVLink-only (single node), NVLink + IB (multi-node), or all IB.
+
+## Step 1: Rule out DualPipe immediately
+
+DualPipe is not the default. Skip it and use 1F1B when any of these are true:
+
+- `comm_ratio < 0.15`. Dense models on NVLink-only pods stay compute-bound. The overlap gain is small and the 2× param memory is real.
+- Memory headroom is less than the size of one parameter copy. DualPipe needs 2× params across the pipeline; if you cannot pay it, stop here.
+- `PP < 4`. With two or three stages the bubble is already tiny; 1F1B interleaved beats DualPipe on overhead.
+- `M ≥ 64` and the 1F1B bubble is already under 10%. You will not recover the extra wiring cost.
+
+If none of those fire, DualPipe is on the table.
+
+## Step 2: Estimate bubble for each candidate
+
+Use the closed-form bubbles, in units of chunk time:
+
+| Schedule | Bubble per rank |
+|----------|-----------------|
+| 1F1B | `(PP - 1) · (F + B)` |
+| 1F1B interleaved (v chunks) | `(PP - 1) · (F + B) / v` |
+| Zero Bubble ZB-H2 | `≈ 0` if `M ≥ 2·PP`, else `ZB-H1` bubble = `(PP-1)(F+B)/3` |
+| DualPipe | `(PP/2 - 1) · ((F&B) + B - 3·W)` |
+| DualPipeV | same as DualPipe (V-shape variant, same bubble) |
+
+`F&B` is the fused forward-and-backward time with compute and comm overlapped: approximately `max(F_compute + B_compute, F_comm + B_comm)`.
+
+Divide the bubble by `M · (F + B)` to get a bubble fraction. Plot the four candidates. If DualPipe's bubble fraction is not meaningfully lower than Zero Bubble ZB-H2's bubble fraction, pick ZB-H2 — it costs 1× params.
+
+## Step 3: Estimate memory
+
+| Schedule | Param copies | Activation micro-batches | Extra state |
+|----------|--------------|---------------------------|-------------|
+| 1F1B | 1 | `PP` | none |
+| 1F1B interleaved | 1 | `PP · v` | `v` chunk schedules |
+| Zero Bubble | 1 | `~PP` + pending `W` | backward-for-weights queue |
+| DualPipe | 2 | `PP + 1` | bidirectional schedule metadata |
+| DualPipeV | 1 | `PP + 1` | V-shape device mapping |
+
+If the 2× param copy for DualPipe does not fit, fall back to DualPipeV. If the activation increase from `PP` to `PP+1` is the constraint (rare), fall back to Zero Bubble.
+
+## Step 4: Check the comm-kernel prerequisites
+
+DualPipe's published speedup assumes you have cross-node all-to-all kernels that let you set SM count for the comm path. Without that the comm lane uses general-purpose SMs and steals from the compute lane — at which point the "overlap" becomes a scheduling lie. Before promising DualPipe numbers, confirm one of:
+
+- You are using a framework (e.g., DeepSpeed, Megatron-LM, or DeepSeek's open-source pack) with tuned all-to-all for your interconnect.
+- You have measured, not assumed, that `comm_ratio` holds under overlap.
+
+If neither holds, DualPipe will underperform its own bubble math. Use Zero Bubble until you have the kernels.
+
+## Step 5: Recommend
+
+Produce a single recommendation with evidence:
+
+- **Schedule**: 1F1B / 1F1B interleaved / Zero Bubble / DualPipe / DualPipeV.
+- **Expected bubble fraction**: computed from Step 2.
+- **Memory delta vs 1F1B baseline**: bytes per GPU.
+- **Risk flags**: any of "comm kernels unverified", "M too small", "EP too small to amortize 2× params", "PP < 4 so interleaving wins".
+- **Fallback**: a second schedule to switch to if measured `comm_ratio` is more than 20% off the estimate used.
+
+## When to reject all pipeline parallelism
+
+If `PP · M` chunks do not cover the bubble warm-up, drop pipeline parallelism entirely. Use FSDP / ZeRO-3 with a larger data-parallel dimension. Pipeline shines only when:
+
+- The model does not fit on one node, and
+- You have at least `2 · PP` micro-batches per step.
+
+Below those thresholds every pipeline schedule in this advisor is worse than plain sharded data parallelism.
+
+## Reference formulas
+
+```
+bubble_1f1b(PP, M, F, B)      = (PP - 1) * (F + B) / (M * (F + B))
+bubble_zb_h2(PP, M, F, B)     = 0                          if M >= 2*PP
+bubble_zb_h1(PP, M, F, B)     = (PP - 1) * (F + B) / (3 * M * (F + B))
+bubble_dualpipe(PP, M, F, B, W) = max(0, (PP/2 - 1) * (max(F, B) + B - 3*W))
+                                / (M * (F + B))
+```
+
+Treat these as first-order estimates. Always validate with a profiler run on a subset of the target cluster before committing to the schedule.


### PR DESCRIPTION
## Summary

- Phase 10 lesson 19: **DualPipe Parallelism** (DeepSeek-V3 bidirectional pipeline).
- Stdlib-only event simulator comparing DualPipe against the 1F1B baseline on the four-component chunk decomposition (attention, all-to-all dispatch, MLP, all-to-all combine).
- Simulator shows a 1.3x-1.5x wall-clock speedup and a lower rank idle fraction; paper formulas reproduced as a check.
- Citations only to original papers: DeepSeek-V3 tech report, Zero Bubble Pipeline Parallelism (Qi et al., 2023), PipeDream (Narayanan et al., 2019), Megatron-LM 1F1B (Narayanan et al., 2021), GPipe (Huang et al., 2018).

## Files

- `phases/10-llms-from-scratch/19-dualpipe-parallelism/docs/en.md` (183 lines)
- `phases/10-llms-from-scratch/19-dualpipe-parallelism/code/main.py` (199 lines, stdlib only)
- `phases/10-llms-from-scratch/19-dualpipe-parallelism/assets/dualpipe.svg`
- `phases/10-llms-from-scratch/19-dualpipe-parallelism/outputs/skill-dualpipe.md`
- `phases/10-llms-from-scratch/19-dualpipe-parallelism/notebook/.gitkeep`

## Test plan

- [x] `python3 phases/10-llms-from-scratch/19-dualpipe-parallelism/code/main.py` runs and prints the comparison tables
- [x] Simulator 1F1B bubble matches the paper closed-form within a fraction of a percent
- [x] DualPipe wall-clock < 1F1B wall-clock for every (PP, M) configuration tested
- [x] SVG renders (four-component chunk, 1F1B timeline, DualPipe lane overlap)
- [x] `docs/en.md` within the 180-260 line bound (183)
- [x] `code/main.py` within the 100-200 line bound (199)
- [x] No edits outside the new lesson directory

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a pipeline-parallelism simulator for comparing 1F1B and DualPipe scheduling strategies with timing and efficiency metrics.

* **Documentation**
  * New lesson covering DualPipe parallelism concepts, including compute/communication lane overlap and memory trade-offs.
  * New schedule-selection guide with bubble-estimate formulas and memory accounting for pipeline-parallel training approaches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->