### PR TITLE
fix(site): swap body font to Inter for readability

### DIFF
--- a/site/catalog.html
+++ b/site/catalog.html
@@ -8,8 +8,8 @@
   <meta name="description" content="Full catalog of 260+ AI engineering lessons. Search, filter, and sort every lesson across all 20 phases.">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Kalam:wght@400;700&family=Patrick+Hand&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css?v=20260417e">
+  <link href="https://fonts.googleapis.com/css2?family=Kalam:wght@400;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css?v=20260424a">
   <style>
     .catalog-page {
       padding: 100px 0 80px;
@@ -269,9 +269,9 @@
     </div>
   </footer>
 
-  <script src="data.js?v=20260417e"></script>
-  <script src="progress.js?v=20260417e"></script>
-  <script src="header.js?v=20260417e" defer></script>
+  <script src="data.js?v=20260424a"></script>
+  <script src="progress.js?v=20260424a"></script>
+  <script src="header.js?v=20260424a" defer></script>
   <script>
     (function () {
       var root = document.documentElement;

--- a/site/glossary.html
+++ b/site/glossary.html
@@ -8,8 +8,8 @@
   <meta name="description" content="AI glossary: what people say vs what things actually mean. Every term explained without hand-waving.">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Kalam:wght@400;700&family=Patrick+Hand&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css?v=20260417e">
+  <link href="https://fonts.googleapis.com/css2?family=Kalam:wght@400;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css?v=20260424a">
   <style>
     .glossary-page {
       padding: 100px 0 80px;
@@ -201,9 +201,9 @@
     </div>
   </footer>
 
-  <script src="data.js?v=20260417e"></script>
-  <script src="progress.js?v=20260417e"></script>
-  <script src="header.js?v=20260417e" defer></script>
+  <script src="data.js?v=20260424a"></script>
+  <script src="progress.js?v=20260424a"></script>
+  <script src="header.js?v=20260424a" defer></script>
   <script>
     (function () {
       var root = document.documentElement;

--- a/site/index.html
+++ b/site/index.html
@@ -17,9 +17,9 @@
   <meta name="twitter:image" content="https://aiengineeringfromscratch.com/og-image.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Kalam:wght@400;700&family=Patrick+Hand&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Kalam:wght@400;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
   <script type="module" src="https://unpkg.com/@splinetool/viewer@1.9.82/build/spline-viewer.js"></script>
-  <link rel="stylesheet" href="style.css?v=20260417e">
+  <link rel="stylesheet" href="style.css?v=20260424a">
 </head>
 <body>
 
@@ -268,10 +268,10 @@
     </div>
   </footer>
 
-  <script src="data.js?v=20260417e"></script>
-  <script src="progress.js?v=20260417e"></script>
-  <script src="header.js?v=20260417e" defer></script>
-  <script src="app.js?v=20260417e"></script>
+  <script src="data.js?v=20260424a"></script>
+  <script src="progress.js?v=20260424a"></script>
+  <script src="header.js?v=20260424a" defer></script>
+  <script src="app.js?v=20260424a"></script>
 <script defer src="https://va.vercel-scripts.com/v1/script.js"></script>
 </body>
 </html>

--- a/site/lesson.html
+++ b/site/lesson.html
@@ -8,8 +8,8 @@
   <meta name="description" content="AI Engineering from Scratch - Lesson Viewer">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Kalam:wght@400;700&family=Patrick+Hand&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css?v=20260417e">
+  <link href="https://fonts.googleapis.com/css2?family=Kalam:wght@400;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css?v=20260424a">
   <style>
     .scroll-progress {
       position: fixed;
@@ -1755,9 +1755,9 @@
     </main>
   </div>
 
-  <script src="data.js?v=20260417e"></script>
-  <script src="progress.js?v=20260417e"></script>
-  <script src="header.js?v=20260417e" defer></script>
+  <script src="data.js?v=20260424a"></script>
+  <script src="progress.js?v=20260424a"></script>
+  <script src="header.js?v=20260424a" defer></script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
     mermaid.initialize({

--- a/site/prereqs.html
+++ b/site/prereqs.html
@@ -8,8 +8,8 @@
   <meta name="description" content="Interactive prerequisite map for 260+ AI engineering lessons. See which phases depend on which, and plan your learning path.">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Kalam:wght@400;700&family=Patrick+Hand&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css?v=20260417e">
+  <link href="https://fonts.googleapis.com/css2?family=Kalam:wght@400;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css?v=20260424a">
   <style>
     /* ===================================================
        Learning Path — Page Styles
@@ -445,9 +445,9 @@
     </div>
   </footer>
 
-  <script src="data.js?v=20260417e"></script>
-  <script src="progress.js?v=20260417e"></script>
-  <script src="header.js?v=20260417e" defer></script>
+  <script src="data.js?v=20260424a"></script>
+  <script src="progress.js?v=20260424a"></script>
+  <script src="header.js?v=20260424a" defer></script>
   <script>
   (function () {
     /* ===================================================

--- a/site/style.css
+++ b/site/style.css
@@ -1,6 +1,6 @@
 :root {
-  --font-heading: 'Kalam', cursive;
-  --font-body: 'Patrick Hand', cursive;
+  --font-heading: 'Kalam', 'Inter', system-ui, sans-serif;
+  --font-body: 'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', sans-serif;
   --font-mono: 'JetBrains Mono', 'Consolas', monospace;
 
   --bg: #0d0d18;


### PR DESCRIPTION
Closes #38.

## Problem

Reported by @sadanandpai in #38: Patrick Hand cursive body font was fancy at first glance but hard to read through long lesson documents (180-260 lines). Target audience is serious learners reading dense technical content.

## Fix

- `--font-body`: Patrick Hand cursive → Inter + system-font fallback
- `--font-heading`: Kalam retained (editorial personality on short headings)
- `--font-mono`: JetBrains Mono unchanged
- Google Fonts import updated across all 5 HTML files
- Cache-bust version bumped `v=20260424a`

## Test plan

- [ ] Deploy preview renders body text in Inter
- [ ] Headings still render in Kalam
- [ ] Code blocks still in JetBrains Mono
- [ ] SVGs in lessons unchanged (Georgia editorial)
- [ ] Reported issue #38 visibly improved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated site typography with the new `Inter` font family for body text, improving readability and consistency across all pages.
  * Refined heading typography to use `Kalam` with `Inter` fallback for better visual hierarchy.
  * Optimized font stack with system-level font fallbacks for improved performance across devices.

* **Chores**
  * Cleared browser cache for all stylesheets and scripts to ensure users load the latest assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->