### PR TITLE
Add README sponsor section

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
 github: [rohitg00]
+custom: ["https://github.com/rohitg00/ai-engineering-from-scratch/blob/main/SPONSORS.md"]

--- a/README.md
+++ b/README.md
@@ -935,16 +935,19 @@ Codex, OpenClaw, Hermes, or any MCP-compatible agent. Real tools, not homework.
 
 Free, MIT-licensed, 428 lessons. The curriculum is maintained on sponsorship alone. Cash only.
 
+**Reach (verified 2026-05-14):** 55,593 monthly visitors · 90,709 page views · 7.5K stars ·
+Twitter/X is the #1 acquisition channel.
+
 | Tier | $/mo | What you get |
 |------|------|---|
 | Backer | $25 | Name in BACKERS.md |
-| Bronze | $100 | Text-only row in README sponsor block |
-| Silver | $500 | Small logo in README, listed as one supported provider in API lessons |
-| Gold | $1,000 | Medium logo in README + sponsor page on the site |
-| Platinum | $2,000 | Hero logo above the fold, max 2 partners |
+| Bronze | $250 | Text-only row in README sponsor block + launch-day tweet |
+| Silver | $750 | Small logo in README + listed as one supported provider in API lessons |
+| Gold | $2,000 | Medium logo in README + sponsor page + quarterly X / LinkedIn co-feature |
+| Platinum | $5,000 | Hero logo above the fold + one dedicated integration lesson, max 1 partner |
 
-Full rate card, hard rules, and pricing anchors: [SPONSORS.md](SPONSORS.md). Sign up via
-[GitHub Sponsors](https://github.com/sponsors/rohitg00).
+Full rate card, hard rules, pricing anchors, and reach data: [SPONSORS.md](SPONSORS.md).
+Sign up via [GitHub Sponsors](https://github.com/sponsors/rohitg00).
 
 ```
 ░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒

--- a/README.md
+++ b/README.md
@@ -931,6 +931,25 @@ Codex, OpenClaw, Hermes, or any MCP-compatible agent. Real tools, not homework.
 ░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒
 ```
 
+## Sponsor the work
+
+Free, MIT-licensed, 428 lessons. The curriculum is maintained on sponsorship alone. Cash only.
+
+| Tier | $/mo | What you get |
+|------|------|---|
+| Backer | $25 | Name in BACKERS.md |
+| Bronze | $100 | Text-only row in README sponsor block |
+| Silver | $500 | Small logo in README, listed as one supported provider in API lessons |
+| Gold | $1,000 | Medium logo in README + sponsor page on the site |
+| Platinum | $2,000 | Hero logo above the fold, max 2 partners |
+
+Full rate card, hard rules, and pricing anchors: [SPONSORS.md](SPONSORS.md). Sign up via
+[GitHub Sponsors](https://github.com/sponsors/rohitg00).
+
+```
+░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒
+```
+
 ## Star history
 
 <a href="https://star-history.com/#rohitg00/ai-engineering-from-scratch&Date">

--- a/SPONSORS.md
+++ b/SPONSORS.md
@@ -1,0 +1,115 @@
+# Sponsorship
+
+`ai-engineering-from-scratch` is a free, MIT-licensed curriculum. 428 lessons across 20
+phases. The work is built and maintained by [Rohit Ghumare](https://github.com/rohitg00).
+
+Sponsorships fund the time it takes to ship lessons, keep the site running, and reply to the
+issue queue. Cash only. Credits-in-kind, equity, or "we'll write your content" arrangements
+are not accepted, see [Hard rules](#hard-rules) below.
+
+If you or your company want to support the curriculum, this page is the rate card.
+
+## How to sponsor
+
+- **GitHub Sponsors:** [github.com/sponsors/rohitg00](https://github.com/sponsors/rohitg00)
+- **Open Collective:** *coming soon, link will land here once the collective is approved*
+- **Wire / invoice** for Gold and Platinum tiers: email the maintainer through the address
+  listed on the GitHub profile.
+
+GitHub Sponsors handles billing, receipts, and tax forms. 0% platform fee on personal
+sponsorships, up to 6% on organization sponsorships, per [GitHub's policy](https://docs.github.com/en/sponsors/receiving-sponsorships-through-github-sponsors/about-github-sponsors-for-open-source-contributors).
+
+## Tier ladder
+
+| Tier | $/mo | Min term | What you get |
+|------|------|----------|---|
+| **Backer** | $25 | month-to-month | Name in [BACKERS.md](BACKERS.md), Sponsors badge on your GitHub profile |
+| **Bronze** | $100 | 3 months | Text-only row in the README sponsor block, name in BACKERS.md |
+| **Silver** | $500 | 6 months | Small logo (max 120×40) in the README sponsor row, listed as one supported provider in API lessons where applicable |
+| **Gold** | $1,000 | 6 months | Medium logo (max 200×60) in README + dedicated row on the sponsor page of the curriculum site |
+| **Platinum** | $2,000 | 12 months, max 2 partners | Hero logo above the fold + one mention per quarter in release notes |
+
+Diamond and Title tiers ($5,000+/mo) are not offered. They make sense for repos with
+verified Fortune-500 enterprise dependency, which this curriculum does not yet have.
+Pricing here is calibrated against the public sponsor pages of comparable projects (see
+[Pricing anchors](#pricing-anchors) below).
+
+## Hard rules
+
+These rules are non-negotiable. Sponsors who cannot accept them are politely declined.
+
+1. **No lesson-body placements.** Logos appear in the README sponsor block, on the
+   curriculum site's sponsor page, and in BACKERS.md only. Never inside `phases/**/docs/en.md`,
+   `outputs/`, code samples, or anywhere a learner is reading the curriculum content itself.
+2. **"Supported provider" does not mean "recommended."** Every API lesson shows three or
+   more providers behind the same interface. Sponsors get listed alongside the others; they
+   are never marked as the default, the preferred choice, or the answer to "which should I
+   use."
+3. **No sponsor-authored content.** The maintainer writes every lesson. Sponsors review
+   integration PRs for technical accuracy only; they do not propose narratives, frame
+   trade-offs, or veto comparisons.
+4. **No roadmap veto.** Platinum sponsors may submit roadmap suggestions like anyone else.
+   The maintainer decides what ships.
+5. **30-day editorial-conflict exit.** If a sponsor pressures the maintainer to bias content,
+   the sponsorship terminates within 30 days with a pro-rata refund. The logo drops on the
+   next site deploy.
+6. **Public ledger.** Once the Open Collective is live, every dollar in and every category of
+   spend is published on the public ledger.
+7. **Conflict refusal.** The curriculum declines sponsors whose product directly contradicts
+   curriculum principles (closed-loop vibe-coding tools, vendor lock-in evangelism, agent
+   products that ignore observability or refuse to ship with open formats). Refusal is at
+   the maintainer's sole discretion. Examples of refusals will be published anonymously on
+   the public ledger when the collective is live.
+8. **Cash only.** Credits-in-kind, equity, free hardware, "we'll do your DevRel for you,"
+   and bundle deals are not accepted. They are too easy to undervalue and too hard to
+   account for cleanly on the public ledger.
+
+## Counter-proposals from prospective sponsors
+
+If your company has a different ask, the right move is to read the tier ladder and the
+hard rules, then propose a specific tier and term in your first email. Do not open with
+"how about we trade you free credits for a hero placement" or "we'd like to write the
+integration ourselves" — those are pre-declined under the hard rules above and the email
+will end with a link back to this page.
+
+## Pricing anchors
+
+The tier amounts above are anchored against public sponsor pages of comparable
+open-source projects (verified 2026-05):
+
+- **$100 Bronze** is the universal floor: [Drupal AI Developer Assistant](https://opencollective.com/drupal-ai-initiative/projects/aidev),
+  [Babel](https://opencollective.com/babel), [Parcel](https://opencollective.com/parcel),
+  [Vue.js](https://opencollective.com/vuejs) all open here.
+- **$500 Silver** matches Babel Silver, Parcel Silver, and Drupal AI Gold.
+- **$1,000 Gold** matches Babel Gold and Parcel Gold; sits between Vue Gold ($500) and Vue
+  Platinum ($2,000).
+- **$2,000 Platinum** matches Babel Base Support (billed yearly at $24,000) and Vue
+  Platinum.
+- **Diamond ($5,000+)** is skipped: only Vue at 207K stars charges this. At 7.5K stars,
+  pricing above $2K/mo loses bids.
+
+## What sponsorship pays for
+
+Listed in order of how the next dollar gets spent:
+
+1. Maintainer time on new lessons and on the issue queue.
+2. Site hosting, domain, and CDN (Vercel + custom domains).
+3. Diagram authoring tools, font licensing, design assets.
+4. One-time research or content fees for guest lesson reviewers when a phase covers
+   territory outside the maintainer's depth.
+5. Contributor bounties on specific issues that have been open longer than 30 days.
+
+## Becoming a sponsor
+
+1. Pick a tier above.
+2. Subscribe via [GitHub Sponsors](https://github.com/sponsors/rohitg00).
+3. For Silver and above, email the maintainer with: your logo (SVG preferred), the URL
+   you want it linked to, and the term length you've committed to.
+4. The logo lands in the next site deploy, usually within 48 hours.
+5. Receipts and invoices are issued by GitHub Sponsors automatically.
+
+## Becoming an ex-sponsor
+
+Cancellation is one click in your GitHub Sponsors dashboard. The logo drops on the next
+site deploy after the current billing period ends. No clawback, no exit interview, no hard
+feelings. Sponsorships fund the curriculum; they do not buy a relationship.

--- a/SPONSORS.md
+++ b/SPONSORS.md
@@ -19,20 +19,43 @@ If you or your company want to support the curriculum, this page is the rate car
 GitHub Sponsors handles billing, receipts, and tax forms. 0% platform fee on personal
 sponsorships, up to 6% on organization sponsorships, per [GitHub's policy](https://docs.github.com/en/sponsors/receiving-sponsorships-through-github-sponsors/about-github-sponsors-for-open-source-contributors).
 
+## Reach
+
+These are real numbers, not pitch decks. Verified 2026-05-14 from the official analytics
+dashboard, screenshots available on request.
+
+| Window | Visitors | Page views | Growth |
+|---|---|---|---|
+| Last 7 days | 33,569 | 53,917 | +450% / +399% |
+| Last 30 days | 55,593 | 90,709 | +335% / +403% |
+
+- **GitHub stars:** 7,500+ and growing
+- **Top referrers (30d):** X / Twitter (18K), Google (7.1K), GitHub (5.3K), Instagram (1.2K),
+  Brave (505), LinkedIn (470)
+- **Top pages:** `/` (63K views), `/index.html` (15K), `/prereqs.html` (5.5K),
+  `/catalog.html` (4.9K), `/glossary.html` (2K)
+- **Cross-platform amplification:** Twitter/X is the #1 acquisition channel; Gold and
+  Platinum sponsors get co-amplified on the same channel via release-note threads.
+
+A sponsor placement at this scale is in the same range as a paid slot in a 50-100K monthly
+dev newsletter or a mid-tier independent dev blog.
+
 ## Tier ladder
 
 | Tier | $/mo | Min term | What you get |
 |------|------|----------|---|
 | **Backer** | $25 | month-to-month | Name in [BACKERS.md](BACKERS.md), Sponsors badge on your GitHub profile |
-| **Bronze** | $100 | 3 months | Text-only row in the README sponsor block, name in BACKERS.md |
-| **Silver** | $500 | 6 months | Small logo (max 120×40) in the README sponsor row, listed as one supported provider in API lessons where applicable |
-| **Gold** | $1,000 | 6 months | Medium logo (max 200×60) in README + dedicated row on the sponsor page of the curriculum site |
-| **Platinum** | $2,000 | 12 months, max 2 partners | Hero logo above the fold + one mention per quarter in release notes |
+| **Bronze** | $250 | 3 months | Text-only row in the README sponsor block, name in BACKERS.md, one launch-day tweet thanking the tier |
+| **Silver** | $750 | 6 months | Small logo (max 120×40) in the README sponsor row, listed as one supported provider in API lessons where applicable, quarterly thank-you in release notes |
+| **Gold** | $2,000 | 6 months | Medium logo (max 200×60) in README + dedicated row on the sponsor page of the curriculum site + one X / LinkedIn co-feature per quarter |
+| **Platinum** | $5,000 | 12 months, max 1 partner | Hero logo above the fold + named in every release-notes post for the term + one dedicated integration lesson under Phase 11 or Phase 14, written by the maintainer to the same editorial standard as the rest of the curriculum |
 
-Diamond and Title tiers ($5,000+/mo) are not offered. They make sense for repos with
-verified Fortune-500 enterprise dependency, which this curriculum does not yet have.
-Pricing here is calibrated against the public sponsor pages of comparable projects (see
-[Pricing anchors](#pricing-anchors) below).
+Diamond / Title tiers ($10,000+/mo) are not offered today. Reasonable to revisit once
+monthly visitors clear 250K or there is verified Fortune-500 enterprise dependency.
+
+Pricing is calibrated against the public sponsor pages of comparable open-source
+projects, the analytics above, and standard dev-blog sponsor rates at the 50-100K monthly
+visitor scale (see [Pricing anchors](#pricing-anchors) below).
 
 ## Hard rules
 
@@ -74,19 +97,25 @@ will end with a link back to this page.
 
 ## Pricing anchors
 
-The tier amounts above are anchored against public sponsor pages of comparable
-open-source projects (verified 2026-05):
+The tier amounts above are anchored against (a) public sponsor pages of comparable
+open-source projects, and (b) standard sponsor-slot rates for 50-100K monthly visitor dev
+publications. Verified 2026-05.
 
-- **$100 Bronze** is the universal floor: [Drupal AI Developer Assistant](https://opencollective.com/drupal-ai-initiative/projects/aidev),
+Comparable open-source rate cards:
+
+- **Open-source baseline** — [Drupal AI Developer Assistant](https://opencollective.com/drupal-ai-initiative/projects/aidev),
   [Babel](https://opencollective.com/babel), [Parcel](https://opencollective.com/parcel),
-  [Vue.js](https://opencollective.com/vuejs) all open here.
-- **$500 Silver** matches Babel Silver, Parcel Silver, and Drupal AI Gold.
-- **$1,000 Gold** matches Babel Gold and Parcel Gold; sits between Vue Gold ($500) and Vue
-  Platinum ($2,000).
-- **$2,000 Platinum** matches Babel Base Support (billed yearly at $24,000) and Vue
+  [Vue.js](https://opencollective.com/vuejs) all open Bronze at $100/mo with text-only
+  recognition. Bronze here sits at $250 because the curriculum carries the audience traffic
+  none of those repos individually carry.
+- **$750 Silver** sits above Babel Silver ($500) and Drupal AI Gold ($500); below Vue
+  Platinum ($2,000). Defensible at the curriculum's monthly traffic.
+- **$2,000 Gold** matches Babel Base Support (billed yearly at $24K = $2K/mo) and Vue
   Platinum.
-- **Diamond ($5,000+)** is skipped: only Vue at 207K stars charges this. At 7.5K stars,
-  pricing above $2K/mo loses bids.
+- **$5,000 Platinum** matches Vue Diamond. At 7.5K stars + 55K monthly visitors + the
+  current growth slope, the dedicated lesson + hero placement is what justifies the price.
+- **Diamond / Title ($10K+)** is skipped. Reasonable to revisit once monthly visitors
+  clear 250K.
 
 ## What sponsorship pays for
 


### PR DESCRIPTION
## Summary

Adds `SPONSORS.md` with a cash-only tier ladder, hard rules on editorial independence, and pricing anchors against comparable repos. Updates `.github/FUNDING.yml` to point at the page and surfaces a sponsor section in `README.md` between Contributing and Star history.

## Tier ladder

| Tier | $/mo | Min term |
|---|---|---|
| Backer | $25 | month-to-month |
| Bronze | $100 | 3 months |
| Silver | $500 | 6 months |
| Gold | $1,000 | 6 months |
| Platinum | $2,000 | 12 months, max 2 partners |

Diamond ($5,000+) intentionally skipped — only Vue.js (207K stars) closes that tier in the public benchmark set; at 7.5K stars it loses bids.

## Pricing anchors (verified 2026-05)

| Anchor | Comparable |
|---|---|
| $100 Bronze | Drupal AI Dev Assistant, Babel, Parcel, Vue.js all open here |
| $500 Silver | Babel Silver, Parcel Silver, Drupal AI Gold |
| $1,000 Gold | Babel Gold, Parcel Gold |
| $2,000 Platinum | Babel Base Support (\$24K/year), Vue Platinum |

## Hard rules (full text in SPONSORS.md)

1. No lesson-body placements; logos only in README + sponsor page + BACKERS.md.
2. "Supported provider" never means "recommended" — every API lesson lists 3+ providers.
3. No sponsor-authored content; maintainer writes lessons, sponsor reviews for technical accuracy only.
4. No roadmap veto.
5. 30-day editorial-conflict exit with pro-rata refund.
6. Public Open Collective ledger once live.
7. Conflict refusal at maintainer discretion.
8. Cash only — no credits, equity, hardware, or bundle deals.

## Test plan

- [x] SPONSORS.md renders on GitHub (preview)
- [x] README sponsor section sits between Contributing and Star history
- [x] FUNDING.yml `custom` field points at SPONSORS.md so the GitHub Sponsors widget links here
- [ ] Once merged: reply to the Atlas Cloud inquiry pointing at this page with the Silver counter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a “Sponsor the work” section explaining sponsorship as the maintenance funding source
  * Introduced sponsorship tiers (Backer, Bronze, Silver, Gold, Platinum) with pricing, benefits, and onboarding details
  * Published comprehensive sponsorship policy and rate card covering reach metrics, logo placement rules, editorial/conflict guidelines, billing/onboarding, and cancellation flow
  * Enabled GitHub Sponsors as a funding option

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/ai-engineering-from-scratch/pull/105)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->