### PR TITLE
fix(lesson): mermaid diagrams clipping inside nodes

### DIFF
--- a/site/lesson.html
+++ b/site/lesson.html
@@ -908,6 +908,22 @@
       height: auto;
     }
 
+    .lesson-article .mermaid-render foreignObject p,
+    .lesson-article .mermaid-render foreignObject span,
+    .mermaid-modal-body foreignObject p,
+    .mermaid-modal-body foreignObject span {
+      font-family: var(--font-mono);
+      font-size: 13px;
+      line-height: 1.4;
+      letter-spacing: 0.02em;
+      text-align: center;
+      text-transform: none;
+      margin: 0;
+      hyphens: none;
+      -webkit-hyphens: none;
+      color: var(--ink);
+    }
+
     .lesson-nav-bottom {
       display: flex;
       justify-content: space-between;
@@ -1557,7 +1573,17 @@
     mermaid.initialize({
       startOnLoad: false,
       theme: document.documentElement.getAttribute('data-theme') === 'light' ? 'default' : 'dark',
-      fontFamily: 'Patrick Hand, cursive'
+      fontFamily: 'JetBrains Mono, ui-monospace, monospace',
+      themeVariables: {
+        fontSize: '13px'
+      },
+      flowchart: {
+        useMaxWidth: true,
+        htmlLabels: true,
+        nodeSpacing: 40,
+        rankSpacing: 50,
+        padding: 12
+      }
     });
     window._mermaidReady = mermaid;
   </script>
@@ -2343,12 +2369,21 @@
       }
 
       function renderMermaidBlocks() {
+        var fontsReady = (document.fonts && document.fonts.load)
+          ? Promise.all([
+              document.fonts.load('400 13px "JetBrains Mono"'),
+              document.fonts.load('500 13px "JetBrains Mono"'),
+              document.fonts.load('700 13px "JetBrains Mono"')
+            ]).catch(function () {})
+          : Promise.resolve();
         var check = setInterval(function () {
           if (!window._mermaidReady) return;
           clearInterval(check);
-          rerenderMermaidBlocks();
-          bindMermaidToolbar();
-          initMermaidModal();
+          fontsReady.then(function () {
+            rerenderMermaidBlocks();
+            bindMermaidToolbar();
+            initMermaidModal();
+          });
         }, 100);
         setTimeout(function () { clearInterval(check); }, 10000);
       }
@@ -2360,7 +2395,13 @@
       function updateMermaidThemeAndRerender() {
         if (!window._mermaidReady) return;
         try {
-          window._mermaidReady.initialize({ startOnLoad: false, theme: mermaidTheme(), fontFamily: 'Patrick Hand, cursive' });
+          window._mermaidReady.initialize({
+            startOnLoad: false,
+            theme: mermaidTheme(),
+            fontFamily: 'JetBrains Mono, ui-monospace, monospace',
+            themeVariables: { fontSize: '13px' },
+            flowchart: { useMaxWidth: true, htmlLabels: true, nodeSpacing: 40, rankSpacing: 50, padding: 12 }
+          });
         } catch (_) {}
         rerenderMermaidBlocks();
         rerenderMermaidModal();


### PR DESCRIPTION
## Summary

Mermaid flowchart nodes were clipping their own text. Three CSS/JS bugs compounded.

**Root causes:**

1. `fontFamily: 'Patrick Hand, cursive'` in mermaid init pointed at a font we don't load. Browser fell back to the body's serif (Source Serif 4), so all node labels rendered as a justified italic-prone serif.

2. `.lesson-article p` sets `font-family: var(--font-body)`, `font-size: 1.06rem`, `text-align: justify`, and `hyphens: auto`. Mermaid renders its labels as `<p>` inside `foreignObject`, and those rules cascade into the SVG — but only **after** mermaid has already measured node dimensions at 13px. Result: labels were physically larger than the boxes mermaid drew around them, and the box clipped the overflow.

3. `document.fonts.ready` resolves before Google Fonts' lazy on-demand weight loads finish. So even when the family was right, JetBrains Mono was still `unloaded` at first paint and mermaid measured wrong glyph widths.

**Fixes:**

- `fontFamily` → `JetBrains Mono, ui-monospace, monospace` (already in head font URL)
- New scoped CSS reset for `.lesson-article .mermaid-render foreignObject p/span` so the article's body-paragraph rule cannot override mermaid's measured font/size/alignment
- `document.fonts.ready` replaced with explicit `document.fonts.load('400 13px JetBrains Mono')` × 3 weights before the first render
- `themeVariables.fontSize=13px` + flowchart `padding`, `nodeSpacing`, `rankSpacing` for consistent breathing room

## Before / After

| | |
|---|---|
| Before | Boxes too short, text falling out of node bottoms ("JULIA", "JULIAUP", "EDITOR GPU" all clipped). Serif font where mono was specified. |
| After | All node text fits inside its box. JBM mono throughout. Correct line wrapping. |

## Test plan

- [x] Local `python3 -m http.server` on `site/`
- [x] Visited `lesson.html?path=phases/00-setup-and-tooling/01-dev-environment`
- [x] Mermaid rendered correctly with JBM mono, no clipping (screenshot verified)
- [ ] Reviewer: spot-check a second lesson with mermaid, both light + dark theme

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced visual appearance of diagrams on lesson pages with better typography and improved layout spacing
  * Diagrams now render more reliably by ensuring web fonts load properly before displaying
  * Better visual styling and typography for expanded diagram modals

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/ai-engineering-from-scratch/pull/96)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->