### PR TITLE
chore: edge cache headers + agent-aware robots.txt

### DIFF
--- a/site/robots.txt
+++ b/site/robots.txt
@@ -1,0 +1,122 @@
+# Humans + agents welcome. Training crawlers + SEO scrapers blocked.
+
+# --- Allowed: search engines (send humans) ---
+User-agent: Googlebot
+Allow: /
+
+User-agent: Bingbot
+Allow: /
+
+User-agent: DuckDuckBot
+Allow: /
+
+# --- Allowed: agent browsers (user-initiated, send AI users) ---
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Perplexity-User
+Allow: /
+
+User-agent: Claude-User
+Allow: /
+
+User-agent: Claude-SearchBot
+Allow: /
+
+User-agent: Applebot
+Allow: /
+
+# --- Blocked: training crawlers ---
+User-agent: GPTBot
+Disallow: /
+
+User-agent: ClaudeBot
+Disallow: /
+
+User-agent: anthropic-ai
+Disallow: /
+
+User-agent: CCBot
+Disallow: /
+
+User-agent: Google-Extended
+Disallow: /
+
+User-agent: Applebot-Extended
+Disallow: /
+
+User-agent: Bytespider
+Disallow: /
+
+User-agent: Amazonbot
+Disallow: /
+
+User-agent: FacebookBot
+Disallow: /
+
+User-agent: Meta-ExternalAgent
+Disallow: /
+
+User-agent: cohere-ai
+Disallow: /
+
+User-agent: Diffbot
+Disallow: /
+
+User-agent: ImagesiftBot
+Disallow: /
+
+User-agent: Omgilibot
+Disallow: /
+
+User-agent: peer39_crawler
+Disallow: /
+
+User-agent: YouBot
+Disallow: /
+
+User-agent: Timpibot
+Disallow: /
+
+User-agent: ICC-Crawler
+Disallow: /
+
+# --- Blocked: SEO scrapers / link spammers ---
+User-agent: AhrefsBot
+Disallow: /
+
+User-agent: SemrushBot
+Disallow: /
+
+User-agent: MJ12bot
+Disallow: /
+
+User-agent: DotBot
+Disallow: /
+
+User-agent: PetalBot
+Disallow: /
+
+User-agent: BLEXBot
+Disallow: /
+
+User-agent: MegaIndex
+Disallow: /
+
+User-agent: SeznamBot
+Disallow: /
+
+User-agent: DataForSeoBot
+Disallow: /
+
+# --- Default: humans + everything else allowed ---
+User-agent: *
+Allow: /
+
+Sitemap: https://ai-engineering-from-scratch.vercel.app/sitemap.xml

--- a/vercel.json
+++ b/vercel.json
@@ -27,6 +27,12 @@
       "headers": [
         { "key": "Cache-Control", "value": "public, max-age=300, s-maxage=86400, stale-while-revalidate=604800" }
       ]
+    },
+    {
+      "source": "/(glossary|catalog|path|roadmap)",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=300, s-maxage=86400, stale-while-revalidate=604800" }
+      ]
     }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -8,5 +8,25 @@
     { "source": "/catalog", "destination": "/catalog.html" },
     { "source": "/path", "destination": "/prereqs.html" },
     { "source": "/roadmap", "destination": "/prereqs.html" }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)\\.(css|js|png|jpg|jpeg|svg|webp|woff2|woff|ttf|ico)",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=86400, s-maxage=604800, stale-while-revalidate=2592000" }
+      ]
+    },
+    {
+      "source": "/(.*)\\.html",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=300, s-maxage=86400, stale-while-revalidate=604800" }
+      ]
+    },
+    {
+      "source": "/",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=300, s-maxage=86400, stale-while-revalidate=604800" }
+      ]
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- Add `Cache-Control` headers to `vercel.json` for assets and HTML so returning visitors stop refetching from Vercel edge
- Add `site/robots.txt` allowing search bots and user-initiated agent browsers (ChatGPT-User, Claude-User, PerplexityBot, OAI-SearchBot, Applebot, DuckDuckBot, Bingbot, Googlebot) while disallowing training crawlers and SEO scrapers

## Why
Vercel hobby plan edge-request budget hit by:
1. Bot/crawler traffic (training + SEO scrapers)
2. Returning visitors refetching uncached static assets

Site stays human-first AND agent-first — explicit allows for legitimate agent browsing, explicit disallows for training data harvesting.

## Bot policy
**Allowed (search + user-initiated agents):**
Googlebot, Bingbot, DuckDuckBot, Applebot, ChatGPT-User, OAI-SearchBot, PerplexityBot, Perplexity-User, Claude-User, Claude-SearchBot

**Disallowed (training + SEO spam):**
GPTBot, ClaudeBot, anthropic-ai, CCBot, Google-Extended, Applebot-Extended, Bytespider, Amazonbot, Meta-ExternalAgent, cohere-ai, Diffbot, ImagesiftBot, Omgilibot, peer39_crawler, YouBot, Timpibot, ICC-Crawler, AhrefsBot, SemrushBot, MJ12bot, DotBot, PetalBot, BLEXBot, MegaIndex, SeznamBot, DataForSeoBot

## Test plan
- [ ] Vercel preview build succeeds
- [ ] `/robots.txt` returns 200 with expected content
- [ ] Asset response includes `Cache-Control: public, max-age=86400, ...`
- [ ] HTML response includes `Cache-Control: public, max-age=300, ...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced search engine indexing and crawler management via a new robots policy that whitelists mainstream engines, restricts known training/scraping bots, and publishes a sitemap.
  * Improved site performance through a refined caching strategy that applies longer cache lifetimes to static assets and shorter, fresher caching to HTML and key pages for quicker content updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->