### PR TITLE
fix(lesson): use wikimedia/wikipedia dataset name for datasets v3+ co…

### DIFF
--- a/phases/00-setup-and-tooling/09-data-management/docs/en.md
+++ b/phases/00-setup-and-tooling/09-data-management/docs/en.md
@@ -57,7 +57,7 @@ This downloads the IMDB movie review dataset. After the first download, it loads
 Some datasets are too large to fit on disk. Streaming loads them row by row without downloading the full thing.
 
 ```python
-dataset = load_dataset("wikipedia", "20220301.en", split="train", streaming=True)
+dataset = load_dataset("wikimedia/wikipedia", "20220301.en", split="train", streaming=True)
 
 for i, example in enumerate(dataset):
     print(example["title"])


### PR DESCRIPTION
# fix(lesson): use wikimedia/wikipedia dataset name for datasets v3+ compatibility

## What this PR does

Fixes the streaming example in the data-management lesson that breaks on `datasets` v3+ due to the Wikipedia dataset being migrated off legacy scripts.

## Kind of change

- [x] Fix to an existing lesson

## Checklist

- [x] Code runs without errors with the listed dependencies
- [x] No comments in code files (docs explain, code is self-explanatory)
- [ ] Built from scratch first, then shown with a framework (for new lessons) — N/A
- [ ] Lesson folder matches `LESSON_TEMPLATE.md` structure — N/A
- [ ] ROADMAP.md row for the lesson is a markdown link — N/A, no new lesson
- [x] One lesson per commit (atomic per-lesson rule)
- [x] Tested locally / code output matches what `docs/en.md` claims

## Phase / lesson

Phase 0 · 09-data-management

## Notes for reviewer

`datasets` v3.0 dropped support for loading datasets via Python scripts. The `wikipedia` dataset used to ship with a `wikipedia.py` loader script. It's now hosted under the `wikimedia` org on the Hub as plain Parquet files.

Before this fix, Step 3 of the lesson throws:

```
RuntimeError: Dataset scripts are no longer supported, but found wikipedia.py
```

One-line fix in `docs/en.md`:

```python
# before
load_dataset("wikipedia", "20220301.en", split="train", streaming=True)

# after
load_dataset("wikimedia/wikipedia", "20220301.en", split="train", streaming=True)
```

`code/data_utils.py` uses `rotten_tomatoes` throughout, so no changes needed there.

**References:**
- [HF Forum: Dataset scripts are no longer supported](https://discuss.huggingface.co/t/dataset-scripts-are-no-longer-supported/163891)
- [wikimedia/wikipedia on HF Hub](https://huggingface.co/datasets/wikimedia/wikipedia)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated streaming data example documentation to reference the correct dataset source location.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/ai-engineering-from-scratch/pull/99)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->