### PR TITLE
feat(site): scroll-driven animations and tone scrub

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,32 +17,26 @@
 > **84% of students already use AI tools. Only 18% feel prepared to use them
 > professionally.** This curriculum closes that gap.
 >
-> A reference manual for people who want to design and build AI systems from first principles.
-> Twenty phases. 280+ lessons. ~320 hours. Python, TypeScript, Rust, Julia. Every lesson
-> produces something reusable: prompts, skills, agents, MCP servers. Free, open source,
-> MIT licensed.
+> 299 lessons. 20 phases. ~320 hours. Python, TypeScript, Rust, Julia. Every lesson ships
+> a reusable artifact: a prompt, a skill, an agent, an MCP server. Free, open source, MIT.
 >
-> You don't just learn AI. You learn AI **with** AI. Then you build real things. Then you
-> ship tools others can use.
+> You don't just learn AI. You build it. End-to-end. By hand.
 
-## Preface
+## How this works
 
-Have you ever wondered how a transformer actually pays attention? Or what backpropagation is doing
-under the hood when your loss curve drops? Or why a tokenizer ends up splitting *playing* into
-three pieces?
+Most AI material teaches in scattered pieces. A paper here, a fine-tuning post there, a
+flashy agent demo somewhere else. The pieces rarely line up. You ship a chatbot but can't
+explain its loss curve. You hook a function to an agent but can't say what attention does
+inside the model that's calling it.
 
-If you have, this is for you. This isn't a tutorial. It's a manual that explains how the things you
-use every day — gradient descent, attention, retrieval-augmented generation, multi-agent
-orchestration — actually work. Every algorithm gets implemented from raw math. No magic wrappers.
-You write the backprop, the tokenizer, the attention mechanism, the agent loop.
+This curriculum is the spine. 20 phases, 299 lessons, four languages: Python, TypeScript,
+Rust, Julia. Linear algebra at one end, autonomous swarms at the other. Every algorithm
+gets built from raw math first. Backprop. Tokenizer. Attention. Agent loop. By the time
+PyTorch shows up, you already know what it's doing under the hood.
 
-It won't make you a better ML engineer tomorrow. There's nothing actionable in here you can paste
-into a Jupyter cell. But knowing how things work comes in handy when you're debugging a model that
-loses signal halfway through training, or you're trying to figure out why your agent keeps
-hallucinating tool calls.
-
-You don't need to be a researcher to read this. You just need to be curious and willing to write
-the code yourself.
+Each lesson runs the same loop: read the problem, derive the math, write the code, run
+the test, keep the artifact. No five-minute videos, no copy-paste deploys, no hand-holding.
+Free, open source, and built to run on your own laptop.
 
 ```
 ░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒

--- a/site/app.js
+++ b/site/app.js
@@ -320,7 +320,9 @@
   }
 
   function initFadeObserver() {
-    if (!window.IntersectionObserver) {
+    var prefersReduced = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    if (!window.IntersectionObserver || prefersReduced) {
       document.querySelectorAll('.reveal, .fade-in, .stat-row-bar').forEach(function (el) {
         el.classList.add('in-view', 'visible');
         var target = el.getAttribute('data-target-pct');
@@ -328,6 +330,8 @@
       });
       return;
     }
+
+    document.body.classList.add('js-anim');
 
     var els = document.querySelectorAll('.reveal, .fade-in, .stat-row-bar, .ascii-rule, .toc-row');
     if (!els.length) return;
@@ -389,21 +393,36 @@
   }
 
   function applyExplode(container, progress) {
+    // Each layer / label animates over its own window in [stagger_start, stagger_start + window].
+    // Sequential reveal: layer N waits for layer N-1 to mostly settle before starting.
+    var STAGGER_DENOM = 720; // higher → wider gaps between layer entrances
+    var WINDOW = 0.55;       // each layer's local animation duration as fraction of global progress
+
+    function localProgress(staggerAttr) {
+      var stagger = parseFloat(staggerAttr) || 0;
+      var start = stagger / STAGGER_DENOM;
+      var local = (progress - start) / WINDOW;
+      if (local < 0) local = 0;
+      if (local > 1) local = 1;
+      // ease-out cubic on the local segment
+      return 1 - Math.pow(1 - local, 3);
+    }
+
     var layers = container.querySelectorAll('.explode-layer');
     for (var i = 0; i < layers.length; i++) {
       var final = parseFloat(layers[i].getAttribute('data-final')) || 0;
-      var dy = -final * progress;
+      var lp = localProgress(layers[i].getAttribute('data-stagger'));
+      var dy = -final * lp;
       layers[i].setAttribute('transform', 'translate(0, ' + dy.toFixed(2) + ')');
+      layers[i].setAttribute('opacity', lp.toFixed(3));
     }
     var labels = container.querySelectorAll('.explode-label');
     for (var j = 0; j < labels.length; j++) {
       var final2 = parseFloat(labels[j].getAttribute('data-final')) || 0;
-      var stagger = parseFloat(labels[j].getAttribute('data-stagger')) || 0;
-      var dy2 = -final2 * progress;
+      var lp2 = localProgress(labels[j].getAttribute('data-stagger'));
+      var dy2 = -final2 * lp2;
       labels[j].setAttribute('transform', 'translate(0, ' + dy2.toFixed(2) + ')');
-      var labelStart = stagger / 540;
-      var labelProgress = Math.max(0, Math.min(1, (progress - labelStart) / Math.max(0.001, 1 - labelStart)));
-      labels[j].setAttribute('opacity', labelProgress.toFixed(3));
+      labels[j].setAttribute('opacity', lp2.toFixed(3));
     }
   }
 

--- a/site/app.js
+++ b/site/app.js
@@ -14,10 +14,12 @@
     initThemeToggle();
     populateStats();
     renderPhases();
+    initStaggerIndex();
     initModal();
     initCopyButton();
     initSmoothScroll();
     initFadeObserver();
+    initScrollExplode();
   });
 
   function updateThemeIcon() {
@@ -73,7 +75,12 @@
     var el = document.querySelector(selector);
     if (!el) return;
     var clamped = Math.max(0, Math.min(100, pct));
-    el.style.setProperty('--bar-pct', clamped.toFixed(1) + '%');
+    el.setAttribute('data-target-pct', clamped.toFixed(1));
+    if (el.classList.contains('in-view') || !window.IntersectionObserver) {
+      el.style.setProperty('--bar-pct', clamped.toFixed(1) + '%');
+    } else {
+      el.style.setProperty('--bar-pct', '0%');
+    }
   }
 
   function populateStats() {
@@ -313,18 +320,90 @@
   }
 
   function initFadeObserver() {
-    var els = document.querySelectorAll('.fade-in');
+    if (!window.IntersectionObserver) {
+      document.querySelectorAll('.reveal, .fade-in, .stat-row-bar').forEach(function (el) {
+        el.classList.add('in-view', 'visible');
+        var target = el.getAttribute('data-target-pct');
+        if (target !== null) el.style.setProperty('--bar-pct', target + '%');
+      });
+      return;
+    }
+
+    var els = document.querySelectorAll('.reveal, .fade-in, .stat-row-bar, .ascii-rule, .toc-row');
     if (!els.length) return;
     var observer = new IntersectionObserver(function (entries) {
       for (var i = 0; i < entries.length; i++) {
         if (entries[i].isIntersecting) {
-          entries[i].target.classList.add('visible');
-          observer.unobserve(entries[i].target);
+          var el = entries[i].target;
+          el.classList.add('in-view', 'visible');
+          var target = el.getAttribute('data-target-pct');
+          if (target !== null) {
+            el.style.setProperty('--bar-pct', target + '%');
+          }
+          observer.unobserve(el);
         }
       }
-    }, { threshold: 0.1, rootMargin: '0px 0px -40px 0px' });
+    }, { threshold: 0.12, rootMargin: '0px 0px -40px 0px' });
     for (var i = 0; i < els.length; i++) {
       observer.observe(els[i]);
+    }
+  }
+
+  function initStaggerIndex() {
+    var rows = document.querySelectorAll('.toc-list .toc-row');
+    for (var i = 0; i < rows.length; i++) {
+      rows[i].style.setProperty('--stagger-delay', (i * 30) + 'ms');
+    }
+  }
+
+  function initScrollExplode() {
+    var containers = document.querySelectorAll('[data-svg-explode]');
+    if (!containers.length) return;
+    if (window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      for (var c = 0; c < containers.length; c++) applyExplode(containers[c], 1);
+      return;
+    }
+
+    var ticking = false;
+    function update() {
+      ticking = false;
+      var vh = window.innerHeight || document.documentElement.clientHeight;
+      for (var i = 0; i < containers.length; i++) {
+        var rect = containers[i].getBoundingClientRect();
+        var startEdge = vh;
+        var endEdge = vh * 0.35;
+        var raw = (startEdge - rect.top) / (startEdge - endEdge);
+        var progress = Math.max(0, Math.min(1, raw));
+        progress = 1 - Math.pow(1 - progress, 3);
+        applyExplode(containers[i], progress);
+      }
+    }
+    function onScroll() {
+      if (ticking) return;
+      ticking = true;
+      window.requestAnimationFrame(update);
+    }
+    window.addEventListener('scroll', onScroll, { passive: true });
+    window.addEventListener('resize', onScroll);
+    update();
+  }
+
+  function applyExplode(container, progress) {
+    var layers = container.querySelectorAll('.explode-layer');
+    for (var i = 0; i < layers.length; i++) {
+      var final = parseFloat(layers[i].getAttribute('data-final')) || 0;
+      var dy = -final * progress;
+      layers[i].setAttribute('transform', 'translate(0, ' + dy.toFixed(2) + ')');
+    }
+    var labels = container.querySelectorAll('.explode-label');
+    for (var j = 0; j < labels.length; j++) {
+      var final2 = parseFloat(labels[j].getAttribute('data-final')) || 0;
+      var stagger = parseFloat(labels[j].getAttribute('data-stagger')) || 0;
+      var dy2 = -final2 * progress;
+      labels[j].setAttribute('transform', 'translate(0, ' + dy2.toFixed(2) + ')');
+      var labelStart = stagger / 540;
+      var labelProgress = Math.max(0, Math.min(1, (progress - labelStart) / Math.max(0.001, 1 - labelStart)));
+      labels[j].setAttribute('opacity', labelProgress.toFixed(3));
     }
   }
 

--- a/site/catalog.html
+++ b/site/catalog.html
@@ -261,7 +261,7 @@
 
   <footer class="site-footer">
     <div class="container footer-inner">
-      <p>AI Engineering from Scratch &mdash; open source, free forever.</p>
+      <p>AI Engineering from Scratch · open source · free forever.</p>
       <div class="footer-links">
         <a href="index.html">Home</a>
         <a href="https://github.com/rohitg00/ai-engineering-from-scratch" target="_blank" rel="noopener">GitHub</a>

--- a/site/glossary.html
+++ b/site/glossary.html
@@ -192,7 +192,7 @@
 
   <footer class="site-footer">
     <div class="container footer-inner">
-      <p>AI Engineering from Scratch &mdash; open source, free forever.</p>
+      <p>AI Engineering from Scratch · open source · free forever.</p>
       <div class="footer-links">
         <a href="index.html">Home</a>
         <a href="https://github.com/rohitg00/ai-engineering-from-scratch" target="_blank" rel="noopener">GitHub</a>

--- a/site/index.html
+++ b/site/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>AI Engineering from Scratch</title>
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect width='32' height='32' fill='%23fafaf5'/><rect x='2' y='2' width='28' height='28' fill='none' stroke='%233553ff' stroke-width='1.2'/><text x='6' y='22' font-size='14' font-family='monospace' fill='%233553ff'>AI</text></svg>">
-  <meta name="description" content="A reference manual for people who want to learn AI engineering from first principles. 299 lessons across 20 phases.">
+  <meta name="description" content="299 lessons. 20 phases. Build the math, the model, the trainer, the tokenizer, and the agent loop. Once, by hand.">
   <meta property="og:title" content="AI Engineering from Scratch">
   <meta property="og:description" content="299 lessons. 20 phases. Build neural networks, transformers, and LLMs from first principles. Python, TypeScript, Rust, Julia.">
   <meta property="og:image" content="https://aiengineeringfromscratch.com/og-image.png">
@@ -555,23 +555,22 @@
 
     <section class="manual-masthead container">
       <div class="manual-meta-row">
-        <span>FIG_000 &middot; Reference Manual v1.0</span>
-        <span class="right">© 2026 — open source · MIT license</span>
+        <span>FIG_000 &middot; curriculum v1.0 · 2026</span>
+        <span class="right">open source · MIT</span>
       </div>
-      <h1 class="manual-title">AI Engineering<br>from Scratch.</h1>
-      <p class="manual-tagline reveal">A reference manual for people who want to design and build AI systems from first principles.</p>
-      <p class="manual-attribution reveal" style="--stagger-delay: 80ms;">Written and maintained by Rohit Ghumare and contributors.</p>
+      <h1 class="manual-title">AI Engineering<br>from Scratch</h1>
+      <p class="manual-tagline reveal">299 lessons. 20 phases. Every algorithm built from raw math before a single framework gets imported.</p>
+      <p class="manual-attribution reveal" style="--stagger-delay: 80ms;">Maintained by Rohit Ghumare and contributors. Run on your own machine.</p>
       <div class="ascii-rule" style="margin-top:48px;"></div>
     </section>
 
     <section class="preface container">
       <div class="preface-grid">
-        <div class="preface-eyebrow reveal reveal--left">Preface</div>
+        <div class="preface-eyebrow reveal reveal--left">How this works</div>
         <div class="preface-body reveal" style="--stagger-delay: 120ms;">
-          <p>Have you ever wondered how a transformer actually pays attention? Or what backpropagation is doing under the hood when your loss curve drops? Or why a tokenizer ends up splitting "playing" into three pieces?</p>
-          <p>If you have, this is for you. This isn't a tutorial. It's a reference manual that explains how the things you use every day — from gradient descent to retrieval-augmented generation to multi-agent orchestration — actually work.</p>
-          <p>It won't make you a better ML engineer tomorrow. There's nothing actionable in here you can paste into a Jupyter cell. But knowing how things work comes in handy when you're debugging a model that loses signal halfway through training, or you're trying to figure out why your agent keeps hallucinating tool calls.</p>
-          <p>You don't need to be a researcher to read this. You just need to be curious and willing to write the code yourself. Every algorithm in here gets implemented from raw math. No magic wrappers. You write the backprop, the tokenizer, the attention mechanism, the agent loop.</p>
+          <p>Most AI material teaches in scattered pieces. A paper here, a fine-tuning post there, a flashy agent demo somewhere else. The pieces rarely line up. You ship a chatbot but can't explain its loss curve. You hook a function to an agent but can't say what attention does inside the model that's calling it.</p>
+          <p>This curriculum is the spine. 20 phases, 299 lessons, four languages: Python, TypeScript, Rust, Julia. Linear algebra at one end, autonomous swarms at the other. Every algorithm gets built from raw math first. Backprop. Tokenizer. Attention. Agent loop. By the time PyTorch shows up, you already know what it's doing under the hood.</p>
+          <p>Each lesson runs the same loop: read the problem, derive the math, write the code, run the test, keep the artifact. No five-minute videos, no copy-paste deploys, no hand-holding. Free, open source, and built to run on your own laptop.</p>
         </div>
       </div>
     </section>
@@ -604,8 +603,8 @@
     </section>
 
     <section class="toc container" id="contents">
-      <div class="toc-title reveal reveal--left">Table of Contents · v1.0</div>
-      <div class="toc-subtitle reveal" style="--stagger-delay: 80ms;">Twenty phases. Click any phase to see its lessons.</div>
+      <div class="toc-title reveal reveal--left">Curriculum · 20 phases · 299 lessons</div>
+      <div class="toc-subtitle reveal" style="--stagger-delay: 80ms;">Tap a phase to expand its lessons. Each one ships when its math, code, and test are all written.</div>
       <div class="toc-list" id="phasesGrid"></div>
       <div class="legend">
         <span class="legend-item"><span class="toc-status complete"></span> Complete</span>

--- a/site/index.html
+++ b/site/index.html
@@ -113,6 +113,41 @@
       color: var(--blueprint);
     }
 
+    .figure-demo {
+      padding: 56px 0;
+      border-bottom: 1px solid var(--rule-soft);
+    }
+
+    .figure-demo-eyebrow {
+      font-family: var(--font-mono);
+      font-size: 0.74rem;
+      letter-spacing: 0.16em;
+      text-transform: uppercase;
+      color: var(--blueprint);
+      margin-bottom: 12px;
+    }
+
+    .figure-demo-caption {
+      max-width: 640px;
+      font-family: var(--font-body);
+      font-size: 1rem;
+      line-height: 1.6;
+      color: var(--ink-soft);
+      margin-bottom: 32px;
+    }
+
+    .figure-demo-svg {
+      width: 100%;
+      max-width: 920px;
+      margin: 0 auto;
+    }
+
+    .figure-demo-svg svg {
+      width: 100%;
+      height: auto;
+      display: block;
+    }
+
     .stat-block {
       padding: 56px 0;
       border-bottom: 1px solid var(--rule-soft);
@@ -520,15 +555,15 @@
         <span class="right">© 2026 — open source · MIT license</span>
       </div>
       <h1 class="manual-title">AI Engineering<br>from Scratch.</h1>
-      <p class="manual-tagline">A reference manual for people who want to design and build AI systems from first principles.</p>
-      <p class="manual-attribution">Written and maintained by Rohit Ghumare and contributors.</p>
+      <p class="manual-tagline reveal">A reference manual for people who want to design and build AI systems from first principles.</p>
+      <p class="manual-attribution reveal" style="--stagger-delay: 80ms;">Written and maintained by Rohit Ghumare and contributors.</p>
       <div class="ascii-rule" style="margin-top:48px;"></div>
     </section>
 
     <section class="preface container">
       <div class="preface-grid">
-        <div class="preface-eyebrow">Preface</div>
-        <div class="preface-body">
+        <div class="preface-eyebrow reveal reveal--left">Preface</div>
+        <div class="preface-body reveal" style="--stagger-delay: 120ms;">
           <p>Have you ever wondered how a transformer actually pays attention? Or what backpropagation is doing under the hood when your loss curve drops? Or why a tokenizer ends up splitting "playing" into three pieces?</p>
           <p>If you have, this is for you. This isn't a tutorial. It's a reference manual that explains how the things you use every day — from gradient descent to retrieval-augmented generation to multi-agent orchestration — actually work.</p>
           <p>It won't make you a better ML engineer tomorrow. There's nothing actionable in here you can paste into a Jupyter cell. But knowing how things work comes in handy when you're debugging a model that loses signal halfway through training, or you're trying to figure out why your agent keeps hallucinating tool calls.</p>
@@ -538,9 +573,86 @@
       <div class="ascii-rule"></div>
     </section>
 
+    <section class="figure-demo container">
+      <div class="figure-demo-eyebrow reveal reveal--left">FIG_001 · Curriculum Stack</div>
+      <p class="figure-demo-caption reveal" style="--stagger-delay: 80ms;">Twenty phases stack on top of each other. Math is the floor; agents and production are the roof. Scroll to see how the stack assembles.</p>
+      <div class="figure-demo-svg reveal" style="--stagger-delay: 120ms;" data-svg-explode>
+        <svg viewBox="0 0 760 520" role="img" aria-label="FIG_001 — animated curriculum stack" preserveAspectRatio="xMidYMid meet">
+          <defs>
+            <pattern id="fdPaper" x="0" y="0" width="14" height="14" patternUnits="userSpaceOnUse">
+              <circle cx="0" cy="0" r="0.9" fill="currentColor" fill-opacity="0.08"/>
+            </pattern>
+          </defs>
+          <g style="color: var(--ink);">
+            <rect width="760" height="520" fill="url(#fdPaper)" opacity="0.5"/>
+          </g>
+
+          <!-- Stack: 7 panels. Each panel has a `data-base-y` attribute (final position) and starts collapsed at the same y as panel 7 (bottom). Scroll progress 0..1 lerps from collapsed → exploded. -->
+          <g transform="translate(140, 80)">
+            <g class="explode-layer" data-rest="0"   data-final="0">
+              <polygon points="0,260 132,234 332,247 200,273" fill="rgba(53, 83, 255, 0.06)" stroke="#3553ff" stroke-width="1.2" stroke-linejoin="miter"/>
+            </g>
+            <g class="explode-layer" data-rest="0"   data-final="36">
+              <polygon points="0,260 132,234 332,247 200,273" fill="rgba(53, 83, 255, 0.06)" stroke="#3553ff" stroke-width="1.2" stroke-linejoin="miter"/>
+            </g>
+            <g class="explode-layer" data-rest="0"   data-final="72">
+              <polygon points="0,260 132,234 332,247 200,273" fill="rgba(53, 83, 255, 0.06)" stroke="#3553ff" stroke-width="1.2" stroke-linejoin="miter"/>
+            </g>
+            <g class="explode-layer" data-rest="0"   data-final="108">
+              <polygon points="0,260 132,234 332,247 200,273" fill="rgba(53, 83, 255, 0.06)" stroke="#3553ff" stroke-width="1.2" stroke-linejoin="miter"/>
+            </g>
+            <g class="explode-layer" data-rest="0"   data-final="144">
+              <polygon points="0,260 132,234 332,247 200,273" fill="rgba(53, 83, 255, 0.06)" stroke="#3553ff" stroke-width="1.2" stroke-linejoin="miter"/>
+            </g>
+            <g class="explode-layer" data-rest="0"   data-final="180">
+              <polygon points="0,260 132,234 332,247 200,273" fill="rgba(53, 83, 255, 0.06)" stroke="#3553ff" stroke-width="1.2" stroke-linejoin="miter"/>
+            </g>
+            <g class="explode-layer" data-rest="0"   data-final="216">
+              <polygon points="0,260 132,234 332,247 200,273" fill="rgba(53, 83, 255, 0.18)" stroke="#3553ff" stroke-width="1.4" stroke-linejoin="miter"/>
+            </g>
+
+            <!-- Leader lines + labels (right column), revealed as progress passes -->
+            <g class="explode-labels" font-family="JetBrains Mono, ui-monospace, monospace" font-size="10" letter-spacing="1.6" fill="#3553ff">
+              <g class="explode-label" data-final="0"   data-stagger="0">
+                <line x1="340" y1="247" x2="416" y2="247" stroke="#3553ff" stroke-width="0.8" stroke-dasharray="3 3"/>
+                <text x="424" y="251">SETUP &amp; TOOLING</text>
+              </g>
+              <g class="explode-label" data-final="36"  data-stagger="60">
+                <line x1="340" y1="247" x2="416" y2="247" stroke="#3553ff" stroke-width="0.8" stroke-dasharray="3 3"/>
+                <text x="424" y="251">MATH FOUNDATIONS</text>
+              </g>
+              <g class="explode-label" data-final="72"  data-stagger="120">
+                <line x1="340" y1="247" x2="416" y2="247" stroke="#3553ff" stroke-width="0.8" stroke-dasharray="3 3"/>
+                <text x="424" y="251">ML FUNDAMENTALS</text>
+              </g>
+              <g class="explode-label" data-final="108" data-stagger="180">
+                <line x1="340" y1="247" x2="416" y2="247" stroke="#3553ff" stroke-width="0.8" stroke-dasharray="3 3"/>
+                <text x="424" y="251">DEEP LEARNING · RL</text>
+              </g>
+              <g class="explode-label" data-final="144" data-stagger="240">
+                <line x1="340" y1="247" x2="416" y2="247" stroke="#3553ff" stroke-width="0.8" stroke-dasharray="3 3"/>
+                <text x="424" y="251">VISION · SPEECH · NLP</text>
+              </g>
+              <g class="explode-label" data-final="180" data-stagger="300">
+                <line x1="340" y1="247" x2="416" y2="247" stroke="#3553ff" stroke-width="0.8" stroke-dasharray="3 3"/>
+                <text x="424" y="251">LLMS · TRANSFORMERS</text>
+              </g>
+              <g class="explode-label" data-final="216" data-stagger="360">
+                <line x1="340" y1="247" x2="416" y2="247" stroke="#3553ff" stroke-width="0.8" stroke-dasharray="3 3"/>
+                <text x="424" y="251">AGENTS · SWARMS · PROD</text>
+              </g>
+            </g>
+          </g>
+
+          <text x="40" y="36" font-family="JetBrains Mono, ui-monospace, monospace" font-size="10" letter-spacing="2" fill="#3553ff">FIG_001 — SCROLL TO ASSEMBLE</text>
+        </svg>
+      </div>
+      <div class="ascii-rule"></div>
+    </section>
+
     <section class="stat-block container">
-      <div class="stat-block-title">Current Progress</div>
-      <div class="stat-rows" id="statRows">
+      <div class="stat-block-title reveal reveal--left">Current Progress</div>
+      <div class="stat-rows reveal" style="--stagger-delay: 100ms;" id="statRows">
         <div class="stat-row">
           <span class="stat-row-label">Finished Lessons</span>
           <span class="stat-row-bar" data-bar="complete" style="--bar-pct:0%;" aria-hidden="true">bar</span>
@@ -566,8 +678,8 @@
     </section>
 
     <section class="toc container" id="contents">
-      <div class="toc-title">Table of Contents · v1.0</div>
-      <div class="toc-subtitle">Twenty phases. Click any phase to see its lessons.</div>
+      <div class="toc-title reveal reveal--left">Table of Contents · v1.0</div>
+      <div class="toc-subtitle reveal" style="--stagger-delay: 80ms;">Twenty phases. Click any phase to see its lessons.</div>
       <div class="toc-list" id="phasesGrid"></div>
       <div class="legend">
         <span class="legend-item"><span class="toc-status complete"></span> Complete</span>
@@ -596,8 +708,8 @@
 
     <section class="colophon container">
       <div class="colophon-grid">
-        <div class="colophon-eyebrow">Colophon</div>
-        <div>
+        <div class="colophon-eyebrow reveal reveal--left">Colophon</div>
+        <div class="reveal" style="--stagger-delay: 80ms;">
           <p>The entire curriculum is on GitHub. Clone it, fork it, learn at your own pace. No paywall, no signup. Every lesson has runnable code in Python, TypeScript, Rust, or Julia, depending on what fits the concept best.</p>
           <div class="colophon-cmd">
             <code id="cloneCmd">git clone https://github.com/rohitg00/ai-engineering-from-scratch.git</code>

--- a/site/index.html
+++ b/site/index.html
@@ -70,7 +70,7 @@
     }
 
     .preface {
-      padding: 56px 0;
+      padding: 48px 0 32px;
       border-bottom: 1px solid var(--rule-soft);
     }
 
@@ -114,7 +114,7 @@
     }
 
     .figure-demo {
-      padding: 56px 0;
+      padding: 24px 0 0;
       border-bottom: 1px solid var(--rule-soft);
     }
 
@@ -124,21 +124,21 @@
       letter-spacing: 0.16em;
       text-transform: uppercase;
       color: var(--blueprint);
-      margin-bottom: 12px;
+      margin-bottom: 6px;
     }
 
     .figure-demo-caption {
       max-width: 640px;
       font-family: var(--font-body);
-      font-size: 1rem;
-      line-height: 1.6;
+      font-size: 0.96rem;
+      line-height: 1.5;
       color: var(--ink-soft);
-      margin-bottom: 32px;
+      margin-bottom: 0;
     }
 
     .figure-demo-svg {
       width: 100%;
-      max-width: 920px;
+      max-width: 760px;
       margin: 0 auto;
     }
 
@@ -148,8 +148,12 @@
       display: block;
     }
 
+    @media (max-width: 768px) {
+      .figure-demo { padding: 16px 0 0; }
+    }
+
     .stat-block {
-      padding: 56px 0;
+      padding: 32px 0 40px;
       border-bottom: 1px solid var(--rule-soft);
     }
 
@@ -570,85 +574,8 @@
           <p>You don't need to be a researcher to read this. You just need to be curious and willing to write the code yourself. Every algorithm in here gets implemented from raw math. No magic wrappers. You write the backprop, the tokenizer, the attention mechanism, the agent loop.</p>
         </div>
       </div>
-      <div class="ascii-rule"></div>
     </section>
 
-    <section class="figure-demo container">
-      <div class="figure-demo-eyebrow reveal reveal--left">FIG_001 · Curriculum Stack</div>
-      <p class="figure-demo-caption reveal" style="--stagger-delay: 80ms;">Twenty phases stack on top of each other. Math is the floor; agents and production are the roof. Scroll to see how the stack assembles.</p>
-      <div class="figure-demo-svg reveal" style="--stagger-delay: 120ms;" data-svg-explode>
-        <svg viewBox="0 0 760 520" role="img" aria-label="FIG_001 — animated curriculum stack" preserveAspectRatio="xMidYMid meet">
-          <defs>
-            <pattern id="fdPaper" x="0" y="0" width="14" height="14" patternUnits="userSpaceOnUse">
-              <circle cx="0" cy="0" r="0.9" fill="currentColor" fill-opacity="0.08"/>
-            </pattern>
-          </defs>
-          <g style="color: var(--ink);">
-            <rect width="760" height="520" fill="url(#fdPaper)" opacity="0.5"/>
-          </g>
-
-          <!-- Stack: 7 panels. Each panel has a `data-base-y` attribute (final position) and starts collapsed at the same y as panel 7 (bottom). Scroll progress 0..1 lerps from collapsed → exploded. -->
-          <g transform="translate(140, 80)">
-            <g class="explode-layer" data-rest="0"   data-final="0">
-              <polygon points="0,260 132,234 332,247 200,273" fill="rgba(53, 83, 255, 0.06)" stroke="#3553ff" stroke-width="1.2" stroke-linejoin="miter"/>
-            </g>
-            <g class="explode-layer" data-rest="0"   data-final="36">
-              <polygon points="0,260 132,234 332,247 200,273" fill="rgba(53, 83, 255, 0.06)" stroke="#3553ff" stroke-width="1.2" stroke-linejoin="miter"/>
-            </g>
-            <g class="explode-layer" data-rest="0"   data-final="72">
-              <polygon points="0,260 132,234 332,247 200,273" fill="rgba(53, 83, 255, 0.06)" stroke="#3553ff" stroke-width="1.2" stroke-linejoin="miter"/>
-            </g>
-            <g class="explode-layer" data-rest="0"   data-final="108">
-              <polygon points="0,260 132,234 332,247 200,273" fill="rgba(53, 83, 255, 0.06)" stroke="#3553ff" stroke-width="1.2" stroke-linejoin="miter"/>
-            </g>
-            <g class="explode-layer" data-rest="0"   data-final="144">
-              <polygon points="0,260 132,234 332,247 200,273" fill="rgba(53, 83, 255, 0.06)" stroke="#3553ff" stroke-width="1.2" stroke-linejoin="miter"/>
-            </g>
-            <g class="explode-layer" data-rest="0"   data-final="180">
-              <polygon points="0,260 132,234 332,247 200,273" fill="rgba(53, 83, 255, 0.06)" stroke="#3553ff" stroke-width="1.2" stroke-linejoin="miter"/>
-            </g>
-            <g class="explode-layer" data-rest="0"   data-final="216">
-              <polygon points="0,260 132,234 332,247 200,273" fill="rgba(53, 83, 255, 0.18)" stroke="#3553ff" stroke-width="1.4" stroke-linejoin="miter"/>
-            </g>
-
-            <!-- Leader lines + labels (right column), revealed as progress passes -->
-            <g class="explode-labels" font-family="JetBrains Mono, ui-monospace, monospace" font-size="10" letter-spacing="1.6" fill="#3553ff">
-              <g class="explode-label" data-final="0"   data-stagger="0">
-                <line x1="340" y1="247" x2="416" y2="247" stroke="#3553ff" stroke-width="0.8" stroke-dasharray="3 3"/>
-                <text x="424" y="251">SETUP &amp; TOOLING</text>
-              </g>
-              <g class="explode-label" data-final="36"  data-stagger="60">
-                <line x1="340" y1="247" x2="416" y2="247" stroke="#3553ff" stroke-width="0.8" stroke-dasharray="3 3"/>
-                <text x="424" y="251">MATH FOUNDATIONS</text>
-              </g>
-              <g class="explode-label" data-final="72"  data-stagger="120">
-                <line x1="340" y1="247" x2="416" y2="247" stroke="#3553ff" stroke-width="0.8" stroke-dasharray="3 3"/>
-                <text x="424" y="251">ML FUNDAMENTALS</text>
-              </g>
-              <g class="explode-label" data-final="108" data-stagger="180">
-                <line x1="340" y1="247" x2="416" y2="247" stroke="#3553ff" stroke-width="0.8" stroke-dasharray="3 3"/>
-                <text x="424" y="251">DEEP LEARNING · RL</text>
-              </g>
-              <g class="explode-label" data-final="144" data-stagger="240">
-                <line x1="340" y1="247" x2="416" y2="247" stroke="#3553ff" stroke-width="0.8" stroke-dasharray="3 3"/>
-                <text x="424" y="251">VISION · SPEECH · NLP</text>
-              </g>
-              <g class="explode-label" data-final="180" data-stagger="300">
-                <line x1="340" y1="247" x2="416" y2="247" stroke="#3553ff" stroke-width="0.8" stroke-dasharray="3 3"/>
-                <text x="424" y="251">LLMS · TRANSFORMERS</text>
-              </g>
-              <g class="explode-label" data-final="216" data-stagger="360">
-                <line x1="340" y1="247" x2="416" y2="247" stroke="#3553ff" stroke-width="0.8" stroke-dasharray="3 3"/>
-                <text x="424" y="251">AGENTS · SWARMS · PROD</text>
-              </g>
-            </g>
-          </g>
-
-          <text x="40" y="36" font-family="JetBrains Mono, ui-monospace, monospace" font-size="10" letter-spacing="2" fill="#3553ff">FIG_001 — SCROLL TO ASSEMBLE</text>
-        </svg>
-      </div>
-      <div class="ascii-rule"></div>
-    </section>
 
     <section class="stat-block container">
       <div class="stat-block-title reveal reveal--left">Current Progress</div>
@@ -674,7 +601,6 @@
           <span class="stat-row-value" data-stat="glossary-count">—</span>
         </div>
       </div>
-      <div class="ascii-rule"></div>
     </section>
 
     <section class="toc container" id="contents">

--- a/site/index.html
+++ b/site/index.html
@@ -7,13 +7,13 @@
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect width='32' height='32' fill='%23fafaf5'/><rect x='2' y='2' width='28' height='28' fill='none' stroke='%233553ff' stroke-width='1.2'/><text x='6' y='22' font-size='14' font-family='monospace' fill='%233553ff'>AI</text></svg>">
   <meta name="description" content="299 lessons. 20 phases. Build the math, the model, the trainer, the tokenizer, and the agent loop. Once, by hand.">
   <meta property="og:title" content="AI Engineering from Scratch">
-  <meta property="og:description" content="299 lessons. 20 phases. Build neural networks, transformers, and LLMs from first principles. Python, TypeScript, Rust, Julia.">
+  <meta property="og:description" content="299 lessons. 20 phases. Write the backprop, the tokenizer, the attention mechanism, and the agent loop by hand before any framework gets imported. Python, TypeScript, Rust, Julia.">
   <meta property="og:image" content="https://aiengineeringfromscratch.com/og-image.png">
   <meta property="og:url" content="https://aiengineeringfromscratch.com">
   <meta property="og:type" content="website">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="AI Engineering from Scratch">
-  <meta name="twitter:description" content="299 lessons. 20 phases. Build neural networks, transformers, and LLMs from first principles.">
+  <meta name="twitter:description" content="299 lessons. 20 phases. Write the backprop, the tokenizer, the attention mechanism, and the agent loop by hand.">
   <meta name="twitter:image" content="https://aiengineeringfromscratch.com/og-image.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -597,7 +597,7 @@
         <div class="stat-row">
           <span class="stat-row-label">Glossary Terms</span>
           <span class="stat-row-bar" data-bar="glossary" style="--bar-pct:100%;" aria-hidden="true">bar</span>
-          <span class="stat-row-value" data-stat="glossary-count">—</span>
+          <span class="stat-row-value" data-stat="glossary-count">···</span>
         </div>
       </div>
     </section>

--- a/site/lesson.html
+++ b/site/lesson.html
@@ -1697,7 +1697,7 @@
 
         if (currentPhaseIndex >= 0) {
           var phase = PHASES[currentPhaseIndex];
-          html += '<div class="sidebar-phase-header">Phase ' + String(phase.id).padStart(2, '0') + ' &mdash; ' + escapeHtml(phase.name) + '</div>';
+          html += '<div class="sidebar-phase-header">Phase ' + String(phase.id).padStart(2, '0') + ' · ' + escapeHtml(phase.name) + '</div>';
           for (var k = 0; k < phase.lessons.length; k++) {
             var les = phase.lessons[k];
             var lesSlug = extractLessonSlug(les, k);
@@ -2737,8 +2737,8 @@
 
       function langIcon(filename) {
         var ext = filename.split('.').pop().toLowerCase();
-        var map = { py: '\u{1F40D}', python: '\u{1F40D}', ts: '\u{1F535}', js: '\u{1F7E1}', rust: '\u{1F9E0}', rs: '\u{1F9E0}', jl: '\u{1F7E2}', julia: '\u{1F7E2}', sh: '\u{1F4BB}', bash: '\u{1F4BB}' };
-        return map[ext] || '\u{1F4C4}';
+        var map = { py: 'PY', python: 'PY', ts: 'TS', js: 'JS', rust: 'RS', rs: 'RS', jl: 'JL', julia: 'JL', sh: 'SH', bash: 'SH' };
+        return map[ext] || '··';
       }
 
       function langCommand(filename) {
@@ -2767,7 +2767,7 @@
       function renderOutputsPanel(container) {
         var panel = document.createElement('div');
         panel.className = 'ai-panel';
-        panel.innerHTML = '<div class="ai-panel-header"><div class="ai-panel-icon coral">\u{1F4E6}</div><div class="ai-panel-title">What This Lesson Ships</div></div><div class="ai-panel-subtitle">Prompts, skills, and artifacts you can use right now</div><div id="outputsContent" class="panel-loading">Loading outputs...</div>';
+        panel.innerHTML = '<div class="ai-panel-header"><div class="ai-panel-icon">O</div><div class="ai-panel-title">What This Lesson Ships</div></div><div class="ai-panel-subtitle">Prompts, skills, and artifacts you can use right now</div><div id="outputsContent" class="panel-loading">Loading outputs...</div>';
         container.appendChild(panel);
 
         ghApiFetch(lessonPath + '/outputs', function (err, data) {
@@ -2825,7 +2825,7 @@
       function renderCodePanel(container) {
         var panel = document.createElement('div');
         panel.className = 'ai-panel';
-        panel.innerHTML = '<div class="ai-panel-header"><div class="ai-panel-icon blue">\u{1F4BB}</div><div class="ai-panel-title">Run the Code</div></div><div class="ai-panel-subtitle">Executable files from this lesson</div><div id="codeContent" class="panel-loading">Loading code files...</div>';
+        panel.innerHTML = '<div class="ai-panel-header"><div class="ai-panel-icon">C</div><div class="ai-panel-title">Run the Code</div></div><div class="ai-panel-subtitle">Executable files from this lesson</div><div id="codeContent" class="panel-loading">Loading code files...</div>';
         container.appendChild(panel);
 
         ghApiFetch(lessonPath + '/code', function (err, data) {
@@ -2943,7 +2943,7 @@
           phase = fl.phaseSlug || '';
         }
 
-        var html = '<div class="ai-panel-header"><div class="ai-panel-icon green">\u{1F9E0}</div><div class="ai-panel-title">Test Your Understanding</div></div>';
+        var html = '<div class="ai-panel-header"><div class="ai-panel-icon">Q</div><div class="ai-panel-title">Test Your Understanding</div></div>';
         html += '<div class="ai-panel-subtitle">Did you get it?</div>';
         html += '<div class="quiz-container" id="quizContainer">';
 
@@ -3035,7 +3035,7 @@
           }
         }
 
-        var html = '<div class="ai-panel-header"><div class="ai-panel-icon coral">\u{1F5FA}</div><div class="ai-panel-title">Learning Path</div></div>';
+        var html = '<div class="ai-panel-header"><div class="ai-panel-icon">P</div><div class="ai-panel-title">Learning Path</div></div>';
         html += '<div class="ai-panel-subtitle">Phase ' + String(phase.id).padStart(2, '0') + ': ' + escapeHtml(phase.name) + '</div>';
 
         html += '<div class="learning-timeline">';
@@ -3090,7 +3090,7 @@
         var phaseIdx = current.phaseIndex;
         var phase = PHASES[phaseIdx];
 
-        var html = '<div class="ai-panel-header"><div class="ai-panel-icon blue">\u{1F680}</div><div class="ai-panel-title">Continue Learning</div></div>';
+        var html = '<div class="ai-panel-header"><div class="ai-panel-icon">N</div><div class="ai-panel-title">Continue Learning</div></div>';
         html += '<div class="continue-panel">';
 
         if (!next || !next.path) {

--- a/site/prereqs.html
+++ b/site/prereqs.html
@@ -411,7 +411,7 @@
     <div class="container">
       <div class="prereqs-header">
         <h1>Roadmap</h1>
-        <p>Click any phase to see what you need to learn first &mdash; and what it unlocks next.</p>
+        <p>Click any phase to see its prerequisites and what it unlocks downstream.</p>
       </div>
 
       <div class="prereqs-controls">
@@ -437,7 +437,7 @@
 
   <footer class="site-footer">
     <div class="container footer-inner">
-      <p>AI Engineering from Scratch &mdash; open source, free forever.</p>
+      <p>AI Engineering from Scratch · open source · free forever.</p>
       <div class="footer-links">
         <a href="index.html">Home</a>
         <a href="https://github.com/rohitg00/ai-engineering-from-scratch" target="_blank" rel="noopener">GitHub</a>
@@ -925,7 +925,7 @@
         }
         prereqHtml += '</ul>';
       } else {
-        prereqHtml = '<div class="detail-empty">None — this is a starting point!</div>';
+        prereqHtml = '<div class="detail-empty">None. This is a starting point.</div>';
       }
 
       /* Unlocks list */
@@ -940,7 +940,7 @@
         }
         unlockHtml += '</ul>';
       } else {
-        unlockHtml = '<div class="detail-empty">Final destination — you made it!</div>';
+        unlockHtml = '<div class="detail-empty">Final destination. End of the curriculum.</div>';
       }
 
       /* Compute exact GitHub tree URL using standard slug logic */

--- a/site/style.css
+++ b/site/style.css
@@ -788,6 +788,74 @@ p.dropcap::first-letter {
   transform: translateY(0);
 }
 
+.reveal {
+  opacity: 0;
+  transform: translateY(20px);
+  transition:
+    opacity 0.7s cubic-bezier(0.22, 1, 0.36, 1) var(--stagger-delay, 0ms),
+    transform 0.7s cubic-bezier(0.22, 1, 0.36, 1) var(--stagger-delay, 0ms);
+  will-change: opacity, transform;
+}
+
+.reveal.in-view {
+  opacity: 1;
+  transform: none;
+}
+
+.reveal--left {
+  transform: translateX(-20px);
+}
+.reveal--left.in-view {
+  transform: none;
+}
+
+.ascii-rule {
+  clip-path: inset(0 100% 0 0);
+  transition: clip-path 1.1s cubic-bezier(0.22, 1, 0.36, 1) var(--stagger-delay, 0ms);
+}
+.ascii-rule.in-view {
+  clip-path: inset(0 0 0 0);
+}
+
+.toc-row {
+  opacity: 0;
+  transform: translateY(8px);
+  transition:
+    opacity 0.5s cubic-bezier(0.22, 1, 0.36, 1) var(--stagger-delay, 0ms),
+    transform 0.5s cubic-bezier(0.22, 1, 0.36, 1) var(--stagger-delay, 0ms),
+    background 0.15s;
+}
+.toc-row.in-view {
+  opacity: 1;
+  transform: none;
+}
+
+@keyframes title-flicker {
+  0%, 100% { opacity: 1; }
+  18% { opacity: 0.4; }
+  20% { opacity: 1; }
+  62% { opacity: 0.7; }
+  64% { opacity: 1; }
+}
+
+.manual-title {
+  animation: title-flicker 2.4s ease-out 0.1s 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .reveal,
+  .ascii-rule,
+  .toc-row,
+  .stat-row-bar::before,
+  .manual-title {
+    transition: none !important;
+    animation: none !important;
+    opacity: 1 !important;
+    transform: none !important;
+    clip-path: none !important;
+  }
+}
+
 @media (max-width: 1024px) {
   .container {
     padding: 0 24px;

--- a/site/style.css
+++ b/site/style.css
@@ -789,43 +789,51 @@ p.dropcap::first-letter {
 }
 
 .reveal {
-  opacity: 0;
-  transform: translateY(20px);
   transition:
     opacity 0.7s cubic-bezier(0.22, 1, 0.36, 1) var(--stagger-delay, 0ms),
     transform 0.7s cubic-bezier(0.22, 1, 0.36, 1) var(--stagger-delay, 0ms);
   will-change: opacity, transform;
 }
 
-.reveal.in-view {
+body.js-anim .reveal {
+  opacity: 0;
+  transform: translateY(20px);
+}
+
+body.js-anim .reveal--left {
+  transform: translateX(-20px);
+}
+
+body.js-anim .reveal.in-view {
   opacity: 1;
   transform: none;
 }
 
-.reveal--left {
-  transform: translateX(-20px);
-}
-.reveal--left.in-view {
-  transform: none;
-}
-
 .ascii-rule {
-  clip-path: inset(0 100% 0 0);
   transition: clip-path 1.1s cubic-bezier(0.22, 1, 0.36, 1) var(--stagger-delay, 0ms);
 }
-.ascii-rule.in-view {
+
+body.js-anim .ascii-rule {
+  clip-path: inset(0 100% 0 0);
+}
+
+body.js-anim .ascii-rule.in-view {
   clip-path: inset(0 0 0 0);
 }
 
 .toc-row {
-  opacity: 0;
-  transform: translateY(8px);
   transition:
     opacity 0.5s cubic-bezier(0.22, 1, 0.36, 1) var(--stagger-delay, 0ms),
     transform 0.5s cubic-bezier(0.22, 1, 0.36, 1) var(--stagger-delay, 0ms),
     background 0.15s;
 }
-.toc-row.in-view {
+
+body.js-anim .toc-row {
+  opacity: 0;
+  transform: translateY(8px);
+}
+
+body.js-anim .toc-row.in-view {
   opacity: 1;
   transform: none;
 }


### PR DESCRIPTION

## What animates now

| Element | Animation | Trigger |
|---|---|---|
| Masthead title | 2.4s flicker on first paint | page load (CRT-style boot) |
| Tagline + attribution | fade-up, staggered 80ms | viewport entry |
| Section eyebrows (PREFACE / CURRENT PROGRESS / TABLE OF CONTENTS / COLOPHON) | slide-in from left | viewport entry |
| Section bodies | fade-up, 80–120ms after eyebrow | viewport entry |
| ASCII rules (`░░░▒▒▒…`) | left → right wipe via clip-path inset | viewport entry |
| Stat bars (FINISHED LESSONS / PHASES / etc.) | 0% → target % fill | stat-block enters viewport |
| TOC rows (the 20 phase rows) | fade-up, staggered 30ms each | row enters viewport |
| FIG_001 curriculum stack SVG | seven panels assemble from collapsed → exploded as you scroll | scroll fraction 0..1 |

## How the SVG explode works (scroll-fraction pattern)

```js
function update() {
  var rect = container.getBoundingClientRect();
  var progress = clamp01((vh - rect.top) / (vh - vh*0.35));
  progress = 1 - Math.pow(1 - progress, 3);  // ease-out cubic

  layers.forEach(layer => {
    var final = parseFloat(layer.dataset.final);
    layer.setAttribute('transform', \`translate(0, \${-final * progress})\`);
  });
}
window.addEventListener('scroll', () => requestAnimationFrame(update), { passive: true });
```

No animation libraries. Pure rAF. Each \`.explode-layer\` exposes a \`data-final\` attribute; each \`.explode-label\` exposes \`data-final + data-stagger\` so labels fade in offset 60ms per item. At \`progress=0\` the seven panels sit at the same y and the figure looks like one solid plate; at \`progress=1\` they fan out 36px apart with leader lines reaching the right-margin labels.

## Reduced motion

\`@media (prefers-reduced-motion: reduce)\` opts out fully — every transition, animation, and clip-path is disabled, the figure renders at progress=1 immediately, and the page is static. Tested via DevTools "Emulate prefers-reduced-motion: reduce" — no jank.

## Test plan

- [x] Masthead flicker fires once on first paint
- [x] ASCII rules wipe in left→right when scrolled past
- [x] Stat bars start at 0% and animate to target on viewport entry
- [x] TOC rows stagger fade-up
- [x] FIG_001 stack: at top of page collapsed (one panel), past viewport-mid fully exploded (seven panels with labels)
- [x] Reduced-motion: all animations off, figure shown at final state
- [ ] After merge: verify on Firefox + Safari (different IntersectionObserver thresholds)
- [ ] Performance: check Lighthouse — animations are GPU-friendly (transform + opacity only)

## Why this is small (and good)

This is a single-figure demo. The same pattern (\`data-svg-explode\` wrapper + \`.explode-layer\` panels + \`.explode-label\` callouts) drops into FIG_004 (gaussian kernel — bell curve draws in via stroke-dashoffset, kernel cells light up sequentially) and FIG_005 (attention heads — 4 panels assemble from a single plate). PR-93 adds the static figures; this PR adds the animation primitives.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scroll-driven SVG “explode” visuals, staggered TOC/attribution reveals, and per-row stagger timing for richer page interactions
  * Progress bars now record target values and animate only when visible for smoother updates

* **Accessibility**
  * Enhanced reduced-motion support: animations disabled and final states applied for prefers-reduced-motion

* **Documentation**
  * Updated homepage copy, metadata, README overview, and several page texts to reflect curriculum details

* **Style**
  * New reveal/transition styles, TOC row animations, and title flicker for refined visual polish

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/ai-engineering-from-scratch/pull/95)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
