### PR TITLE
fix(site): keep phase cards visible after renderPhases re-render

### DIFF
--- a/site/app.js
+++ b/site/app.js
@@ -132,6 +132,24 @@
       html += '</div>';
     }
     grid.innerHTML = html;
+
+    // Re-apply per-row stagger delays for the freshly created rows.
+    initStaggerIndex();
+
+    // If the reveal observer has already initialised (body.js-anim is set),
+    // the IntersectionObserver is only watching the *original* rows it was
+    // given at startup. Re-rendering via innerHTML replaces those nodes with
+    // brand-new elements that are NOT being observed, so they would otherwise
+    // stay hidden forever under `body.js-anim .toc-row { opacity: 0 }`.
+    //
+    // Since the user has already seen the initial reveal animation, just mark
+    // the rebuilt rows as visible immediately (no second fade-in).
+    if (document.body.classList.contains('js-anim')) {
+      var newRows = grid.querySelectorAll('.toc-row');
+      for (var r = 0; r < newRows.length; r++) {
+        newRows[r].classList.add('in-view', 'visible');
+      }
+    }
   }
 
   function toRoman(num) {


### PR DESCRIPTION
renderPhases() rebuilds the .toc-row nodes via innerHTML, but the IntersectionObserver in initFadeObserver() only watches the original rows from page load. When AIFSProgress.onChange fires (e.g. on a storage event after returning from lesson.html), the new rows are not observed and stay at opacity:0 under 'body.js-anim .toc-row', making the curriculum cards disappear.

After re-rendering, re-apply stagger delays and, if the reveal has already initialised (body.js-anim is set), mark the rebuilt rows .in-view .visible immediately so they don't get stuck hidden.

<!-- Thanks for contributing. Fill out what applies. Delete sections that don't. -->

## What this PR does

<!-- One-sentence summary. -->

## Kind of change

- [ ] New lesson
- [ ] Fix to an existing lesson
- [ ] Translation
- [ ] New output (prompt, skill, agent, MCP server)
- [x] Docs / website / tooling

## Checklist

- [x] Code runs without errors with the listed dependencies
- [ ] No comments in code files (docs explain, code is self-explanatory)
- [ ] Built from scratch first, then shown with a framework (for new lessons)
- [ ] Lesson folder matches `LESSON_TEMPLATE.md` structure
- [ ] ROADMAP.md row for the lesson is a markdown link (`[Name](phases/...)`), not bare text
- [ ] One lesson per commit (atomic per-lesson rule)
- [ ] Tested locally / code output matches what `docs/en.md` claims

## Phase / lesson

<!-- e.g. Phase 5 · 03-tokenizers -->

## Notes for reviewer

<!-- Anything surprising, any deviations from the template, open questions. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed animation stagger timing to properly reapply when grid content is regenerated dynamically, ensuring smooth and consistent visual transitions throughout updates
  * Resolved visibility issues where newly created grid elements remained hidden when page animations were already in progress, preventing them from appearing as intended

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/ai-engineering-from-scratch/pull/107)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->