### PR TITLE
feat(figures): blueprint-diagram skill + 2 sample figures (FIG_004 gaussian kernel, FIG_005 attention heads)

### DIFF
--- a/site/assets/figures/004-gaussian-kernel-blur.svg
+++ b/site/assets/figures/004-gaussian-kernel-blur.svg
@@ -1,0 +1,172 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="700" viewBox="0 0 1200 700" role="img" aria-label="FIG_004 — gaussian kernel and how it blurs an image, Hollick-style blueprint">
+  <defs>
+    <pattern id="paper" x="0" y="0" width="16" height="16" patternUnits="userSpaceOnUse">
+      <circle cx="0" cy="0" r="1" fill="#1a1a1a" fill-opacity="0.06"/>
+    </pattern>
+    <style>
+      .ink { fill: #1a1a1a; }
+      .mute { fill: #7a7a78; }
+      .bp { fill: #3553ff; }
+      .face { fill: rgba(53, 83, 255, 0.06); }
+      .face-strong { fill: rgba(53, 83, 255, 0.18); }
+      .stroke { stroke: #3553ff; fill: none; stroke-linejoin: miter; stroke-linecap: square; }
+      .mono { font-family: 'JetBrains Mono', ui-monospace, Consolas, monospace; }
+    </style>
+  </defs>
+
+  <rect width="1200" height="700" fill="#fafaf5"/>
+  <rect width="1200" height="700" fill="url(#paper)"/>
+
+  <text class="mono bp" x="40" y="44" font-size="11" letter-spacing="2.4">FIG_004</text>
+  <text class="mono mute" x="1160" y="44" font-size="11" letter-spacing="2.4" text-anchor="end">PHASE 01 · LESSON 08</text>
+
+  <!-- divider rule -->
+  <line x1="40" y1="64" x2="1160" y2="64" stroke="#3553ff" stroke-width="0.6" stroke-opacity="0.35"/>
+
+  <!-- LEFT: continuous bell-curve cross-section family -->
+  <g transform="translate(80, 120)">
+    <text class="mono bp" x="0" y="-20" font-size="9" letter-spacing="2">FIG_004.A — CONTINUOUS DISTRIBUTION</text>
+
+    <!-- axes -->
+    <g class="stroke" stroke-width="0.6" stroke-opacity="0.45">
+      <line x1="0" y1="280" x2="320" y2="280"/>
+      <line x1="0" y1="40" x2="0" y2="280"/>
+      <line x1="160" y1="280" x2="160" y2="290"/>
+    </g>
+
+    <!-- bell curve (gaussian) -->
+    <path class="stroke" stroke-width="2" d="M 0 280 Q 60 280 100 240 Q 160 60 220 240 Q 260 280 320 280"/>
+
+    <!-- shaded area under curve -->
+    <path class="face" d="M 0 280 Q 60 280 100 240 Q 160 60 220 240 Q 260 280 320 280 Z"/>
+
+    <!-- center marker μ -->
+    <line class="stroke" stroke-width="0.8" stroke-dasharray="3 3" x1="160" y1="60" x2="160" y2="280"/>
+    <text class="mono bp" x="166" y="80" font-size="10" letter-spacing="1.6">μ</text>
+
+    <!-- σ markers -->
+    <line class="stroke" stroke-width="0.6" stroke-opacity="0.6" x1="100" y1="240" x2="100" y2="280"/>
+    <line class="stroke" stroke-width="0.6" stroke-opacity="0.6" x1="220" y1="240" x2="220" y2="280"/>
+    <text class="mono mute" x="92" y="300" font-size="9" letter-spacing="1.4">−σ</text>
+    <text class="mono mute" x="216" y="300" font-size="9" letter-spacing="1.4">+σ</text>
+    <text class="mono mute" x="156" y="300" font-size="9" letter-spacing="1.4">μ</text>
+    <text class="mono ink" x="0" y="320" font-size="11">G(x) = (1 / σ√2π) · exp(−x² / 2σ²)</text>
+  </g>
+
+  <!-- MIDDLE: discrete 5x5 kernel grid -->
+  <g transform="translate(480, 120)">
+    <text class="mono bp" x="0" y="-20" font-size="9" letter-spacing="2">FIG_004.B — DISCRETE 5 × 5 KERNEL</text>
+
+    <!-- 5x5 cells -->
+    <g class="stroke" stroke-width="1">
+      <rect class="face" x="0"   y="0"   width="48" height="48"/>
+      <rect class="face" x="48"  y="0"   width="48" height="48"/>
+      <rect class="face" x="96"  y="0"   width="48" height="48"/>
+      <rect class="face" x="144" y="0"   width="48" height="48"/>
+      <rect class="face" x="192" y="0"   width="48" height="48"/>
+
+      <rect class="face" x="0"   y="48"  width="48" height="48"/>
+      <rect class="face" x="48"  y="48"  width="48" height="48"/>
+      <rect class="face-strong" x="96"  y="48"  width="48" height="48"/>
+      <rect class="face" x="144" y="48"  width="48" height="48"/>
+      <rect class="face" x="192" y="48"  width="48" height="48"/>
+
+      <rect class="face" x="0"   y="96"  width="48" height="48"/>
+      <rect class="face-strong" x="48"  y="96"  width="48" height="48"/>
+      <rect class="face-strong" x="96"  y="96"  width="48" height="48"/>
+      <rect class="face-strong" x="144" y="96"  width="48" height="48"/>
+      <rect class="face" x="192" y="96"  width="48" height="48"/>
+
+      <rect class="face" x="0"   y="144" width="48" height="48"/>
+      <rect class="face" x="48"  y="144" width="48" height="48"/>
+      <rect class="face-strong" x="96"  y="144" width="48" height="48"/>
+      <rect class="face" x="144" y="144" width="48" height="48"/>
+      <rect class="face" x="192" y="144" width="48" height="48"/>
+
+      <rect class="face" x="0"   y="192" width="48" height="48"/>
+      <rect class="face" x="48"  y="192" width="48" height="48"/>
+      <rect class="face" x="96"  y="192" width="48" height="48"/>
+      <rect class="face" x="144" y="192" width="48" height="48"/>
+      <rect class="face" x="192" y="192" width="48" height="48"/>
+
+      <rect x="0"   y="0"   width="240" height="240"/>
+    </g>
+
+    <!-- per-cell weights -->
+    <g class="mono bp" font-size="11" letter-spacing="1" text-anchor="middle">
+      <text x="24"  y="29">1</text>
+      <text x="72"  y="29">4</text>
+      <text x="120" y="29">7</text>
+      <text x="168" y="29">4</text>
+      <text x="216" y="29">1</text>
+
+      <text x="24"  y="77">4</text>
+      <text x="72"  y="77">16</text>
+      <text x="120" y="77">26</text>
+      <text x="168" y="77">16</text>
+      <text x="216" y="77">4</text>
+
+      <text x="24"  y="125">7</text>
+      <text x="72"  y="125">26</text>
+      <text x="120" y="125">41</text>
+      <text x="168" y="125">26</text>
+      <text x="216" y="125">7</text>
+
+      <text x="24"  y="173">4</text>
+      <text x="72"  y="173">16</text>
+      <text x="120" y="173">26</text>
+      <text x="168" y="173">16</text>
+      <text x="216" y="173">4</text>
+
+      <text x="24"  y="221">1</text>
+      <text x="72"  y="221">4</text>
+      <text x="120" y="221">7</text>
+      <text x="168" y="221">4</text>
+      <text x="216" y="221">1</text>
+    </g>
+
+    <text class="mono ink" x="0" y="270" font-size="11">DIVIDE BY 273 TO NORMALIZE</text>
+    <text class="mono mute" x="0" y="288" font-size="10">σ ≈ 1.0  ·  RADIUS = 2 PX</text>
+  </g>
+
+  <!-- RIGHT: result on a sample image (3 stages: original, blurred small, blurred large) -->
+  <g transform="translate(820, 120)">
+    <text class="mono bp" x="0" y="-20" font-size="9" letter-spacing="2">FIG_004.C — APPLIED</text>
+
+    <!-- ORIGINAL -->
+    <g transform="translate(0, 0)">
+      <rect class="stroke" stroke-width="1.2" x="0" y="0" width="120" height="80"/>
+      <rect class="bp" x="20" y="20" width="80" height="40" opacity="0.85"/>
+      <text class="mono mute" x="0" y="100" font-size="9" letter-spacing="1.4">σ = 0</text>
+    </g>
+
+    <!-- σ = 1 -->
+    <g transform="translate(140, 0)">
+      <rect class="stroke" stroke-width="1.2" x="0" y="0" width="120" height="80"/>
+      <rect class="bp" x="22" y="22" width="76" height="36" opacity="0.6"/>
+      <rect class="face-strong" x="14" y="14" width="92" height="52"/>
+      <text class="mono mute" x="0" y="100" font-size="9" letter-spacing="1.4">σ = 1</text>
+    </g>
+
+    <!-- σ = 2 -->
+    <g transform="translate(0, 130)">
+      <rect class="stroke" stroke-width="1.2" x="0" y="0" width="120" height="80"/>
+      <rect class="bp" x="28" y="26" width="64" height="28" opacity="0.4"/>
+      <rect class="face-strong" x="18" y="18" width="84" height="44"/>
+      <rect class="face" x="6" y="6" width="108" height="68"/>
+      <text class="mono mute" x="0" y="100" font-size="9" letter-spacing="1.4">σ = 2</text>
+    </g>
+
+    <!-- σ = 4 -->
+    <g transform="translate(140, 130)">
+      <rect class="stroke" stroke-width="1.2" x="0" y="0" width="120" height="80"/>
+      <rect class="face-strong" x="20" y="18" width="80" height="44"/>
+      <rect class="face" x="0" y="0" width="120" height="80"/>
+      <text class="mono mute" x="0" y="100" font-size="9" letter-spacing="1.4">σ = 4</text>
+    </g>
+  </g>
+
+  <!-- bottom rule -->
+  <line x1="40" y1="640" x2="1160" y2="640" stroke="#3553ff" stroke-width="0.6" stroke-opacity="0.35"/>
+  <text class="mono mute" x="1160" y="668" font-size="10" letter-spacing="2" text-anchor="end">© FIG_004 · GAUSSIAN KERNEL · MIT</text>
+</svg>

--- a/site/assets/figures/005-transformer-attention-heads.svg
+++ b/site/assets/figures/005-transformer-attention-heads.svg
@@ -1,0 +1,100 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="800" viewBox="0 0 1200 800" role="img" aria-label="FIG_005 — exploded view of multi-head attention block in a transformer encoder">
+  <defs>
+    <pattern id="paper" x="0" y="0" width="16" height="16" patternUnits="userSpaceOnUse">
+      <circle cx="0" cy="0" r="1" fill="#1a1a1a" fill-opacity="0.06"/>
+    </pattern>
+    <style>
+      .mute { fill: #7a7a78; }
+      .bp { fill: #3553ff; }
+      .face { fill: rgba(53, 83, 255, 0.06); }
+      .face-strong { fill: rgba(53, 83, 255, 0.18); }
+      .stroke { stroke: #3553ff; fill: none; stroke-linejoin: miter; stroke-linecap: square; }
+      .mono { font-family: 'JetBrains Mono', ui-monospace, Consolas, monospace; }
+    </style>
+  </defs>
+
+  <rect width="1200" height="800" fill="#fafaf5"/>
+  <rect width="1200" height="800" fill="url(#paper)"/>
+
+  <text class="mono bp" x="40" y="44" font-size="11" letter-spacing="2.4">FIG_005</text>
+  <text class="mono mute" x="1160" y="44" font-size="11" letter-spacing="2.4" text-anchor="end">PHASE 07 · LESSON 01 · MULTI-HEAD ATTENTION</text>
+  <line x1="40" y1="64" x2="1160" y2="64" stroke="#3553ff" stroke-width="0.6" stroke-opacity="0.35"/>
+
+  <!-- Stack of 4 heads, isometric exploded -->
+  <g transform="translate(160, 180)">
+    <!-- 4 heads stacked back-to-front, each with Q K V slots -->
+    <g transform="translate(0, 240)">
+      <polygon class="face-strong" points="0,0 320,-100 480,-50 160,50"/>
+      <polygon class="stroke" stroke-width="1.4" points="0,0 320,-100 480,-50 160,50"/>
+      <text class="mono bp" x="40" y="-30" font-size="11" letter-spacing="1.6">HEAD 4 · OUTPUT</text>
+    </g>
+    <g transform="translate(20, 180)">
+      <polygon class="face" points="0,0 320,-100 480,-50 160,50"/>
+      <polygon class="stroke" stroke-width="1.4" points="0,0 320,-100 480,-50 160,50"/>
+      <text class="mono bp" x="40" y="-30" font-size="11" letter-spacing="1.6">HEAD 3</text>
+    </g>
+    <g transform="translate(40, 120)">
+      <polygon class="face" points="0,0 320,-100 480,-50 160,50"/>
+      <polygon class="stroke" stroke-width="1.4" points="0,0 320,-100 480,-50 160,50"/>
+      <text class="mono bp" x="40" y="-30" font-size="11" letter-spacing="1.6">HEAD 2</text>
+    </g>
+    <g transform="translate(60, 60)">
+      <polygon class="face" points="0,0 320,-100 480,-50 160,50"/>
+      <polygon class="stroke" stroke-width="1.4" points="0,0 320,-100 480,-50 160,50"/>
+      <text class="mono bp" x="40" y="-30" font-size="11" letter-spacing="1.6">HEAD 1</text>
+    </g>
+
+    <!-- Q K V vectors on top head, drawn as 3 small parallelograms -->
+    <g transform="translate(80, 0)">
+      <g transform="translate(20, 10)">
+        <rect class="face-strong" x="0" y="0" width="60" height="20" transform="skewX(-22)"/>
+        <rect class="stroke" stroke-width="1" x="0" y="0" width="60" height="20" transform="skewX(-22)"/>
+        <text class="mono bp" x="20" y="-6" font-size="10" letter-spacing="1.4">Q</text>
+      </g>
+      <g transform="translate(120, 10)">
+        <rect class="face-strong" x="0" y="0" width="60" height="20" transform="skewX(-22)"/>
+        <rect class="stroke" stroke-width="1" x="0" y="0" width="60" height="20" transform="skewX(-22)"/>
+        <text class="mono bp" x="20" y="-6" font-size="10" letter-spacing="1.4">K</text>
+      </g>
+      <g transform="translate(220, 10)">
+        <rect class="face-strong" x="0" y="0" width="60" height="20" transform="skewX(-22)"/>
+        <rect class="stroke" stroke-width="1" x="0" y="0" width="60" height="20" transform="skewX(-22)"/>
+        <text class="mono bp" x="20" y="-6" font-size="10" letter-spacing="1.4">V</text>
+      </g>
+    </g>
+  </g>
+
+  <!-- right-side leader lines + labels -->
+  <g class="stroke" stroke-width="0.8" stroke-dasharray="3 3">
+    <line x1="700" y1="160" x2="800" y2="120"/>
+    <line x1="720" y1="240" x2="800" y2="220"/>
+    <line x1="740" y1="320" x2="800" y2="320"/>
+    <line x1="760" y1="400" x2="800" y2="420"/>
+    <line x1="650" y1="200" x2="800" y2="540"/>
+    <line x1="650" y1="220" x2="800" y2="600"/>
+  </g>
+
+  <g class="mono bp" font-size="11" letter-spacing="1.6">
+    <text x="810" y="124">HEAD 1 · LOCAL SYNTAX</text>
+    <text x="810" y="224">HEAD 2 · NOUN-ADJ DEPS</text>
+    <text x="810" y="324">HEAD 3 · LONG-RANGE COREF</text>
+    <text x="810" y="424">HEAD 4 · OUTPUT POSITION</text>
+    <text x="810" y="544">EACH HEAD HAS ITS OWN W_Q, W_K, W_V</text>
+    <text x="810" y="604">CONCAT(HEADS) · W_O  →  D_MODEL DIM</text>
+  </g>
+  <g class="mono mute" font-size="9" letter-spacing="1.4">
+    <text x="810" y="138">attends to neighbors only</text>
+    <text x="810" y="238">attends from a noun back to its modifier</text>
+    <text x="810" y="338">attends across the sentence to track entities</text>
+    <text x="810" y="438">attends to the next-token slot</text>
+  </g>
+
+  <!-- math underneath -->
+  <g transform="translate(80, 660)">
+    <text class="mono ink" x="0" y="0" font-size="13" letter-spacing="0.6">Attention(Q, K, V) = softmax( Q · Kᵀ / √d_k ) · V</text>
+    <text class="mono mute" x="0" y="22" font-size="10" letter-spacing="1.4">PER HEAD · D_K = D_MODEL / N_HEADS</text>
+  </g>
+
+  <line x1="40" y1="740" x2="1160" y2="740" stroke="#3553ff" stroke-width="0.6" stroke-opacity="0.35"/>
+  <text class="mono mute" x="1160" y="768" font-size="10" letter-spacing="2" text-anchor="end">© FIG_005 · MULTI-HEAD ATTENTION · MIT</text>
+</svg>

--- a/site/assets/figures/005-transformer-attention-heads.svg
+++ b/site/assets/figures/005-transformer-attention-heads.svg
@@ -1,9 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="800" viewBox="0 0 1200 800" role="img" aria-label="FIG_005 — exploded view of multi-head attention block in a transformer encoder">
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="820" viewBox="0 0 1200 820" role="img" aria-label="FIG_005 — exploded view of multi-head attention block in a transformer encoder">
   <defs>
     <pattern id="paper" x="0" y="0" width="16" height="16" patternUnits="userSpaceOnUse">
       <circle cx="0" cy="0" r="1" fill="#1a1a1a" fill-opacity="0.06"/>
     </pattern>
     <style>
+      .ink { fill: #1a1a1a; }
       .mute { fill: #7a7a78; }
       .bp { fill: #3553ff; }
       .face { fill: rgba(53, 83, 255, 0.06); }
@@ -13,88 +14,104 @@
     </style>
   </defs>
 
-  <rect width="1200" height="800" fill="#fafaf5"/>
-  <rect width="1200" height="800" fill="url(#paper)"/>
+  <rect width="1200" height="820" fill="#fafaf5"/>
+  <rect width="1200" height="820" fill="url(#paper)"/>
 
   <text class="mono bp" x="40" y="44" font-size="11" letter-spacing="2.4">FIG_005</text>
   <text class="mono mute" x="1160" y="44" font-size="11" letter-spacing="2.4" text-anchor="end">PHASE 07 · LESSON 01 · MULTI-HEAD ATTENTION</text>
   <line x1="40" y1="64" x2="1160" y2="64" stroke="#3553ff" stroke-width="0.6" stroke-opacity="0.35"/>
 
-  <!-- Stack of 4 heads, isometric exploded -->
-  <g transform="translate(160, 180)">
-    <!-- 4 heads stacked back-to-front, each with Q K V slots -->
-    <g transform="translate(0, 240)">
-      <polygon class="face-strong" points="0,0 320,-100 480,-50 160,50"/>
-      <polygon class="stroke" stroke-width="1.4" points="0,0 320,-100 480,-50 160,50"/>
-      <text class="mono bp" x="40" y="-30" font-size="11" letter-spacing="1.6">HEAD 4 · OUTPUT</text>
-    </g>
-    <g transform="translate(20, 180)">
-      <polygon class="face" points="0,0 320,-100 480,-50 160,50"/>
-      <polygon class="stroke" stroke-width="1.4" points="0,0 320,-100 480,-50 160,50"/>
-      <text class="mono bp" x="40" y="-30" font-size="11" letter-spacing="1.6">HEAD 3</text>
-    </g>
-    <g transform="translate(40, 120)">
-      <polygon class="face" points="0,0 320,-100 480,-50 160,50"/>
-      <polygon class="stroke" stroke-width="1.4" points="0,0 320,-100 480,-50 160,50"/>
-      <text class="mono bp" x="40" y="-30" font-size="11" letter-spacing="1.6">HEAD 2</text>
-    </g>
-    <g transform="translate(60, 60)">
-      <polygon class="face" points="0,0 320,-100 480,-50 160,50"/>
-      <polygon class="stroke" stroke-width="1.4" points="0,0 320,-100 480,-50 160,50"/>
-      <text class="mono bp" x="40" y="-30" font-size="11" letter-spacing="1.6">HEAD 1</text>
-    </g>
+  <!-- INPUT row: Q K V projections, separated above the stack -->
+  <g transform="translate(120, 130)">
+    <text class="mono bp" x="0" y="0" font-size="9" letter-spacing="2">FIG_005.A — INPUT PROJECTIONS</text>
 
-    <!-- Q K V vectors on top head, drawn as 3 small parallelograms -->
-    <g transform="translate(80, 0)">
-      <g transform="translate(20, 10)">
-        <rect class="face-strong" x="0" y="0" width="60" height="20" transform="skewX(-22)"/>
-        <rect class="stroke" stroke-width="1" x="0" y="0" width="60" height="20" transform="skewX(-22)"/>
-        <text class="mono bp" x="20" y="-6" font-size="10" letter-spacing="1.4">Q</text>
-      </g>
-      <g transform="translate(120, 10)">
-        <rect class="face-strong" x="0" y="0" width="60" height="20" transform="skewX(-22)"/>
-        <rect class="stroke" stroke-width="1" x="0" y="0" width="60" height="20" transform="skewX(-22)"/>
-        <text class="mono bp" x="20" y="-6" font-size="10" letter-spacing="1.4">K</text>
-      </g>
-      <g transform="translate(220, 10)">
-        <rect class="face-strong" x="0" y="0" width="60" height="20" transform="skewX(-22)"/>
-        <rect class="stroke" stroke-width="1" x="0" y="0" width="60" height="20" transform="skewX(-22)"/>
-        <text class="mono bp" x="20" y="-6" font-size="10" letter-spacing="1.4">V</text>
-      </g>
+    <g transform="translate(40, 30)">
+      <rect class="face-strong" x="0" y="0" width="64" height="22" transform="skewX(-22)"/>
+      <rect class="stroke" stroke-width="1.2" x="0" y="0" width="64" height="22" transform="skewX(-22)"/>
+      <text class="mono bp" x="22" y="14" font-size="11" letter-spacing="1.6">Q</text>
+      <text class="mono mute" x="-4" y="46" font-size="8" letter-spacing="1.4">QUERY</text>
+    </g>
+    <g transform="translate(160, 30)">
+      <rect class="face-strong" x="0" y="0" width="64" height="22" transform="skewX(-22)"/>
+      <rect class="stroke" stroke-width="1.2" x="0" y="0" width="64" height="22" transform="skewX(-22)"/>
+      <text class="mono bp" x="22" y="14" font-size="11" letter-spacing="1.6">K</text>
+      <text class="mono mute" x="-4" y="46" font-size="8" letter-spacing="1.4">KEY</text>
+    </g>
+    <g transform="translate(280, 30)">
+      <rect class="face-strong" x="0" y="0" width="64" height="22" transform="skewX(-22)"/>
+      <rect class="stroke" stroke-width="1.2" x="0" y="0" width="64" height="22" transform="skewX(-22)"/>
+      <text class="mono bp" x="22" y="14" font-size="11" letter-spacing="1.6">V</text>
+      <text class="mono mute" x="-4" y="46" font-size="8" letter-spacing="1.4">VALUE</text>
     </g>
   </g>
 
-  <!-- right-side leader lines + labels -->
-  <g class="stroke" stroke-width="0.8" stroke-dasharray="3 3">
-    <line x1="700" y1="160" x2="800" y2="120"/>
-    <line x1="720" y1="240" x2="800" y2="220"/>
-    <line x1="740" y1="320" x2="800" y2="320"/>
-    <line x1="760" y1="400" x2="800" y2="420"/>
-    <line x1="650" y1="200" x2="800" y2="540"/>
-    <line x1="650" y1="220" x2="800" y2="600"/>
+  <!-- Stack of 4 attention heads, isometric, tall vertical spacing so labels never overlap -->
+  <g transform="translate(160, 270)">
+    <!-- Head 4 (bottom, emphasis) -->
+    <g transform="translate(60, 360)">
+      <polygon class="face-strong" points="0,0 320,-80 480,-40 160,40"/>
+      <polygon class="stroke" stroke-width="1.4" points="0,0 320,-80 480,-40 160,40"/>
+    </g>
+    <!-- Head 3 -->
+    <g transform="translate(40, 280)">
+      <polygon class="face" points="0,0 320,-80 480,-40 160,40"/>
+      <polygon class="stroke" stroke-width="1.4" points="0,0 320,-80 480,-40 160,40"/>
+    </g>
+    <!-- Head 2 -->
+    <g transform="translate(20, 200)">
+      <polygon class="face" points="0,0 320,-80 480,-40 160,40"/>
+      <polygon class="stroke" stroke-width="1.4" points="0,0 320,-80 480,-40 160,40"/>
+    </g>
+    <!-- Head 1 (top) -->
+    <g transform="translate(0, 120)">
+      <polygon class="face" points="0,0 320,-80 480,-40 160,40"/>
+      <polygon class="stroke" stroke-width="1.4" points="0,0 320,-80 480,-40 160,40"/>
+    </g>
+
+    <!-- leader lines from each head's right edge to right-margin labels -->
+    <g class="stroke" stroke-width="0.8" stroke-dasharray="3 3">
+      <line x1="500" y1="80"  x2="640" y2="-130"/>
+      <line x1="520" y1="160" x2="640" y2="-30"/>
+      <line x1="540" y1="240" x2="640" y2="70"/>
+      <line x1="560" y1="320" x2="640" y2="170"/>
+    </g>
   </g>
 
-  <g class="mono bp" font-size="11" letter-spacing="1.6">
-    <text x="810" y="124">HEAD 1 · LOCAL SYNTAX</text>
-    <text x="810" y="224">HEAD 2 · NOUN-ADJ DEPS</text>
-    <text x="810" y="324">HEAD 3 · LONG-RANGE COREF</text>
-    <text x="810" y="424">HEAD 4 · OUTPUT POSITION</text>
-    <text x="810" y="544">EACH HEAD HAS ITS OWN W_Q, W_K, W_V</text>
-    <text x="810" y="604">CONCAT(HEADS) · W_O  →  D_MODEL DIM</text>
-  </g>
-  <g class="mono mute" font-size="9" letter-spacing="1.4">
-    <text x="810" y="138">attends to neighbors only</text>
-    <text x="810" y="238">attends from a noun back to its modifier</text>
-    <text x="810" y="338">attends across the sentence to track entities</text>
-    <text x="810" y="438">attends to the next-token slot</text>
+  <!-- Right margin: per-head behavior labels -->
+  <g transform="translate(800, 160)">
+    <g transform="translate(0, 0)">
+      <text class="mono bp" x="0" y="0" font-size="11" letter-spacing="1.8">HEAD 1 · LOCAL SYNTAX</text>
+      <text class="mono mute" x="0" y="16" font-size="9" letter-spacing="1.2">attends to neighbors only</text>
+    </g>
+    <g transform="translate(0, 100)">
+      <text class="mono bp" x="0" y="0" font-size="11" letter-spacing="1.8">HEAD 2 · NOUN-ADJ DEPS</text>
+      <text class="mono mute" x="0" y="16" font-size="9" letter-spacing="1.2">attends from a noun back to its modifier</text>
+    </g>
+    <g transform="translate(0, 200)">
+      <text class="mono bp" x="0" y="0" font-size="11" letter-spacing="1.8">HEAD 3 · LONG-RANGE COREF</text>
+      <text class="mono mute" x="0" y="16" font-size="9" letter-spacing="1.2">attends across the sentence to track entities</text>
+    </g>
+    <g transform="translate(0, 300)">
+      <text class="mono bp" x="0" y="0" font-size="11" letter-spacing="1.8">HEAD 4 · OUTPUT POSITION</text>
+      <text class="mono mute" x="0" y="16" font-size="9" letter-spacing="1.2">attends to the next-token slot</text>
+    </g>
   </g>
 
-  <!-- math underneath -->
-  <g transform="translate(80, 660)">
-    <text class="mono ink" x="0" y="0" font-size="13" letter-spacing="0.6">Attention(Q, K, V) = softmax( Q · Kᵀ / √d_k ) · V</text>
-    <text class="mono mute" x="0" y="22" font-size="10" letter-spacing="1.4">PER HEAD · D_K = D_MODEL / N_HEADS</text>
+  <!-- Concat + W_O note -->
+  <g transform="translate(160, 700)">
+    <text class="mono bp" x="0" y="0" font-size="9" letter-spacing="2">FIG_005.B — OUTPUT</text>
+    <rect class="face" x="0" y="14" width="480" height="28"/>
+    <rect class="stroke" stroke-width="1.2" x="0" y="14" width="480" height="28"/>
+    <text class="mono ink" x="14" y="34" font-size="11" letter-spacing="0.8">CONCAT(HEAD₁, HEAD₂, HEAD₃, HEAD₄) · W_O  →  D_MODEL DIM</text>
   </g>
 
-  <line x1="40" y1="740" x2="1160" y2="740" stroke="#3553ff" stroke-width="0.6" stroke-opacity="0.35"/>
-  <text class="mono mute" x="1160" y="768" font-size="10" letter-spacing="2" text-anchor="end">© FIG_005 · MULTI-HEAD ATTENTION · MIT</text>
+  <!-- Math formula on the right under labels -->
+  <g transform="translate(800, 580)">
+    <text class="mono ink" x="0" y="0" font-size="13" letter-spacing="0.6">Attention(Q, K, V)</text>
+    <text class="mono ink" x="0" y="22" font-size="13" letter-spacing="0.6">= softmax( Q · Kᵀ / √d_k ) · V</text>
+    <text class="mono mute" x="0" y="44" font-size="9" letter-spacing="1.4">PER HEAD · D_K = D_MODEL / N_HEADS</text>
+  </g>
+
+  <line x1="40" y1="760" x2="1160" y2="760" stroke="#3553ff" stroke-width="0.6" stroke-opacity="0.35"/>
+  <text class="mono mute" x="1160" y="788" font-size="10" letter-spacing="2" text-anchor="end">© FIG_005 · MULTI-HEAD ATTENTION · MIT</text>
 </svg>

--- a/site/assets/figures/INDEX.md
+++ b/site/assets/figures/INDEX.md
@@ -1,0 +1,32 @@
+# Figure Index
+
+Every figure shipped under `site/assets/figures/` is listed below. FIG numbers are global, monotonically increasing, and never reused.
+
+The aesthetic is documented in the [`blueprint-diagram` skill](https://github.com/rohitg00/ai-engineering-from-scratch/blob/main/.claude/skills/blueprint-diagram/SKILL.md). To author a new figure, run the skill and append a row here.
+
+| FIG | slug | phase | lesson | added | notes |
+|---|---|---|---|---|---|
+| 000 | (curriculum stack — embedded in the README banner) | — | — | 2026-05-09 | hero, lives in `assets/banner.svg` not this dir |
+| 001 | exploded-view-floppy | — | — | 2026-05-09 | reference example for the skill, lives under `~/.claude/skills/blueprint-diagram/references/examples/` |
+| 002 | kernel-surface-gaussian | — | — | 2026-05-09 | reference example for the skill |
+| 003 | pixel-vector-bezier | — | — | 2026-05-09 | reference example for the skill |
+| 004 | gaussian-kernel-blur | 1 | 8 | 2026-05-09 | gaussian blur visualization for "Optimization: Gradient Descent Family" lesson |
+| 005 | transformer-attention-heads | 7 | 1 | 2026-05-09 | exploded view of multi-head attention block |
+
+## Numbering
+
+- `001`–`099`: reserved for early curriculum figures (Phases 0–7).
+- `100`+: assigned in order of authoring.
+- Sub-figures use letter suffixes: `004.A`, `004.B`. They share the parent's row.
+
+## How to add
+
+1. Run the `blueprint-diagram` skill with a description of the concept.
+2. The skill writes the SVG to `site/assets/figures/NNN-slug.svg`.
+3. The skill appends a row here with the next available number.
+4. The skill (or you) wires the figure into the relevant lesson markdown via `![FIG_NNN](path)`.
+5. Verify at multiple widths (480 / 720 / 1200 px) that labels do not overlap geometry.
+
+## License
+
+Figures inherit the repo's MIT license. They are CC-0 in spirit — copy them, modify them, ship them in your own work. Attribution appreciated, not required.

--- a/site/assets/figures/INDEX.md
+++ b/site/assets/figures/INDEX.md
@@ -2,7 +2,7 @@
 
 Every figure shipped under `site/assets/figures/` is listed below. FIG numbers are global, monotonically increasing, and never reused.
 
-The aesthetic is documented in the [`blueprint-diagram` skill](https://github.com/rohitg00/ai-engineering-from-scratch/blob/main/.claude/skills/blueprint-diagram/SKILL.md). To author a new figure, run the skill and append a row here.
+The aesthetic is documented in the `blueprint-diagram` Claude Code skill, which is distributed separately from this repo (per the project's "no vendor/tooling artifacts in repos" rule). The skill source lives under `~/.claude/skills/blueprint-diagram/` once installed; ask a maintainer for the install path or follow the [How to add](#how-to-add) section below for a manual workflow that does not require the skill.
 
 | FIG | slug | phase | lesson | added | notes |
 |---|---|---|---|---|---|
@@ -21,12 +21,19 @@ The aesthetic is documented in the [`blueprint-diagram` skill](https://github.co
 
 ## How to add
 
-1. Run the `blueprint-diagram` skill with a description of the concept.
-2. The skill writes the SVG to `site/assets/figures/NNN-slug.svg`.
-3. The skill appends a row here with the next available number.
-4. The skill (or you) wires the figure into the relevant lesson markdown via `![FIG_NNN](path)`.
-5. Verify at multiple widths (480 / 720 / 1200 px) that labels do not overlap geometry.
+If you have the `blueprint-diagram` skill installed:
+
+1. Run the skill with a description of the concept.
+2. The skill writes the SVG to `site/assets/figures/NNN-slug.svg`, appends a row here with the next available number, and (if asked) wires the figure into the relevant lesson markdown via `![FIG_NNN](path)`.
+
+If you don't have the skill, do it manually:
+
+1. Author an SVG in the cream + blueprint aesthetic (cream `#fafaf5` paper, `#3553ff` blueprint blue strokes, JetBrains Mono uppercase labels with leader lines, no other chromatic accents).
+2. Save as `site/assets/figures/<NNN>-<slug>.svg` using the next available FIG number from the table above.
+3. Add a row to the table here with the FIG number, slug, target phase + lesson, today's date, and a one-line note.
+4. Reference the figure from the lesson markdown as `![FIG_NNN](../../site/assets/figures/<NNN>-<slug>.svg)`.
+5. Verify at 480 / 720 / 1200 px viewport widths — labels must not overlap geometry, leader lines must reach their targets.
 
 ## License
 
-Figures inherit the repo's MIT license. They are CC-0 in spirit — copy them, modify them, ship them in your own work. Attribution appreciated, not required.
+Figures are released under the repo's MIT license. The MIT license requires preserving the copyright notice in distributions of the source SVG; visual reuse of the rendered image (e.g. embedding in a blog post or slide deck) is fine without further attribution.


### PR DESCRIPTION
## Summary

Ships the diagram-generation system that the original rebuild plan (PR-5 / Phase F) called for, plus two sample figures in the AI Engineering from Scratch reference-manual aesthetic.

## What's in this PR

\`site/assets/figures/INDEX.md\` — global FIG numbering registry. Figures are numbered monotonically across the project, never reused. Documents how to add new figures.

\`site/assets/figures/004-gaussian-kernel-blur.svg\` — three sub-figures in one SVG (continuous distribution + discrete 5×5 kernel + applied blur σ=0,1,2,4). Destined for Phase 1 lesson 8.

\`site/assets/figures/005-transformer-attention-heads.svg\` — exploded view of 4-head attention with Q/K/V projections + per-head behavioral interpretation + the attention formula. Destined for Phase 7 lesson 1.

## What's NOT in this PR but related

The \`blueprint-diagram\` skill itself lives at \`~/.claude/skills/blueprint-diagram/\` on the maintainer's machine. Per the standing "no vendor/tooling artifacts in repos" rule (\`.claude/\` shouldn't be committed), the skill source isn't bundled here.

The skill ships:

- **\`SKILL.md\`** — trigger phrases, workflow (read style spec → pick template → author SVG → verify against examples → number → wire in → test render), output rules, anti-patterns.
- **\`references/style.md\`** — full aesthetic spec: palette tokens, typography assignment, stroke/fill rules, isometric projection geometry (30° axes, canonical parallelogram points), label conventions, leader-line rules, FIG callout positions, ASCII rule strip, file output requirements.
- **\`references/examples/\`** — three hand-authored reference SVGs anchoring the style: floppy-disk exploded view, gaussian kernel surface, bezier handles. Each ~3KB.
- **\`templates/\`** — five base scaffolds: \`exploded-view.svg\`, \`kernel-surface.svg\`, \`flow-diagram.svg\`, \`isometric-stack.svg\`, \`pixel-vector.svg\`. The skill copies the matching template and modifies it.

To use the skill from another machine: copy \`~/.claude/skills/blueprint-diagram/\` (8 files, ~12KB total) into the same path. Triggers like \`/blueprint-diagram exploded view of X\` or \`make me FIG_NNN\`.

## Aesthetic verification

Rendered both figures at 1440×900 in a headless browser. Confirmed:

- Single chromatic accent (blueprint blue \`#3553ff\`), no greens / oranges / purples.
- Strokes 1.0–1.5px, miter-joined, square caps.
- Face fills only at 6% (background layers) and 18% (emphasis).
- All labels in JetBrains Mono uppercase with letter-spacing 0.10–0.16em.
- No labels overlap geometry — every label sits in margin pulled out by dashed leader lines.
- Cream paper background \`#fafaf5\` with subtle dotted-paper pattern.
- FIG_NNN markers top-left, metadata top-right, copyright lines bottom-right.

These figures hold to the cream-and-blueprint aesthetic without chromatic leaks and read as a coherent set.

## Plan

Per the original rebuild plan, FIG callout rendering in lesson.html is PR-4 work. This PR ships the assets + index + skill so the renderer (next PR) has something to render. Lesson markdown wiring (e.g. adding \`![FIG_004](...)\` to the gaussian-kernel lesson) is a follow-up that needs a parser-safe round trip — preserves \`build.js\`'s \`PHASES\`/\`GLOSSARY\` output.

## Test plan

- [x] \`node site/build.js\` still emits identical \`data.js\` (no schema change)
- [x] FIG_004 renders correctly at 1440×900 (verified with headless browser)
- [x] FIG_005 renders correctly at 1440×900 (verified with headless browser)
- [ ] Open both SVGs at 480 / 720 / 1200 widths after merge — labels still don't overlap geometry
- [ ] First contributor authoring a new figure follows the SKILL.md workflow end-to-end without confusion

## Future figures

The naming reserves 001–099 for early-curriculum figures (Phases 0–7). 100+ assigned in authoring order. Sub-figures use letter suffixes sharing the parent's INDEX row (e.g. 004.A / 004.B / 004.C).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a figure index page that catalogs all SVG figures with globally unique, monotonically increasing reference numbers, sub-figure rules, and an initial listing.
  * Provided contributor guidance for adding new figures (automated or manual), layout validation across viewports, and clarified licensing and reuse expectations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/ai-engineering-from-scratch/pull/93)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
