### PR TITLE
fix(site): mobile responsiveness — header, lesson body, catalog, stat block, TOC

### DIFF
--- a/site/catalog.html
+++ b/site/catalog.html
@@ -93,6 +93,7 @@
       width: 100%;
       border-collapse: collapse;
       font-size: 0.95rem;
+      min-width: 640px;
     }
 
     .catalog-table th {

--- a/site/index.html
+++ b/site/index.html
@@ -305,11 +305,15 @@
 
     .colophon-grid {
       display: grid;
-      grid-template-columns: 200px 1fr;
+      grid-template-columns: 200px minmax(0, 1fr);
       gap: 48px;
       font-family: var(--font-body);
       font-size: 0.96rem;
       color: var(--ink-soft);
+    }
+
+    .colophon-grid > div {
+      min-width: 0;
     }
 
     .colophon-eyebrow {
@@ -321,7 +325,7 @@
     }
 
     .colophon-cmd {
-      display: inline-flex;
+      display: flex;
       align-items: center;
       gap: 12px;
       margin-top: 16px;
@@ -331,10 +335,21 @@
       font-family: var(--font-mono);
       font-size: 0.85rem;
       color: var(--blueprint);
+      max-width: 100%;
+      overflow-x: auto;
+      -webkit-overflow-scrolling: touch;
     }
 
     .colophon-cmd code {
       white-space: nowrap;
+    }
+
+    .colophon-cmd .copy-btn {
+      flex-shrink: 0;
+      position: sticky;
+      right: 0;
+      background: var(--code-bg);
+      padding-left: 8px;
     }
 
     @media (max-width: 900px) {
@@ -349,17 +364,17 @@
       }
 
       .stat-row {
-        grid-template-columns: 140px 1fr 70px;
-        gap: 10px;
+        grid-template-columns: 160px minmax(0, 1fr) 92px;
+        gap: 12px;
         font-size: 0.82rem;
       }
 
-      .stat-row-bar {
-        font-size: 0.76rem;
+      .toc-row {
+        grid-template-columns: 36px 1fr auto;
       }
 
-      .toc-row {
-        grid-template-columns: 40px 1fr auto;
+      .toc-row .toc-meta + .toc-meta {
+        display: none;
       }
 
       .toc-leader {
@@ -368,6 +383,54 @@
 
       .toc-name {
         font-size: 1.1rem;
+      }
+
+      .colophon-cmd {
+        max-width: 100%;
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+      }
+    }
+
+    @media (max-width: 480px) {
+      .manual-title {
+        font-size: clamp(2.4rem, 14vw, 3.6rem);
+        line-height: 0.92;
+      }
+
+      .stat-row {
+        grid-template-columns: 1fr;
+        gap: 4px;
+        padding: 6px 0;
+      }
+
+      .stat-row-bar {
+        order: 3;
+      }
+
+      .stat-row-value {
+        order: 2;
+        text-align: left;
+      }
+
+      .toc-row {
+        grid-template-columns: 30px 1fr auto;
+        gap: 10px;
+        padding: 12px 0;
+      }
+
+      .toc-name {
+        font-size: 0.96rem;
+        white-space: normal;
+      }
+
+      .toc-num {
+        font-size: 0.7rem;
+      }
+
+      .manual-meta-row {
+        font-size: 0.6rem;
+        letter-spacing: 0.12em;
       }
     }
   </style>

--- a/site/index.html
+++ b/site/index.html
@@ -353,24 +353,45 @@
     }
 
     @media (max-width: 900px) {
+      .manual-masthead { padding: 80px 0 16px; }
+      .preface { padding: 32px 0; }
+      .stat-block { padding: 32px 0; }
+      .toc { padding: 32px 0 40px; }
+      .colophon { padding: 32px 0; }
+
+      .manual-meta-row { margin-bottom: 20px; }
+      .manual-tagline { margin: 20px 0 6px; font-size: 1rem; }
+      .manual-attribution { font-size: 0.9rem; }
+
       .preface-grid,
       .colophon-grid {
         grid-template-columns: 1fr;
-        gap: 16px;
+        gap: 12px;
       }
 
       .preface-body {
         column-count: 1;
+        font-size: 0.98rem;
+        line-height: 1.65;
       }
 
+      .preface-body p:first-of-type::first-letter {
+        font-size: 3.2rem;
+      }
+
+      .stat-rows { gap: 8px; }
       .stat-row {
         grid-template-columns: 160px minmax(0, 1fr) 92px;
         gap: 12px;
         font-size: 0.82rem;
       }
+      .stat-block-title,
+      .toc-title { margin-bottom: 16px; }
+      .toc-subtitle { margin-bottom: 20px; }
 
       .toc-row {
         grid-template-columns: 36px 1fr auto;
+        padding: 11px 0;
       }
 
       .toc-row .toc-meta + .toc-meta {
@@ -393,14 +414,52 @@
     }
 
     @media (max-width: 480px) {
+      .manual-masthead { padding: 72px 0 12px; }
+      .preface { padding: 24px 0; }
+      .stat-block { padding: 24px 0; }
+      .toc { padding: 24px 0 32px; }
+      .colophon { padding: 24px 0; }
+
       .manual-title {
         font-size: clamp(2.4rem, 14vw, 3.6rem);
         line-height: 0.92;
       }
 
+      .manual-meta-row {
+        font-size: 0.6rem;
+        letter-spacing: 0.12em;
+        margin-bottom: 16px;
+        gap: 8px;
+      }
+
+      .manual-tagline {
+        font-size: 0.96rem;
+        margin: 16px 0 4px;
+      }
+
+      .ascii-rule {
+        margin: 16px 0;
+      }
+
+      .preface-eyebrow,
+      .stat-block-title,
+      .toc-title,
+      .colophon-eyebrow { font-size: 0.7rem; }
+
+      .preface-body {
+        font-size: 0.94rem;
+        line-height: 1.6;
+        text-align: left;
+      }
+
+      .preface-body p:first-of-type::first-letter {
+        font-size: 2.8rem;
+        padding: 0.04em 0.1em 0 0;
+      }
+
       .stat-row {
         grid-template-columns: 1fr;
-        gap: 4px;
+        gap: 2px;
         padding: 6px 0;
       }
 
@@ -415,8 +474,8 @@
 
       .toc-row {
         grid-template-columns: 30px 1fr auto;
-        gap: 10px;
-        padding: 12px 0;
+        gap: 8px;
+        padding: 10px 0;
       }
 
       .toc-name {
@@ -426,11 +485,6 @@
 
       .toc-num {
         font-size: 0.7rem;
-      }
-
-      .manual-meta-row {
-        font-size: 0.6rem;
-        letter-spacing: 0.12em;
       }
     }
   </style>

--- a/site/lesson.html
+++ b/site/lesson.html
@@ -153,6 +153,7 @@
 
     .lesson-main {
       flex: 1;
+      min-width: 0;
       margin-left: 240px;
       display: flex;
       justify-content: center;
@@ -162,6 +163,13 @@
     .lesson-content {
       max-width: 720px;
       width: 100%;
+      min-width: 0;
+    }
+
+    .lesson-article {
+      max-width: 100%;
+      overflow-wrap: break-word;
+      word-wrap: break-word;
     }
 
     .lesson-loading {
@@ -1444,8 +1452,16 @@
     @media (max-width: 900px) {
       .lesson-sidebar { transform: translateX(-100%); }
       .lesson-sidebar.open { transform: translateX(0); }
-      .lesson-sidebar-toggle { display: flex; }
-      .lesson-main { margin-left: 0; padding: 40px 20px 80px; }
+      .lesson-sidebar-toggle {
+        display: flex;
+        top: 70px;
+        right: 12px;
+        left: auto;
+        width: 32px;
+        height: 32px;
+        font-size: 0.95rem;
+      }
+      .lesson-main { margin-left: 0; padding: 56px 20px 80px; }
     }
 
     @media (max-width: 768px) {

--- a/site/lesson.html
+++ b/site/lesson.html
@@ -1465,7 +1465,7 @@
     }
 
     @media (max-width: 768px) {
-      .lesson-main { padding: 32px 16px 60px; }
+      .lesson-main { padding: 56px 16px 60px; }
       .lesson-article { max-width: 100%; }
       .lesson-article p,
       .lesson-article ul li,

--- a/site/style.css
+++ b/site/style.css
@@ -801,7 +801,35 @@ p.dropcap::first-letter {
 
   .header-inner {
     height: 56px;
-    padding: 0 16px;
+    padding: 0 12px;
+    gap: 8px;
+  }
+
+  .logo {
+    font-size: 1.2rem;
+    gap: 6px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    flex-shrink: 1;
+    min-width: 0;
+  }
+
+  .header-nav {
+    gap: 8px;
+    flex-shrink: 0;
+  }
+
+  .header-github {
+    padding: 4px 8px;
+    font-size: 0.7rem;
+    gap: 4px;
+  }
+
+  .theme-toggle {
+    width: 32px;
+    height: 32px;
+    flex-shrink: 0;
   }
 
   .container {
@@ -859,6 +887,36 @@ p.dropcap::first-letter {
 @media (max-width: 480px) {
   body {
     font-size: 16px;
+  }
+
+  .header-inner {
+    padding: 0 10px;
+    gap: 6px;
+  }
+
+  .logo {
+    font-size: 1rem;
+    letter-spacing: 0.02em;
+  }
+
+  .logo-icon {
+    width: 10px;
+    height: 10px;
+  }
+
+  .header-github {
+    padding: 3px 6px;
+    font-size: 0.65rem;
+  }
+
+  .header-github .star-count {
+    font-size: 0.7rem;
+  }
+
+  .theme-toggle {
+    width: 30px;
+    height: 30px;
+    font-size: 0.85rem;
   }
 }
 


### PR DESCRIPTION
## Summary

Site looked great on desktop but broke on mobile (375x812 default). Root issues found via browse + DOM inspection (\`document.body.scrollWidth\` was 752px on a 375px viewport):

| Bug | Cause | Fix |
|---|---|---|
| Header logo wraps to 2 lines | logo font 1.6rem + GitHub badge + theme toggle don't fit at 375px | Shrink logo to 1.2rem (≤768) and 1rem (≤480), tighten badge padding, shrink toggle to 30×30 |
| Lesson body overflows viewport | .lesson-main was flex child without min-width:0 → grew to content natural size | Add min-width:0 to .lesson-main + .lesson-content, max-width:100% + overflow-wrap on .lesson-article |
| Sidebar toggle overlaps H1 | toggle at left:10/top:74 collided with article title on narrow viewports | Move to right:12/top:70, shrink to 32×32, bump lesson-main top padding |
| Stat block "416 / 416" wraps + bar clips | value column 70px too narrow, bar 1fr unbounded | Widen to 92px, minmax(0, 1fr) on bar, stack vertically at ≤480 |
| TOC page number wraps below row | row had 4 cells but mobile grid was 3 cols | Hide the second .toc-meta on mobile |
| Colophon paragraph overflows | inline-flex cmd box with white-space:nowrap on long clone URL stretched the grid column | display:flex + max-width:100% + overflow-x:auto + min-width:0 on grid column; sticky copy button |
| Catalog table status column cut off | 5 cols squeezed into 375px | min-width:640px on .catalog-table; existing .catalog-table-wrap overflow-x scrolls it |

## Test plan

- [x] Header fits on a single line at 375px across all 4 pages
- [x] Lesson body wraps inside viewport, no horizontal scroll on body itself
- [x] Stat block fits with all 4 rows readable
- [x] TOC rows show roman numeral + status + name + fraction (no orphan page-number row)
- [x] Colophon paragraph wraps cleanly, code box scrolls horizontally inside its own bounds
- [x] Catalog table scrolls horizontally to reach Type / Lang / Status
- [x] Lesson sidebar toggle visible top-right, doesn't collide with H1
- [x] Both light and dark modes still render correctly
- [x] Theme toggle persists via localStorage

## What's NOT in this PR

- README docs rebuild → tracked in #89 (separate branch)
- Phase 2 structural pass on catalog/glossary/prereqs → planned PR-2
- FIG callout system + status glyph SVGs → planned PR-4
- blueprint-diagram skill → planned PR-5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved responsive layout and horizontal overflow handling across pages for better mobile and tablet experiences
  * Enhanced header spacing and scaled typography/icons for smaller screens (≤768px and ≤480px)
  * Prevented lesson and catalog content from shrinking; improved long-content wrapping and table stability
  * Refined colophon and metadata area to allow horizontal scrolling and sticky controls on narrow viewports
  * Adjusted sidebar toggle sizing and top spacing for compact screens

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/ai-engineering-from-scratch/pull/90)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->