### PR TITLE
fix(site):mermaid diagram light mode text color fixed

### DIFF
--- a/site/lesson.html
+++ b/site/lesson.html
@@ -2613,7 +2613,6 @@
         window._mermaidReady.render('mermaid-modal-svg', def).then(function (result) {
           if (center._mermaidRenderToken !== token) return;
           center.innerHTML = result.svg;
-          fixMermaidLightModeContrast(center.querySelector('svg'));
         }).catch(function () {
           if (center._mermaidRenderToken !== token) return;
           center.innerHTML = '<p style="color:var(--text-muted);font-style:italic;">Diagram could not be rendered.</p>';

--- a/site/lesson.html
+++ b/site/lesson.html
@@ -2453,13 +2453,14 @@
         if (document.documentElement.getAttribute('data-theme') !== 'light' || !def) return def;
         return def.split('\n').map(function (line) {
           if (!/^\s*style\s+/i.test(line)) return line;
-          var lower = line.toLowerCase();
           var hadDarkFill = false;
           var out = line;
           Object.keys(MERMAID_DARK_FILLS).forEach(function (dark) {
-            if (lower.indexOf('fill:' + dark) === -1) return;
+            var escapeDark = dark.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            var fillRe = new RegExp('\\bfill:\\s*' + escapeDark + '\\b', 'i');
+            if (!fillRe.test(out)) return;
             hadDarkFill = true;
-            out = out.replace(new RegExp('fill:\\s*' + dark.replace('#', '#') + '\\b', 'gi'), 'fill:' + MERMAID_DARK_FILLS[dark]);
+            out = out.replace(fillRe, 'fill:' + MERMAID_DARK_FILLS[dark]);
           });
           if (hadDarkFill && /color:\s*#fff\b/i.test(out)) {
             out = out.replace(/color:\s*#fff\b/gi, 'color:#1a1a2e');

--- a/site/lesson.html
+++ b/site/lesson.html
@@ -2447,6 +2447,27 @@
         return document.documentElement.getAttribute('data-theme') === 'light' ? 'default' : 'dark';
       }
 
+      var MERMAID_DARK_FILLS = { '#1a1a2e': '#eef0f8', '#0f3460': '#d6e4f7', '#16213e': '#dce8f5' };
+
+      function prepareMermaidDef(def) {
+        if (document.documentElement.getAttribute('data-theme') !== 'light' || !def) return def;
+        return def.split('\n').map(function (line) {
+          if (!/^\s*style\s+/i.test(line)) return line;
+          var lower = line.toLowerCase();
+          var hadDarkFill = false;
+          var out = line;
+          Object.keys(MERMAID_DARK_FILLS).forEach(function (dark) {
+            if (lower.indexOf('fill:' + dark) === -1) return;
+            hadDarkFill = true;
+            out = out.replace(new RegExp('fill:\\s*' + dark.replace('#', '#') + '\\b', 'gi'), 'fill:' + MERMAID_DARK_FILLS[dark]);
+          });
+          if (hadDarkFill && /color:\s*#fff\b/i.test(out)) {
+            out = out.replace(/color:\s*#fff\b/gi, 'color:#1a1a2e');
+          }
+          return out;
+        }).join('\n');
+      }
+
       function updateMermaidThemeAndRerender() {
         if (!window._mermaidReady) return;
         try {
@@ -2471,7 +2492,7 @@
           if (!idx) return;
           var target = document.getElementById('mermaid-render-' + idx);
           if (!target) return;
-          var def = pre.textContent;
+          var def = prepareMermaidDef(pre.textContent);
           target.innerHTML = '<div class="panel-loading">Rendering diagram...</div>';
 
           var token = ++mermaidRenderSeq;
@@ -2583,7 +2604,7 @@
 
         var pre = document.getElementById('mermaid-' + openMermaidIndex);
         if (!pre) return;
-        var def = pre.textContent;
+        var def = prepareMermaidDef(pre.textContent);
 
         center.innerHTML = '<div class="panel-loading">Rendering diagram...</div>';
         var token = ++mermaidRenderSeq;
@@ -2592,6 +2613,7 @@
         window._mermaidReady.render('mermaid-modal-svg', def).then(function (result) {
           if (center._mermaidRenderToken !== token) return;
           center.innerHTML = result.svg;
+          fixMermaidLightModeContrast(center.querySelector('svg'));
         }).catch(function () {
           if (center._mermaidRenderToken !== token) return;
           center.innerHTML = '<p style="color:var(--text-muted);font-style:italic;">Diagram could not be rendered.</p>';


### PR DESCRIPTION
<!-- Thanks for contributing. Fill out what applies. Delete sections that don't. -->

## What this PR does

This PR fixes unreadable Mermaid labels in light mode on site/lesson.html. Fixes #110 

## Kind of change

- [ ] New lesson
- [x] Fix to an existing lesson
- [ ] Translation
- [ ] New output (prompt, skill, agent, MCP server)
- [x] Docs / website / tooling

## Notes for reviewer

Dark mode is unchanged: original markdown styles are used as-is.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Mermaid diagram rendering in light theme by remapping dark fill colors to lighter equivalents for better contrast.
  * Adjusted diagram rendering so both inline and modal diagrams consistently apply the light-theme color fixes and improved text color for readability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/ai-engineering-from-scratch/pull/111)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->