### PR TITLE
docs(readme): bust banner cache with ?v=2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="assets/banner.svg" alt="AI Engineering from Scratch — reference manual banner" width="100%">
+  <img src="assets/banner.svg?v=2" alt="AI Engineering from Scratch — reference manual banner" width="100%">
 </p>
 
 <p align="center">


### PR DESCRIPTION
## What

Append \`?v=2\` to the banner image URL in README so GitHub re-fetches it.

## Why

After #89 merged, \`assets/banner.svg\` is the new blueprint banner on \`raw.githubusercontent.com\` (verified — 1280×420 viewBox, FIG_000 caption, ASCII rule strip). But the README on github.com still renders the old dark gradient banner because GitHub's image proxy (camo) caches by URL and the URL didn't change.

Cache-busting query string forces a fresh fetch.

## Test plan

- [ ] Open https://github.com/rohitg00/ai-engineering-from-scratch after merge — banner shows the cream + blueprint version with VT323 wordmark and isometric stack
- [ ] Hard-refresh in case browser also cached

## Going forward

Bump \`?v=N\` on every banner edit. Or rename the file. Or use a commit-pinned URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the banner image asset reference in the README.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/ai-engineering-from-scratch/pull/92)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->