### PR TITLE
fix(site): CodeRabbit nitpicks — progressive-enhancement search, focus-visible, prefill UX

### DIFF
--- a/site/app.js
+++ b/site/app.js
@@ -19,6 +19,7 @@
     initCopyButton();
     initSmoothScroll();
     initFadeObserver();
+    initHeroSearch();
   });
 
   function updateThemeIcon() {
@@ -332,6 +333,21 @@
           target.scrollIntoView({ behavior: 'smooth' });
         }
       });
+    });
+  }
+
+  function initHeroSearch() {
+    var form = document.querySelector('.hero-search');
+    if (!form) return;
+    form.addEventListener('submit', function (e) {
+      var input = form.querySelector('input[name="q"]');
+      if (!input) return;
+      var trimmed = input.value.trim();
+      if (!trimmed) {
+        e.preventDefault();
+        return;
+      }
+      input.value = trimmed;
     });
   }
 

--- a/site/catalog.html
+++ b/site/catalog.html
@@ -409,6 +409,8 @@
         var urlQuery = new URLSearchParams(window.location.search).get('q');
         if (urlQuery) {
           searchInput.value = urlQuery;
+          try { searchInput.setSelectionRange(urlQuery.length, urlQuery.length); } catch (_) {}
+          try { searchInput.focus({ preventScroll: true }); } catch (_) { searchInput.focus(); }
         }
 
         searchInput.addEventListener('input', render);

--- a/site/index.html
+++ b/site/index.html
@@ -83,7 +83,7 @@
           <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" style="display:inline;vertical-align:middle;margin-right:6px;"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>Star on GitHub
         </a>
       </div>
-      <form class="hero-search" role="search" onsubmit="event.preventDefault(); var q = this.q.value.trim(); if (q) location.href = 'catalog.html?q=' + encodeURIComponent(q);">
+      <form class="hero-search" role="search" action="catalog.html" method="get">
         <input type="search" name="q" placeholder="Search 299 lessons (e.g. 'attention', 'RLHF', 'MCP')..." aria-label="Search lessons">
         <button type="submit" class="btn btn-secondary">Search</button>
       </form>

--- a/site/style.css
+++ b/site/style.css
@@ -373,6 +373,11 @@ a:hover {
   border-color: var(--accent);
 }
 
+.hero-search input[type="search"]:focus-visible {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 30%, transparent);
+}
+
 .hero-stars {
   text-align: center;
 }


### PR DESCRIPTION
Follow-up to PR #76. Addresses 3 CodeRabbit nitpicks:

1. Hero search form: `onsubmit` inline handler -> native `action="catalog.html" method="get"`. Form works with JS disabled or strict CSP. Behavior (trim + skip-empty) moved to `app.js#initHeroSearch`.
2. Catalog prefill UX: focus + caret-at-end when `?q=` auto-populates the search.
3. Focus indicator a11y: added `:focus-visible` 3px `box-shadow` ring using `color-mix(in srgb, var(--accent) 30%, transparent)` — stronger keyboard cue without polluting mouse-focus state.

## Smoke tests
- `node --check site/app.js` passes
- HTML round-trips with `html.parser`

## Test plan
- [ ] Landing search with JS disabled still routes to catalog
- [ ] Tab to search input shows visible focus ring
- [ ] Catalog with `?q=attention` focuses + carets to end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search input now auto-focuses on results page with cursor automatically positioned
  * Added keyboard focus visual styling for improved accessibility

* **Bug Fixes**
  * Search form now properly trims whitespace from input and prevents empty submissions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->