### PR TITLE
Add Tools We Maintain ecosystem panel + FIG_006 agent-stack diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -953,6 +953,21 @@ Sign up via [GitHub Sponsors](https://github.com/sponsors/rohitg00).
 ░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒
 ```
 
+## From the same author
+
+The curriculum teaches the primitives. These three repositories ship them in production —
+memory, reasoning, and a knowledge-base protocol — and compose into a full agent stack.
+
+| Repo | Stars | What it is |
+|---|---|---|
+| [agentmemory](https://github.com/rohitg00/agentmemory) | ![stars](https://img.shields.io/github/stars/rohitg00/agentmemory?style=flat-square&label=%E2%98%85&color=3553ff&labelColor=fafaf5) | Persistent memory for AI coding agents. The state surface from Phase 14, productionized. |
+| [agentbrain](https://github.com/rohitg00/agentbrain) | ![stars](https://img.shields.io/github/stars/rohitg00/agentbrain?style=flat-square&label=%E2%98%85&color=3553ff&labelColor=fafaf5) | Evidence-first operating system for agents. Reasoning + verification surfaces, end-to-end. |
+| [akbp](https://github.com/rohitg00/akbp) | ![stars](https://img.shields.io/github/stars/rohitg00/akbp?style=flat-square&label=%E2%98%85&color=3553ff&labelColor=fafaf5) | Agent Knowledge Base Protocol. Handoff + knowledge layer between sessions and across agents. |
+
+```
+░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒
+```
+
 ## Star history
 
 <a href="https://star-history.com/#rohitg00/ai-engineering-from-scratch&Date">

--- a/site/index.html
+++ b/site/index.html
@@ -611,6 +611,42 @@
     @media (max-width: 800px) {
       .ecosystem-grid { grid-template-columns: 1fr; }
     }
+
+    /* Figure card (makingsoftware aesthetic) */
+    .figure-card {
+      border: 1px solid var(--rule-soft);
+      background: var(--bg);
+      padding: 0;
+      margin: 24px 0 36px;
+      background-image: radial-gradient(circle at 4px 4px, rgba(0,0,0,0.05) 1px, transparent 1.5px);
+      background-size: 16px 16px;
+    }
+    .figure-head {
+      display: flex;
+      justify-content: space-between;
+      gap: 16px;
+      padding: 14px 24px;
+      border-bottom: 1px solid var(--rule-soft);
+      font-family: var(--font-mono);
+      font-size: 0.72rem;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+    }
+    .figure-head .left { color: var(--blueprint); }
+    .figure-head .right { color: var(--ink-mute); }
+    .figure-body {
+      padding: 32px 24px;
+      overflow-x: auto;
+    }
+    .figure-body svg { display: block; width: 100%; height: auto; max-width: 1100px; margin: 0 auto; }
+    .figure-foot {
+      padding: 14px 24px;
+      border-top: 1px solid var(--rule-soft);
+      font-family: var(--font-body);
+      font-size: 0.96rem;
+      color: var(--ink-soft);
+      line-height: 1.5;
+    }
   </style>
 </head>
 <body>
@@ -729,6 +765,96 @@
       <div class="ecosystem-eyebrow reveal reveal--left">From the same author</div>
       <h2 class="ecosystem-title reveal" style="--stagger-delay: 60ms;">Memory + reasoning + knowledge protocol</h2>
       <p class="ecosystem-lede reveal" style="--stagger-delay: 120ms;">Three open-source repositories that compose into a full agent stack. The curriculum teaches the primitives; these tools ship them in production.</p>
+
+      <figure class="figure-card reveal" style="--stagger-delay: 160ms;">
+        <div class="figure-head">
+          <span class="left">FIG_006 · the agent stack</span>
+          <span class="right">memory · reasoning · knowledge</span>
+        </div>
+        <div class="figure-body">
+          <svg viewBox="0 0 1100 460" xmlns="http://www.w3.org/2000/svg"
+               fill="none" stroke="currentColor" stroke-width="1.5"
+               role="img" aria-labelledby="figAgentStackTitle">
+            <title id="figAgentStackTitle">Three repositories — agentmemory, agentbrain, akbp — composing into the agent stack the curriculum teaches.</title>
+            <style>
+              .bp-fill { fill: #3553ff; }
+              .bp-tint { fill: rgba(53, 83, 255, 0.08); }
+              .bp-tint-strong { fill: rgba(53, 83, 255, 0.16); }
+              .ink { fill: #1a1a1a; }
+              .ink-mute { fill: #7a7a78; }
+              .mono { font-family: 'JetBrains Mono', ui-monospace, Consolas, monospace; }
+              .serif { font-family: 'Source Serif 4', Georgia, serif; }
+              .leader { stroke: #3553ff; stroke-opacity: 0.35; stroke-width: 1; }
+              .flow { stroke: #3553ff; stroke-width: 1.6; }
+              .anchor { fill: #3553ff; }
+            </style>
+
+            <!-- Center: AGENT block (what the curriculum builds) -->
+            <g transform="translate(440, 170)">
+              <rect width="220" height="120" class="bp-tint-strong" stroke="#3553ff" stroke-width="1.5"/>
+              <text x="110" y="34" text-anchor="middle" class="mono ink" font-size="12" letter-spacing="2.4">AGENT LOOP</text>
+              <line x1="20" y1="46" x2="200" y2="46" stroke="#3553ff" stroke-opacity="0.3" stroke-width="0.8"/>
+              <text x="110" y="70" text-anchor="middle" class="serif ink" font-size="14" font-style="italic">function · worker · trigger</text>
+              <text x="110" y="92" text-anchor="middle" class="serif ink-mute" font-size="13">you build this in Phase 14</text>
+              <text x="110" y="110" text-anchor="middle" class="mono ink-mute" font-size="10" letter-spacing="2">FROM THE CURRICULUM</text>
+            </g>
+
+            <!-- Left module: agentmemory -->
+            <g transform="translate(60, 180)">
+              <rect width="220" height="100" class="bp-tint" stroke="#3553ff" stroke-width="1.5"/>
+              <text x="14" y="28" class="mono bp-fill" font-size="9" letter-spacing="1.6">REPO · MEMORY SURFACE</text>
+              <text x="14" y="56" class="mono ink" font-size="18" font-weight="500">agentmemory</text>
+              <text x="14" y="78" class="serif ink-mute" font-size="13">persistent memory for AI coding agents.</text>
+              <text x="206" y="94" text-anchor="end" class="mono bp-fill" font-size="11" data-eco-svg-stars="agentmemory">★ ...</text>
+            </g>
+
+            <!-- Top module: agentbrain -->
+            <g transform="translate(440, 30)">
+              <rect width="220" height="100" class="bp-tint" stroke="#3553ff" stroke-width="1.5"/>
+              <text x="14" y="28" class="mono bp-fill" font-size="9" letter-spacing="1.6">REPO · REASONING SURFACE</text>
+              <text x="14" y="56" class="mono ink" font-size="18" font-weight="500">agentbrain</text>
+              <text x="14" y="78" class="serif ink-mute" font-size="13">evidence-first operating system for agents.</text>
+              <text x="206" y="94" text-anchor="end" class="mono bp-fill" font-size="11" data-eco-svg-stars="agentbrain">★ ...</text>
+            </g>
+
+            <!-- Right module: akbp -->
+            <g transform="translate(820, 180)">
+              <rect width="220" height="100" class="bp-tint" stroke="#3553ff" stroke-width="1.5"/>
+              <text x="14" y="28" class="mono bp-fill" font-size="9" letter-spacing="1.6">REPO · KNOWLEDGE SURFACE</text>
+              <text x="14" y="56" class="mono ink" font-size="18" font-weight="500">akbp</text>
+              <text x="14" y="78" class="serif ink-mute" font-size="13">agent knowledge base protocol.</text>
+              <text x="206" y="94" text-anchor="end" class="mono bp-fill" font-size="11" data-eco-svg-stars="akbp">★ ...</text>
+            </g>
+
+            <!-- Flow: agentmemory <-> AGENT (one label, two arrowheads) -->
+            <line x1="280" y1="230" x2="440" y2="230" class="flow"/>
+            <polyline points="434,225 440,230 434,235" class="flow"/>
+            <polyline points="286,225 280,230 286,235" class="flow"/>
+            <text x="360" y="222" text-anchor="middle" class="mono bp-fill" font-size="10" letter-spacing="1.6">READ / WRITE STATE</text>
+
+            <!-- Flow: agentbrain → AGENT (top) -->
+            <line x1="550" y1="130" x2="550" y2="170" class="flow"/>
+            <polyline points="545,164 550,170 555,164" class="flow"/>
+            <text x="565" y="155" class="mono bp-fill" font-size="10" letter-spacing="1.6">STEERS</text>
+
+            <!-- Flow: akbp <-> AGENT (one label, two arrowheads) -->
+            <line x1="820" y1="230" x2="660" y2="230" class="flow"/>
+            <polyline points="666,225 660,230 666,235" class="flow"/>
+            <polyline points="814,225 820,230 814,235" class="flow"/>
+            <text x="740" y="222" text-anchor="middle" class="mono bp-fill" font-size="10" letter-spacing="1.6">ANSWERS QUERIES</text>
+
+            <!-- Footer rule + caption inside SVG -->
+            <line x1="60" y1="340" x2="1040" y2="340" stroke="#3553ff" stroke-opacity="0.25" stroke-width="0.6"/>
+            <text x="60" y="372" class="mono bp-fill" font-size="10" letter-spacing="1.8">EIGHT PRIMITIVES</text>
+            <text x="60" y="396" class="serif ink" font-size="14">function · worker · trigger · runtime · HTTP/RPC · queue · session persistence · authorization policy</text>
+            <text x="60" y="424" class="serif ink-mute" font-size="13" font-style="italic">Phase 14 teaches the primitives. The three repos above are the same primitives, shipped.</text>
+          </svg>
+        </div>
+        <figcaption class="figure-foot">
+          Three repositories, one stack: <strong>agentmemory</strong> writes durable state, <strong>agentbrain</strong> steers the loop from evidence, <strong>akbp</strong> answers knowledge queries between sessions and across agents.
+        </figcaption>
+      </figure>
+
       <div class="ecosystem-grid">
         <a class="ecosystem-card reveal" style="--stagger-delay: 180ms;" href="https://github.com/rohitg00/agentmemory" target="_blank" rel="noopener">
           <div class="ecosystem-card-head">
@@ -813,9 +939,23 @@
           return r.json();
         }).then(function (data) {
           try { localStorage.setItem(key, JSON.stringify({ count: data.stargazers_count, ts: Date.now() })); } catch (e) {}
-          var el = document.querySelector('[data-eco-repo="' + repo + '"]');
-          if (el) el.textContent = fmt(data.stargazers_count);
+          paint(repo, fmt(data.stargazers_count));
         }).catch(function () {});
+      });
+
+      function paint(repo, text) {
+        document.querySelectorAll('[data-eco-repo="' + repo + '"], [data-eco-svg-stars="' + repo + '"]').forEach(function (el) {
+          el.textContent = text;
+        });
+      }
+
+      // Re-run paint for any cache hits set above (only the card was updated in the inline path).
+      ECO_REPOS.forEach(function (repo) {
+        var key = 'aifs:stars:' + repo;
+        try {
+          var cached = JSON.parse(localStorage.getItem(key));
+          if (cached && Date.now() - cached.ts < 6 * 3600 * 1000) paint(repo, fmt(cached.count));
+        } catch (e) {}
       });
     })();
   </script>

--- a/site/index.html
+++ b/site/index.html
@@ -69,6 +69,50 @@
       font-style: italic;
     }
 
+    .manual-hero-grid {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) 360px;
+      gap: 48px;
+      align-items: start;
+    }
+
+    .manual-hero-left { min-width: 0; }
+
+    .manual-hero-stack {
+      border: 1px solid var(--rule-soft);
+      background-color: var(--bg);
+      background-image: radial-gradient(circle at 4px 4px, rgba(0,0,0,0.05) 1px, transparent 1.5px);
+      background-size: 16px 16px;
+      padding: 14px 16px 16px;
+    }
+
+    .hero-stack-head {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      gap: 10px;
+      padding-bottom: 10px;
+      border-bottom: 1px solid var(--rule-soft);
+      margin-bottom: 12px;
+      font-family: var(--font-mono);
+      font-size: 0.62rem;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+    }
+    .hero-stack-eyebrow { color: var(--blueprint); }
+    .hero-stack-tag { color: var(--ink-mute); }
+
+    .manual-hero-stack svg {
+      display: block;
+      width: 100%;
+      height: auto;
+    }
+
+    @media (max-width: 1024px) {
+      .manual-hero-grid { grid-template-columns: 1fr; gap: 32px; }
+      .manual-hero-stack { max-width: 420px; }
+    }
+
     .preface {
       padding: 48px 0 32px;
       border-bottom: 1px solid var(--rule-soft);
@@ -688,9 +732,90 @@
         <span>FIG_000 &middot; curriculum v1.0 · 2026</span>
         <span class="right">open source · MIT</span>
       </div>
-      <h1 class="manual-title">AI Engineering<br>from Scratch</h1>
-      <p class="manual-tagline reveal">416 lessons. 20 phases. Every algorithm built from raw math before a single framework gets imported.</p>
-      <p class="manual-attribution reveal" style="--stagger-delay: 80ms;">Maintained by Rohit Ghumare and contributors. Run on your own machine.</p>
+      <div class="manual-hero-grid">
+        <div class="manual-hero-left">
+          <h1 class="manual-title">AI Engineering<br>from Scratch</h1>
+          <p class="manual-tagline reveal">416 lessons. 20 phases. Every algorithm built from raw math before a single framework gets imported.</p>
+          <p class="manual-attribution reveal" style="--stagger-delay: 80ms;">Maintained by Rohit Ghumare and contributors. Run on your own machine.</p>
+        </div>
+        <aside class="manual-hero-stack reveal" style="--stagger-delay: 120ms;" aria-labelledby="heroStackTitle">
+          <div class="hero-stack-head">
+            <span class="hero-stack-eyebrow">FIG_006 · the stack</span>
+            <span class="hero-stack-tag">memory · reasoning · kb</span>
+          </div>
+          <svg viewBox="0 0 320 380" xmlns="http://www.w3.org/2000/svg"
+               fill="none" stroke="currentColor" stroke-width="1.5" role="img" aria-labelledby="heroStackTitle">
+            <title id="heroStackTitle">Three repos compose into the agent stack the curriculum teaches.</title>
+            <style>
+              .hbp-fill { fill: #3553ff; }
+              .hbp-tint { fill: rgba(53, 83, 255, 0.08); }
+              .hbp-tint-strong { fill: rgba(53, 83, 255, 0.16); }
+              .hink { fill: #1a1a1a; }
+              .hink-mute { fill: #7a7a78; }
+              .hmono { font-family: 'JetBrains Mono', ui-monospace, Consolas, monospace; }
+              .hflow { stroke: #3553ff; stroke-width: 1.4; }
+            </style>
+
+            <!-- agentbrain (top) -->
+            <g transform="translate(60, 16)">
+              <rect width="200" height="56" class="hbp-tint" stroke="#3553ff"/>
+              <text x="12" y="20" class="hmono hbp-fill" font-size="8" letter-spacing="1.4">REPO · REASONING</text>
+              <text x="12" y="40" class="hmono hink" font-size="14" font-weight="500">agentbrain</text>
+              <text x="188" y="50" text-anchor="end" class="hmono hbp-fill" font-size="10" data-eco-svg-stars="agentbrain">★ ...</text>
+            </g>
+
+            <!-- arrow brain -> agent -->
+            <line x1="160" y1="72" x2="160" y2="118" class="hflow"/>
+            <polyline points="155,112 160,118 165,112" class="hflow"/>
+            <text x="170" y="100" class="hmono hbp-fill" font-size="8" letter-spacing="1.4">STEERS</text>
+
+            <!-- AGENT center -->
+            <g transform="translate(60, 122)">
+              <rect width="200" height="92" class="hbp-tint-strong" stroke="#3553ff"/>
+              <text x="100" y="22" text-anchor="middle" class="hmono hink" font-size="10" letter-spacing="2">AGENT LOOP</text>
+              <line x1="14" y1="32" x2="186" y2="32" stroke="#3553ff" stroke-opacity="0.25"/>
+              <text x="100" y="52" text-anchor="middle" class="hmono hink" font-size="10">function · worker · trigger</text>
+              <text x="100" y="68" text-anchor="middle" class="hmono hink-mute" font-size="9">+ queue · persistence · authz</text>
+              <text x="100" y="84" text-anchor="middle" class="hmono hbp-fill" font-size="8" letter-spacing="1.6">FROM THE CURRICULUM</text>
+            </g>
+
+            <!-- arrow agent -> memory -->
+            <line x1="100" y1="214" x2="100" y2="258" class="hflow"/>
+            <polyline points="95,252 100,258 105,252" class="hflow"/>
+            <line x1="86" y1="214" x2="86" y2="258" class="hflow"/>
+            <polyline points="81,220 86,214 91,220" class="hflow"/>
+            <text x="115" y="240" class="hmono hbp-fill" font-size="8" letter-spacing="1.4">READ / WRITE</text>
+
+            <!-- agentmemory -->
+            <g transform="translate(0, 262)">
+              <rect width="148" height="56" class="hbp-tint" stroke="#3553ff"/>
+              <text x="12" y="20" class="hmono hbp-fill" font-size="8" letter-spacing="1.4">REPO · MEMORY</text>
+              <text x="12" y="40" class="hmono hink" font-size="14" font-weight="500">agentmemory</text>
+              <text x="136" y="50" text-anchor="end" class="hmono hbp-fill" font-size="10" data-eco-svg-stars="agentmemory">★ ...</text>
+            </g>
+
+            <!-- arrow agent -> akbp -->
+            <line x1="220" y1="214" x2="220" y2="258" class="hflow"/>
+            <polyline points="215,252 220,258 225,252" class="hflow"/>
+            <text x="270" y="240" class="hmono hbp-fill" font-size="8" letter-spacing="1.4">ANSWERS</text>
+            <line x1="234" y1="214" x2="234" y2="258" class="hflow"/>
+            <polyline points="229,220 234,214 239,220" class="hflow"/>
+
+            <!-- akbp -->
+            <g transform="translate(172, 262)">
+              <rect width="148" height="56" class="hbp-tint" stroke="#3553ff"/>
+              <text x="12" y="20" class="hmono hbp-fill" font-size="8" letter-spacing="1.4">REPO · KNOWLEDGE</text>
+              <text x="12" y="40" class="hmono hink" font-size="14" font-weight="500">akbp</text>
+              <text x="136" y="50" text-anchor="end" class="hmono hbp-fill" font-size="10" data-eco-svg-stars="akbp">★ ...</text>
+            </g>
+
+            <!-- divider -->
+            <line x1="0" y1="338" x2="320" y2="338" stroke="#3553ff" stroke-opacity="0.25" stroke-width="0.6"/>
+            <text x="160" y="358" text-anchor="middle" class="hmono hbp-fill" font-size="9" letter-spacing="2">SAME AUTHOR · OPEN SOURCE</text>
+            <text x="160" y="374" text-anchor="middle" class="hmono hink-mute" font-size="8" letter-spacing="1.4">FULL STACK BELOW · SCROLL TO FIG_006</text>
+          </svg>
+        </aside>
+      </div>
       <div class="ascii-rule" style="margin-top:48px;"></div>
     </section>
 

--- a/site/index.html
+++ b/site/index.html
@@ -108,6 +108,12 @@
       height: auto;
     }
 
+    .hero-repo-link { cursor: pointer; }
+    .hero-repo-link .hrepo-rect { transition: fill 0.15s; }
+    .hero-repo-link:hover .hrepo-rect { fill: rgba(53, 83, 255, 0.18); }
+    .hero-repo-link:focus { outline: none; }
+    .hero-repo-link:focus .hrepo-rect { stroke-width: 2; }
+
     @media (max-width: 1024px) {
       .manual-hero-grid { grid-template-columns: 1fr; gap: 32px; }
       .manual-hero-stack { max-width: 420px; }
@@ -757,12 +763,14 @@
             </style>
 
             <!-- agentbrain (top) -->
-            <g transform="translate(60, 16)">
-              <rect width="200" height="56" class="hbp-tint" stroke="#3553ff"/>
-              <text x="12" y="20" class="hmono hbp-fill" font-size="8" letter-spacing="1.4">REPO · REASONING</text>
-              <text x="12" y="40" class="hmono hink" font-size="14" font-weight="500">agentbrain</text>
-              <text x="188" y="50" text-anchor="end" class="hmono hbp-fill" font-size="10" data-eco-svg-stars="agentbrain">★ ...</text>
-            </g>
+            <a href="https://github.com/rohitg00/agentbrain" target="_blank" rel="noopener" class="hero-repo-link">
+              <g transform="translate(60, 16)">
+                <rect width="200" height="56" class="hbp-tint hrepo-rect" stroke="#3553ff"/>
+                <text x="12" y="20" class="hmono hbp-fill" font-size="8" letter-spacing="1.4">REPO · REASONING</text>
+                <text x="12" y="40" class="hmono hink" font-size="13">agentbrain</text>
+                <text x="188" y="50" text-anchor="end" class="hmono hbp-fill" font-size="10" data-eco-svg-stars="agentbrain">★ ...</text>
+              </g>
+            </a>
 
             <!-- arrow brain -> agent -->
             <line x1="160" y1="72" x2="160" y2="118" class="hflow"/>
@@ -787,12 +795,14 @@
             <text x="115" y="240" class="hmono hbp-fill" font-size="8" letter-spacing="1.4">READ / WRITE</text>
 
             <!-- agentmemory -->
-            <g transform="translate(0, 262)">
-              <rect width="148" height="56" class="hbp-tint" stroke="#3553ff"/>
-              <text x="12" y="20" class="hmono hbp-fill" font-size="8" letter-spacing="1.4">REPO · MEMORY</text>
-              <text x="12" y="40" class="hmono hink" font-size="14" font-weight="500">agentmemory</text>
-              <text x="136" y="50" text-anchor="end" class="hmono hbp-fill" font-size="10" data-eco-svg-stars="agentmemory">★ ...</text>
-            </g>
+            <a href="https://github.com/rohitg00/agentmemory" target="_blank" rel="noopener" class="hero-repo-link">
+              <g transform="translate(0, 262)">
+                <rect width="148" height="56" class="hbp-tint hrepo-rect" stroke="#3553ff"/>
+                <text x="12" y="20" class="hmono hbp-fill" font-size="8" letter-spacing="1.4">REPO · MEMORY</text>
+                <text x="12" y="40" class="hmono hink" font-size="13">agentmemory</text>
+                <text x="136" y="50" text-anchor="end" class="hmono hbp-fill" font-size="10" data-eco-svg-stars="agentmemory">★ ...</text>
+              </g>
+            </a>
 
             <!-- arrow agent -> akbp -->
             <line x1="220" y1="214" x2="220" y2="258" class="hflow"/>
@@ -802,12 +812,14 @@
             <polyline points="229,220 234,214 239,220" class="hflow"/>
 
             <!-- akbp -->
-            <g transform="translate(172, 262)">
-              <rect width="148" height="56" class="hbp-tint" stroke="#3553ff"/>
-              <text x="12" y="20" class="hmono hbp-fill" font-size="8" letter-spacing="1.4">REPO · KNOWLEDGE</text>
-              <text x="12" y="40" class="hmono hink" font-size="14" font-weight="500">akbp</text>
-              <text x="136" y="50" text-anchor="end" class="hmono hbp-fill" font-size="10" data-eco-svg-stars="akbp">★ ...</text>
-            </g>
+            <a href="https://github.com/rohitg00/akbp" target="_blank" rel="noopener" class="hero-repo-link">
+              <g transform="translate(172, 262)">
+                <rect width="148" height="56" class="hbp-tint hrepo-rect" stroke="#3553ff"/>
+                <text x="12" y="20" class="hmono hbp-fill" font-size="8" letter-spacing="1.4">REPO · KNOWLEDGE</text>
+                <text x="12" y="40" class="hmono hink" font-size="13">akbp</text>
+                <text x="136" y="50" text-anchor="end" class="hmono hbp-fill" font-size="10" data-eco-svg-stars="akbp">★ ...</text>
+              </g>
+            </a>
 
             <!-- divider -->
             <line x1="0" y1="338" x2="320" y2="338" stroke="#3553ff" stroke-opacity="0.25" stroke-width="0.6"/>
@@ -925,31 +937,37 @@
             </g>
 
             <!-- Left module: agentmemory -->
-            <g transform="translate(60, 180)">
-              <rect width="220" height="100" class="bp-tint" stroke="#3553ff" stroke-width="1.5"/>
-              <text x="14" y="28" class="mono bp-fill" font-size="9" letter-spacing="1.6">REPO · MEMORY SURFACE</text>
-              <text x="14" y="56" class="mono ink" font-size="18" font-weight="500">agentmemory</text>
-              <text x="14" y="78" class="serif ink-mute" font-size="13">persistent memory for AI coding agents.</text>
-              <text x="206" y="94" text-anchor="end" class="mono bp-fill" font-size="11" data-eco-svg-stars="agentmemory">★ ...</text>
-            </g>
+            <a href="https://github.com/rohitg00/agentmemory" target="_blank" rel="noopener" class="hero-repo-link">
+              <g transform="translate(60, 180)">
+                <rect width="220" height="100" class="bp-tint hrepo-rect" stroke="#3553ff" stroke-width="1.5"/>
+                <text x="14" y="28" class="mono bp-fill" font-size="9" letter-spacing="1.6">REPO · MEMORY SURFACE</text>
+                <text x="14" y="56" class="mono ink" font-size="17">agentmemory</text>
+                <text x="14" y="78" class="serif ink-mute" font-size="13">persistent memory for AI coding agents.</text>
+                <text x="206" y="94" text-anchor="end" class="mono bp-fill" font-size="11" data-eco-svg-stars="agentmemory">★ ...</text>
+              </g>
+            </a>
 
             <!-- Top module: agentbrain -->
-            <g transform="translate(440, 30)">
-              <rect width="220" height="100" class="bp-tint" stroke="#3553ff" stroke-width="1.5"/>
-              <text x="14" y="28" class="mono bp-fill" font-size="9" letter-spacing="1.6">REPO · REASONING SURFACE</text>
-              <text x="14" y="56" class="mono ink" font-size="18" font-weight="500">agentbrain</text>
-              <text x="14" y="78" class="serif ink-mute" font-size="13">evidence-first operating system for agents.</text>
-              <text x="206" y="94" text-anchor="end" class="mono bp-fill" font-size="11" data-eco-svg-stars="agentbrain">★ ...</text>
-            </g>
+            <a href="https://github.com/rohitg00/agentbrain" target="_blank" rel="noopener" class="hero-repo-link">
+              <g transform="translate(440, 30)">
+                <rect width="220" height="100" class="bp-tint hrepo-rect" stroke="#3553ff" stroke-width="1.5"/>
+                <text x="14" y="28" class="mono bp-fill" font-size="9" letter-spacing="1.6">REPO · REASONING SURFACE</text>
+                <text x="14" y="56" class="mono ink" font-size="17">agentbrain</text>
+                <text x="14" y="78" class="serif ink-mute" font-size="13">evidence-first operating system for agents.</text>
+                <text x="206" y="94" text-anchor="end" class="mono bp-fill" font-size="11" data-eco-svg-stars="agentbrain">★ ...</text>
+              </g>
+            </a>
 
             <!-- Right module: akbp -->
-            <g transform="translate(820, 180)">
-              <rect width="220" height="100" class="bp-tint" stroke="#3553ff" stroke-width="1.5"/>
-              <text x="14" y="28" class="mono bp-fill" font-size="9" letter-spacing="1.6">REPO · KNOWLEDGE SURFACE</text>
-              <text x="14" y="56" class="mono ink" font-size="18" font-weight="500">akbp</text>
-              <text x="14" y="78" class="serif ink-mute" font-size="13">agent knowledge base protocol.</text>
-              <text x="206" y="94" text-anchor="end" class="mono bp-fill" font-size="11" data-eco-svg-stars="akbp">★ ...</text>
-            </g>
+            <a href="https://github.com/rohitg00/akbp" target="_blank" rel="noopener" class="hero-repo-link">
+              <g transform="translate(820, 180)">
+                <rect width="220" height="100" class="bp-tint hrepo-rect" stroke="#3553ff" stroke-width="1.5"/>
+                <text x="14" y="28" class="mono bp-fill" font-size="9" letter-spacing="1.6">REPO · KNOWLEDGE SURFACE</text>
+                <text x="14" y="56" class="mono ink" font-size="17">akbp</text>
+                <text x="14" y="78" class="serif ink-mute" font-size="13">agent knowledge base protocol.</text>
+                <text x="206" y="94" text-anchor="end" class="mono bp-fill" font-size="11" data-eco-svg-stars="akbp">★ ...</text>
+              </g>
+            </a>
 
             <!-- Flow: agentmemory <-> AGENT (one label, two arrowheads) -->
             <line x1="280" y1="230" x2="440" y2="230" class="flow"/>

--- a/site/index.html
+++ b/site/index.html
@@ -109,7 +109,8 @@
       color: var(--blueprint);
     }
 
-    .hero-repo-link { cursor: pointer; }
+    .hero-repo-link { cursor: pointer; font-weight: 400; text-decoration: none; }
+    .hero-repo-link text { font-weight: 400; }
     .hero-repo-link .hrepo-rect { transition: fill 0.15s, stroke-width 0.15s; }
     .hero-repo-link:hover .hrepo-rect { fill: var(--blueprint-tint-strong); }
     .hero-repo-link:focus { outline: none; }
@@ -757,12 +758,14 @@
                fill="none" stroke="currentColor" stroke-width="1.5" role="img" aria-labelledby="heroStackTitle">
             <title id="heroStackTitle">Three repos compose into the agent stack the curriculum teaches.</title>
             <style>
+              text { font-weight: 400; }
               .hbp-fill { fill: var(--blueprint); }
               .hbp-tint { fill: var(--blueprint-tint); }
               .hbp-tint-strong { fill: var(--blueprint-tint-strong); }
               .hink { fill: var(--ink); }
               .hink-mute { fill: var(--ink-mute); }
-              .hmono { font-family: var(--font-mono); }
+              .hmono { font-family: var(--font-mono); font-weight: 400; }
+              .hserif { font-family: var(--font-body); font-weight: 400; }
               .hflow { stroke: var(--blueprint); stroke-width: 1.4; }
             </style>
 
@@ -771,7 +774,7 @@
               <g transform="translate(60, 16)">
                 <rect width="200" height="56" class="hbp-tint hrepo-rect" stroke="currentColor"/>
                 <text x="12" y="20" class="hmono hbp-fill" font-size="8" letter-spacing="1.4">REPO · REASONING</text>
-                <text x="12" y="40" class="hmono hink" font-size="13">agentbrain</text>
+                <text x="12" y="42" class="hserif hink" font-size="16" font-style="italic">agentbrain</text>
                 <text x="188" y="50" text-anchor="end" class="hmono hbp-fill" font-size="10" data-eco-svg-stars="agentbrain">★ ...</text>
               </g>
             </a>
@@ -803,7 +806,7 @@
               <g transform="translate(0, 262)">
                 <rect width="148" height="56" class="hbp-tint hrepo-rect" stroke="currentColor"/>
                 <text x="12" y="20" class="hmono hbp-fill" font-size="8" letter-spacing="1.4">REPO · MEMORY</text>
-                <text x="12" y="40" class="hmono hink" font-size="13">agentmemory</text>
+                <text x="12" y="42" class="hserif hink" font-size="16" font-style="italic">agentmemory</text>
                 <text x="136" y="50" text-anchor="end" class="hmono hbp-fill" font-size="10" data-eco-svg-stars="agentmemory">★ ...</text>
               </g>
             </a>
@@ -820,7 +823,7 @@
               <g transform="translate(172, 262)">
                 <rect width="148" height="56" class="hbp-tint hrepo-rect" stroke="currentColor"/>
                 <text x="12" y="20" class="hmono hbp-fill" font-size="8" letter-spacing="1.4">REPO · KNOWLEDGE</text>
-                <text x="12" y="40" class="hmono hink" font-size="13">akbp</text>
+                <text x="12" y="42" class="hserif hink" font-size="16" font-style="italic">akbp</text>
                 <text x="136" y="50" text-anchor="end" class="hmono hbp-fill" font-size="10" data-eco-svg-stars="akbp">★ ...</text>
               </g>
             </a>
@@ -918,13 +921,14 @@
                role="img" aria-labelledby="figAgentStackTitle">
             <title id="figAgentStackTitle">Three repositories — agentmemory, agentbrain, akbp — composing into the agent stack the curriculum teaches.</title>
             <style>
+              text { font-weight: 400; }
               .bp-fill { fill: var(--blueprint); }
               .bp-tint { fill: var(--blueprint-tint); }
               .bp-tint-strong { fill: var(--blueprint-tint-strong); }
               .ink { fill: var(--ink); }
               .ink-mute { fill: var(--ink-mute); }
-              .mono { font-family: var(--font-mono); }
-              .serif { font-family: var(--font-body); }
+              .mono { font-family: var(--font-mono); font-weight: 400; }
+              .serif { font-family: var(--font-body); font-weight: 400; }
               .leader { stroke: var(--blueprint); stroke-opacity: 0.35; stroke-width: 1; }
               .flow { stroke: var(--blueprint); stroke-width: 1.6; }
               .anchor { fill: var(--blueprint); }
@@ -945,8 +949,8 @@
               <g transform="translate(60, 180)">
                 <rect width="220" height="100" class="bp-tint hrepo-rect" stroke="currentColor" stroke-width="1.5"/>
                 <text x="14" y="28" class="mono bp-fill" font-size="9" letter-spacing="1.6">REPO · MEMORY SURFACE</text>
-                <text x="14" y="56" class="mono ink" font-size="17">agentmemory</text>
-                <text x="14" y="78" class="serif ink-mute" font-size="13">persistent memory for AI coding agents.</text>
+                <text x="14" y="58" class="serif ink" font-size="22" font-style="italic">agentmemory</text>
+                <text x="14" y="80" class="serif ink-mute" font-size="13">persistent memory for AI coding agents.</text>
                 <text x="206" y="94" text-anchor="end" class="mono bp-fill" font-size="11" data-eco-svg-stars="agentmemory">★ ...</text>
               </g>
             </a>
@@ -956,8 +960,8 @@
               <g transform="translate(440, 30)">
                 <rect width="220" height="100" class="bp-tint hrepo-rect" stroke="currentColor" stroke-width="1.5"/>
                 <text x="14" y="28" class="mono bp-fill" font-size="9" letter-spacing="1.6">REPO · REASONING SURFACE</text>
-                <text x="14" y="56" class="mono ink" font-size="17">agentbrain</text>
-                <text x="14" y="78" class="serif ink-mute" font-size="13">evidence-first operating system for agents.</text>
+                <text x="14" y="58" class="serif ink" font-size="22" font-style="italic">agentbrain</text>
+                <text x="14" y="80" class="serif ink-mute" font-size="13">evidence-first operating system for agents.</text>
                 <text x="206" y="94" text-anchor="end" class="mono bp-fill" font-size="11" data-eco-svg-stars="agentbrain">★ ...</text>
               </g>
             </a>
@@ -967,8 +971,8 @@
               <g transform="translate(820, 180)">
                 <rect width="220" height="100" class="bp-tint hrepo-rect" stroke="currentColor" stroke-width="1.5"/>
                 <text x="14" y="28" class="mono bp-fill" font-size="9" letter-spacing="1.6">REPO · KNOWLEDGE SURFACE</text>
-                <text x="14" y="56" class="mono ink" font-size="17">akbp</text>
-                <text x="14" y="78" class="serif ink-mute" font-size="13">agent knowledge base protocol.</text>
+                <text x="14" y="58" class="serif ink" font-size="22" font-style="italic">akbp</text>
+                <text x="14" y="80" class="serif ink-mute" font-size="13">agent knowledge base protocol.</text>
                 <text x="206" y="94" text-anchor="end" class="mono bp-fill" font-size="11" data-eco-svg-stars="akbp">★ ...</text>
               </g>
             </a>

--- a/site/index.html
+++ b/site/index.html
@@ -526,6 +526,91 @@
         font-size: 0.7rem;
       }
     }
+
+    .ecosystem {
+      padding: 64px 0;
+      border-top: 1px solid var(--rule-soft);
+      border-bottom: 1px solid var(--rule-soft);
+    }
+    .ecosystem-eyebrow {
+      font-family: var(--font-mono);
+      font-size: 0.72rem;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      color: var(--ink-mute);
+      margin-bottom: 12px;
+    }
+    .ecosystem-title {
+      font-family: var(--font-display);
+      font-size: clamp(1.8rem, 4vw, 2.8rem);
+      line-height: 1.1;
+      color: var(--ink);
+      margin-bottom: 12px;
+    }
+    .ecosystem-lede {
+      font-family: var(--font-body);
+      font-size: 1.06rem;
+      color: var(--ink-soft);
+      max-width: 720px;
+      line-height: 1.55;
+      margin-bottom: 36px;
+    }
+    .ecosystem-grid {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 20px;
+    }
+    .ecosystem-card {
+      display: flex;
+      flex-direction: column;
+      padding: 24px;
+      border: 1px solid var(--rule-soft);
+      background: var(--bg-surface);
+      text-decoration: none;
+      color: var(--ink);
+      transition: border-color 0.15s, background 0.15s;
+    }
+    .ecosystem-card:hover {
+      border-color: var(--blueprint);
+      background: var(--bg);
+    }
+    .ecosystem-card-head {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      margin-bottom: 12px;
+      gap: 8px;
+    }
+    .ecosystem-card-name {
+      font-family: var(--font-mono);
+      font-size: 1.05rem;
+      font-weight: 500;
+      color: var(--ink);
+    }
+    .ecosystem-card-stars {
+      font-family: var(--font-mono);
+      font-size: 0.78rem;
+      color: var(--ink-mute);
+      white-space: nowrap;
+    }
+    .ecosystem-card-desc {
+      font-family: var(--font-body);
+      font-size: 0.96rem;
+      color: var(--ink-soft);
+      line-height: 1.45;
+      flex: 1;
+    }
+    .ecosystem-card-cta {
+      font-family: var(--font-mono);
+      font-size: 0.72rem;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: var(--blueprint);
+      margin-top: 16px;
+    }
+    @media (max-width: 800px) {
+      .ecosystem-grid { grid-template-columns: 1fr; }
+    }
   </style>
 </head>
 <body>
@@ -640,6 +725,38 @@
       </div>
     </div>
 
+    <section class="ecosystem container" id="ecosystem">
+      <div class="ecosystem-eyebrow reveal reveal--left">From the same author</div>
+      <h2 class="ecosystem-title reveal" style="--stagger-delay: 60ms;">Memory + reasoning + knowledge protocol</h2>
+      <p class="ecosystem-lede reveal" style="--stagger-delay: 120ms;">Three open-source repositories that compose into a full agent stack. The curriculum teaches the primitives; these tools ship them in production.</p>
+      <div class="ecosystem-grid">
+        <a class="ecosystem-card reveal" style="--stagger-delay: 180ms;" href="https://github.com/rohitg00/agentmemory" target="_blank" rel="noopener">
+          <div class="ecosystem-card-head">
+            <span class="ecosystem-card-name">agentmemory</span>
+            <span class="ecosystem-card-stars" data-eco-repo="agentmemory"></span>
+          </div>
+          <p class="ecosystem-card-desc">Persistent memory for AI coding agents. The state surface from Phase 14, productionized.</p>
+          <span class="ecosystem-card-cta">View on GitHub →</span>
+        </a>
+        <a class="ecosystem-card reveal" style="--stagger-delay: 240ms;" href="https://github.com/rohitg00/agentbrain" target="_blank" rel="noopener">
+          <div class="ecosystem-card-head">
+            <span class="ecosystem-card-name">agentbrain</span>
+            <span class="ecosystem-card-stars" data-eco-repo="agentbrain"></span>
+          </div>
+          <p class="ecosystem-card-desc">Evidence-first operating system for agents. The reasoning + verification surfaces, wired end-to-end.</p>
+          <span class="ecosystem-card-cta">View on GitHub →</span>
+        </a>
+        <a class="ecosystem-card reveal" style="--stagger-delay: 300ms;" href="https://github.com/rohitg00/akbp" target="_blank" rel="noopener">
+          <div class="ecosystem-card-head">
+            <span class="ecosystem-card-name">akbp</span>
+            <span class="ecosystem-card-stars" data-eco-repo="akbp"></span>
+          </div>
+          <p class="ecosystem-card-desc">Agent Knowledge Base Protocol. The handoff + knowledge layer between sessions and across agents.</p>
+          <span class="ecosystem-card-cta">View on GitHub →</span>
+        </a>
+      </div>
+    </section>
+
     <section class="colophon container">
       <div class="colophon-grid">
         <div class="colophon-eyebrow reveal reveal--left">Colophon</div>
@@ -673,5 +790,34 @@
   <script src="cmdpalette.js?v=20260508a" defer></script>
   <script src="app.js?v=20260508a"></script>
   <script defer src="https://va.vercel-scripts.com/v1/script.js"></script>
+  <script>
+    (function () {
+      var ECO_REPOS = ['agentmemory', 'agentbrain', 'akbp'];
+      function fmt(n) {
+        if (typeof n !== 'number') return '';
+        if (n >= 1000) return '★ ' + (n / 1000).toFixed(1).replace(/\.0$/, '') + 'K';
+        return '★ ' + String(n);
+      }
+      ECO_REPOS.forEach(function (repo) {
+        var key = 'aifs:stars:' + repo;
+        try {
+          var cached = JSON.parse(localStorage.getItem(key));
+          if (cached && Date.now() - cached.ts < 6 * 3600 * 1000) {
+            var el = document.querySelector('[data-eco-repo="' + repo + '"]');
+            if (el) el.textContent = fmt(cached.count);
+            return;
+          }
+        } catch (e) {}
+        fetch('https://api.github.com/repos/rohitg00/' + repo).then(function (r) {
+          if (!r.ok) throw 0;
+          return r.json();
+        }).then(function (data) {
+          try { localStorage.setItem(key, JSON.stringify({ count: data.stargazers_count, ts: Date.now() })); } catch (e) {}
+          var el = document.querySelector('[data-eco-repo="' + repo + '"]');
+          if (el) el.textContent = fmt(data.stargazers_count);
+        }).catch(function () {});
+      });
+    })();
+  </script>
 </body>
 </html>

--- a/site/index.html
+++ b/site/index.html
@@ -106,13 +106,17 @@
       display: block;
       width: 100%;
       height: auto;
+      color: var(--blueprint);
     }
 
     .hero-repo-link { cursor: pointer; }
-    .hero-repo-link .hrepo-rect { transition: fill 0.15s; }
-    .hero-repo-link:hover .hrepo-rect { fill: rgba(53, 83, 255, 0.18); }
+    .hero-repo-link .hrepo-rect { transition: fill 0.15s, stroke-width 0.15s; }
+    .hero-repo-link:hover .hrepo-rect { fill: var(--blueprint-tint-strong); }
     .hero-repo-link:focus { outline: none; }
-    .hero-repo-link:focus .hrepo-rect { stroke-width: 2; }
+    .hero-repo-link:focus-visible .hrepo-rect {
+      fill: var(--blueprint-tint-strong);
+      stroke-width: 2.5;
+    }
 
     @media (max-width: 1024px) {
       .manual-hero-grid { grid-template-columns: 1fr; gap: 32px; }
@@ -688,7 +692,7 @@
       padding: 32px 24px;
       overflow-x: auto;
     }
-    .figure-body svg { display: block; width: 100%; height: auto; max-width: 1100px; margin: 0 auto; }
+    .figure-body svg { display: block; width: 100%; height: auto; max-width: 1100px; margin: 0 auto; color: var(--blueprint); }
     .figure-foot {
       padding: 14px 24px;
       border-top: 1px solid var(--rule-soft);
@@ -753,19 +757,19 @@
                fill="none" stroke="currentColor" stroke-width="1.5" role="img" aria-labelledby="heroStackTitle">
             <title id="heroStackTitle">Three repos compose into the agent stack the curriculum teaches.</title>
             <style>
-              .hbp-fill { fill: #3553ff; }
-              .hbp-tint { fill: rgba(53, 83, 255, 0.08); }
-              .hbp-tint-strong { fill: rgba(53, 83, 255, 0.16); }
-              .hink { fill: #1a1a1a; }
-              .hink-mute { fill: #7a7a78; }
-              .hmono { font-family: 'JetBrains Mono', ui-monospace, Consolas, monospace; }
-              .hflow { stroke: #3553ff; stroke-width: 1.4; }
+              .hbp-fill { fill: var(--blueprint); }
+              .hbp-tint { fill: var(--blueprint-tint); }
+              .hbp-tint-strong { fill: var(--blueprint-tint-strong); }
+              .hink { fill: var(--ink); }
+              .hink-mute { fill: var(--ink-mute); }
+              .hmono { font-family: var(--font-mono); }
+              .hflow { stroke: var(--blueprint); stroke-width: 1.4; }
             </style>
 
             <!-- agentbrain (top) -->
             <a href="https://github.com/rohitg00/agentbrain" target="_blank" rel="noopener" class="hero-repo-link">
               <g transform="translate(60, 16)">
-                <rect width="200" height="56" class="hbp-tint hrepo-rect" stroke="#3553ff"/>
+                <rect width="200" height="56" class="hbp-tint hrepo-rect" stroke="currentColor"/>
                 <text x="12" y="20" class="hmono hbp-fill" font-size="8" letter-spacing="1.4">REPO · REASONING</text>
                 <text x="12" y="40" class="hmono hink" font-size="13">agentbrain</text>
                 <text x="188" y="50" text-anchor="end" class="hmono hbp-fill" font-size="10" data-eco-svg-stars="agentbrain">★ ...</text>
@@ -779,9 +783,9 @@
 
             <!-- AGENT center -->
             <g transform="translate(60, 122)">
-              <rect width="200" height="92" class="hbp-tint-strong" stroke="#3553ff"/>
+              <rect width="200" height="92" class="hbp-tint-strong" stroke="currentColor"/>
               <text x="100" y="22" text-anchor="middle" class="hmono hink" font-size="10" letter-spacing="2">AGENT LOOP</text>
-              <line x1="14" y1="32" x2="186" y2="32" stroke="#3553ff" stroke-opacity="0.25"/>
+              <line x1="14" y1="32" x2="186" y2="32" stroke="currentColor" stroke-opacity="0.25"/>
               <text x="100" y="52" text-anchor="middle" class="hmono hink" font-size="10">function · worker · trigger</text>
               <text x="100" y="68" text-anchor="middle" class="hmono hink-mute" font-size="9">+ queue · persistence · authz</text>
               <text x="100" y="84" text-anchor="middle" class="hmono hbp-fill" font-size="8" letter-spacing="1.6">FROM THE CURRICULUM</text>
@@ -797,7 +801,7 @@
             <!-- agentmemory -->
             <a href="https://github.com/rohitg00/agentmemory" target="_blank" rel="noopener" class="hero-repo-link">
               <g transform="translate(0, 262)">
-                <rect width="148" height="56" class="hbp-tint hrepo-rect" stroke="#3553ff"/>
+                <rect width="148" height="56" class="hbp-tint hrepo-rect" stroke="currentColor"/>
                 <text x="12" y="20" class="hmono hbp-fill" font-size="8" letter-spacing="1.4">REPO · MEMORY</text>
                 <text x="12" y="40" class="hmono hink" font-size="13">agentmemory</text>
                 <text x="136" y="50" text-anchor="end" class="hmono hbp-fill" font-size="10" data-eco-svg-stars="agentmemory">★ ...</text>
@@ -814,7 +818,7 @@
             <!-- akbp -->
             <a href="https://github.com/rohitg00/akbp" target="_blank" rel="noopener" class="hero-repo-link">
               <g transform="translate(172, 262)">
-                <rect width="148" height="56" class="hbp-tint hrepo-rect" stroke="#3553ff"/>
+                <rect width="148" height="56" class="hbp-tint hrepo-rect" stroke="currentColor"/>
                 <text x="12" y="20" class="hmono hbp-fill" font-size="8" letter-spacing="1.4">REPO · KNOWLEDGE</text>
                 <text x="12" y="40" class="hmono hink" font-size="13">akbp</text>
                 <text x="136" y="50" text-anchor="end" class="hmono hbp-fill" font-size="10" data-eco-svg-stars="akbp">★ ...</text>
@@ -822,7 +826,7 @@
             </a>
 
             <!-- divider -->
-            <line x1="0" y1="338" x2="320" y2="338" stroke="#3553ff" stroke-opacity="0.25" stroke-width="0.6"/>
+            <line x1="0" y1="338" x2="320" y2="338" stroke="currentColor" stroke-opacity="0.25" stroke-width="0.6"/>
             <text x="160" y="358" text-anchor="middle" class="hmono hbp-fill" font-size="9" letter-spacing="2">SAME AUTHOR · OPEN SOURCE</text>
             <text x="160" y="374" text-anchor="middle" class="hmono hink-mute" font-size="8" letter-spacing="1.4">FULL STACK BELOW · SCROLL TO FIG_006</text>
           </svg>
@@ -914,23 +918,23 @@
                role="img" aria-labelledby="figAgentStackTitle">
             <title id="figAgentStackTitle">Three repositories — agentmemory, agentbrain, akbp — composing into the agent stack the curriculum teaches.</title>
             <style>
-              .bp-fill { fill: #3553ff; }
-              .bp-tint { fill: rgba(53, 83, 255, 0.08); }
-              .bp-tint-strong { fill: rgba(53, 83, 255, 0.16); }
-              .ink { fill: #1a1a1a; }
-              .ink-mute { fill: #7a7a78; }
-              .mono { font-family: 'JetBrains Mono', ui-monospace, Consolas, monospace; }
-              .serif { font-family: 'Source Serif 4', Georgia, serif; }
-              .leader { stroke: #3553ff; stroke-opacity: 0.35; stroke-width: 1; }
-              .flow { stroke: #3553ff; stroke-width: 1.6; }
-              .anchor { fill: #3553ff; }
+              .bp-fill { fill: var(--blueprint); }
+              .bp-tint { fill: var(--blueprint-tint); }
+              .bp-tint-strong { fill: var(--blueprint-tint-strong); }
+              .ink { fill: var(--ink); }
+              .ink-mute { fill: var(--ink-mute); }
+              .mono { font-family: var(--font-mono); }
+              .serif { font-family: var(--font-body); }
+              .leader { stroke: var(--blueprint); stroke-opacity: 0.35; stroke-width: 1; }
+              .flow { stroke: var(--blueprint); stroke-width: 1.6; }
+              .anchor { fill: var(--blueprint); }
             </style>
 
             <!-- Center: AGENT block (what the curriculum builds) -->
             <g transform="translate(440, 170)">
-              <rect width="220" height="120" class="bp-tint-strong" stroke="#3553ff" stroke-width="1.5"/>
+              <rect width="220" height="120" class="bp-tint-strong" stroke="currentColor" stroke-width="1.5"/>
               <text x="110" y="34" text-anchor="middle" class="mono ink" font-size="12" letter-spacing="2.4">AGENT LOOP</text>
-              <line x1="20" y1="46" x2="200" y2="46" stroke="#3553ff" stroke-opacity="0.3" stroke-width="0.8"/>
+              <line x1="20" y1="46" x2="200" y2="46" stroke="currentColor" stroke-opacity="0.3" stroke-width="0.8"/>
               <text x="110" y="70" text-anchor="middle" class="serif ink" font-size="14" font-style="italic">function · worker · trigger</text>
               <text x="110" y="92" text-anchor="middle" class="serif ink-mute" font-size="13">you build this in Phase 14</text>
               <text x="110" y="110" text-anchor="middle" class="mono ink-mute" font-size="10" letter-spacing="2">FROM THE CURRICULUM</text>
@@ -939,7 +943,7 @@
             <!-- Left module: agentmemory -->
             <a href="https://github.com/rohitg00/agentmemory" target="_blank" rel="noopener" class="hero-repo-link">
               <g transform="translate(60, 180)">
-                <rect width="220" height="100" class="bp-tint hrepo-rect" stroke="#3553ff" stroke-width="1.5"/>
+                <rect width="220" height="100" class="bp-tint hrepo-rect" stroke="currentColor" stroke-width="1.5"/>
                 <text x="14" y="28" class="mono bp-fill" font-size="9" letter-spacing="1.6">REPO · MEMORY SURFACE</text>
                 <text x="14" y="56" class="mono ink" font-size="17">agentmemory</text>
                 <text x="14" y="78" class="serif ink-mute" font-size="13">persistent memory for AI coding agents.</text>
@@ -950,7 +954,7 @@
             <!-- Top module: agentbrain -->
             <a href="https://github.com/rohitg00/agentbrain" target="_blank" rel="noopener" class="hero-repo-link">
               <g transform="translate(440, 30)">
-                <rect width="220" height="100" class="bp-tint hrepo-rect" stroke="#3553ff" stroke-width="1.5"/>
+                <rect width="220" height="100" class="bp-tint hrepo-rect" stroke="currentColor" stroke-width="1.5"/>
                 <text x="14" y="28" class="mono bp-fill" font-size="9" letter-spacing="1.6">REPO · REASONING SURFACE</text>
                 <text x="14" y="56" class="mono ink" font-size="17">agentbrain</text>
                 <text x="14" y="78" class="serif ink-mute" font-size="13">evidence-first operating system for agents.</text>
@@ -961,7 +965,7 @@
             <!-- Right module: akbp -->
             <a href="https://github.com/rohitg00/akbp" target="_blank" rel="noopener" class="hero-repo-link">
               <g transform="translate(820, 180)">
-                <rect width="220" height="100" class="bp-tint hrepo-rect" stroke="#3553ff" stroke-width="1.5"/>
+                <rect width="220" height="100" class="bp-tint hrepo-rect" stroke="currentColor" stroke-width="1.5"/>
                 <text x="14" y="28" class="mono bp-fill" font-size="9" letter-spacing="1.6">REPO · KNOWLEDGE SURFACE</text>
                 <text x="14" y="56" class="mono ink" font-size="17">akbp</text>
                 <text x="14" y="78" class="serif ink-mute" font-size="13">agent knowledge base protocol.</text>
@@ -987,7 +991,7 @@
             <text x="740" y="222" text-anchor="middle" class="mono bp-fill" font-size="10" letter-spacing="1.6">ANSWERS QUERIES</text>
 
             <!-- Footer rule + caption inside SVG -->
-            <line x1="60" y1="340" x2="1040" y2="340" stroke="#3553ff" stroke-opacity="0.25" stroke-width="0.6"/>
+            <line x1="60" y1="340" x2="1040" y2="340" stroke="currentColor" stroke-opacity="0.25" stroke-width="0.6"/>
             <text x="60" y="372" class="mono bp-fill" font-size="10" letter-spacing="1.8">EIGHT PRIMITIVES</text>
             <text x="60" y="396" class="serif ink" font-size="14">function · worker · trigger · runtime · HTTP/RPC · queue · session persistence · authorization policy</text>
             <text x="60" y="424" class="serif ink-mute" font-size="13" font-style="italic">Phase 14 teaches the primitives. The three repos above are the same primitives, shipped.</text>

--- a/site/lesson.html
+++ b/site/lesson.html
@@ -1306,6 +1306,62 @@
       white-space: nowrap;
     }
 
+    .tools-card {
+      margin-top: 32px;
+      padding: 16px;
+      border: 1px solid var(--rule-soft);
+      background: var(--bg-surface);
+    }
+    .tools-card-header {
+      font-family: var(--font-mono);
+      font-size: 0.66rem;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--ink-mute);
+      margin-bottom: 14px;
+    }
+    .tools-card-item {
+      display: block;
+      padding: 12px 0;
+      text-decoration: none;
+      color: var(--ink);
+      border-top: 1px solid var(--rule-soft);
+    }
+    .tools-card-item:first-of-type { border-top: none; padding-top: 0; }
+    .tools-card-item:hover { color: var(--blueprint); }
+    .tools-card-name {
+      font-family: var(--font-mono);
+      font-size: 0.82rem;
+      font-weight: 500;
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      gap: 8px;
+    }
+    .tools-card-stars {
+      font-family: var(--font-mono);
+      font-size: 0.72rem;
+      color: var(--ink-mute);
+      white-space: nowrap;
+    }
+    .tools-card-desc {
+      font-family: var(--font-body);
+      font-size: 0.86rem;
+      color: var(--ink-soft);
+      line-height: 1.4;
+      margin-top: 4px;
+    }
+    .tools-card-foot {
+      margin-top: 14px;
+      padding-top: 12px;
+      border-top: 1px solid var(--rule-soft);
+      font-family: var(--font-body);
+      font-size: 0.78rem;
+      color: var(--ink-mute);
+      font-style: italic;
+      line-height: 1.4;
+    }
+
     .phase-progress-bar {
       width: 100%;
       height: 4px;
@@ -1891,6 +1947,55 @@
         });
       }
 
+      var TOOLS = [
+        { repo: 'agentmemory', name: 'agentmemory', desc: 'Persistent memory for AI coding agents.' },
+        { repo: 'agentbrain',  name: 'agentbrain',  desc: 'Evidence-first operating system for agents.' },
+        { repo: 'akbp',        name: 'akbp',        desc: 'Agent Knowledge Base Protocol.' }
+      ];
+
+      function formatStars(n) {
+        if (typeof n !== 'number') return '';
+        if (n >= 1000) return '★ ' + (n / 1000).toFixed(1).replace(/\.0$/, '') + 'K';
+        return '★ ' + String(n);
+      }
+
+      function fetchStars(repo) {
+        var key = 'aifs:stars:' + repo;
+        try {
+          var cached = JSON.parse(localStorage.getItem(key));
+          if (cached && Date.now() - cached.ts < 6 * 3600 * 1000) return Promise.resolve(cached.count);
+        } catch (e) {}
+        return fetch('https://api.github.com/repos/rohitg00/' + repo).then(function (r) {
+          if (!r.ok) throw new Error('gh-' + r.status);
+          return r.json();
+        }).then(function (data) {
+          var count = data.stargazers_count;
+          try { localStorage.setItem(key, JSON.stringify({ count: count, ts: Date.now() })); } catch (e) {}
+          return count;
+        });
+      }
+
+      function renderToolsCard(sidebar) {
+        if (!sidebar || sidebar.querySelector('.tools-card')) return;
+        var html = '<div class="tools-card">';
+        html += '<div class="tools-card-header">Tools we maintain</div>';
+        TOOLS.forEach(function (t) {
+          html += '<a class="tools-card-item" href="https://github.com/rohitg00/' + t.repo + '" target="_blank" rel="noopener">';
+          html += '<div class="tools-card-name"><span>' + escapeHtml(t.name) + '</span><span class="tools-card-stars" data-repo="' + escapeAttr(t.repo) + '"></span></div>';
+          html += '<div class="tools-card-desc">' + escapeHtml(t.desc) + '</div>';
+          html += '</a>';
+        });
+        html += '<div class="tools-card-foot">Memory + reasoning + knowledge protocol for agents and harnesses.</div>';
+        html += '</div>';
+        sidebar.insertAdjacentHTML('beforeend', html);
+        TOOLS.forEach(function (t) {
+          fetchStars(t.repo).then(function (count) {
+            var el = sidebar.querySelector('.tools-card-stars[data-repo="' + t.repo + '"]');
+            if (el) el.textContent = formatStars(count);
+          }).catch(function () { /* rate limit, silent */ });
+        });
+      }
+
       function buildTOC() {
         var sidebar = document.getElementById('tocSidebar');
         if (!sidebar) return;
@@ -1898,14 +2003,16 @@
         var article = document.querySelector('.lesson-article');
         if (!article) {
           sidebar.innerHTML = '';
-          sidebar.setAttribute('aria-hidden', 'true');
+          renderToolsCard(sidebar);
+          sidebar.removeAttribute('aria-hidden');
           return;
         }
 
         var headings = article.querySelectorAll('h2, h3');
         if (!headings.length) {
           sidebar.innerHTML = '';
-          sidebar.setAttribute('aria-hidden', 'true');
+          renderToolsCard(sidebar);
+          sidebar.removeAttribute('aria-hidden');
           return;
         }
 
@@ -1951,6 +2058,7 @@
         }
         html += '</ul></nav>';
         sidebar.innerHTML = html;
+        renderToolsCard(sidebar);
         sidebar.removeAttribute('aria-hidden');
 
         sidebar.querySelectorAll('.toc-link').forEach(function (a) {


### PR DESCRIPTION
## Summary

Cross-links the three production repositories (agentmemory · agentbrain · akbp) into the curriculum site so the 55K monthly visitors discover them naturally.

## What lands

**`site/index.html`** — new `From the same author` section between the curriculum grid and the colophon. Two layers:

1. **`FIG_006 · the agent stack`** — figure card in the makingsoftware aesthetic (cream paper + dotted grid + 1.5px blueprint strokes + JetBrains Mono labels). Shows three repo boxes orbiting a center `AGENT LOOP` block, with directional arrows labeled `STEERS`, `READ / WRITE STATE`, `ANSWERS QUERIES`. Bottom rule lists the eight primitives Phase 14 teaches. Caption ties the three repos together.
2. **3-card grid** — agentmemory · agentbrain · akbp with live ★ counts via GitHub REST + localStorage cache (6h TTL).

**`site/lesson.html`** — `Tools we maintain` card appended to the right-rail TOC sidebar on every lesson page. Three repos, one-line descs, live ★ counts. Sticky, follows the reader.

**`README.md`** — `From the same author` section after Sponsor block. Repo table with [shields.io](https://shields.io) live-star badges.

## Star fetch

- Single `fetch('https://api.github.com/repos/rohitg00/<repo>')` per repo per 6h
- Cached in `localStorage` keyed `aifs:stars:<repo>`
- Rate-limit handling: silent failure, falls back to empty star slot
- Same pattern used both on index `<script>` and inside lesson.html's `renderToolsCard`

## Test plan

- [x] Live screenshots of figure card (rendered at 1400px viewport) and sidebar card
- [x] Live star counts verified: agentmemory 14.7K, agentbrain 19, akbp 52
- [x] Figure paper-dot pattern + cream bg + blueprint strokes match the makingsoftware reference
- [x] Bidirectional arrows have arrowheads on both ends; no label-on-description overlap
- [x] Cache hit path repaints both card and SVG star slots
- [ ] Reviewer to confirm `data-eco-svg-stars` selector covers all SVG star anchors after future SVG edits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an ecosystem section showcasing related projects with live, formatted GitHub star counts (cached for performance) and an illustrative "agent stack"
  * Added a tools showcase card in lesson pages showing dynamic repository metrics and inserted it into the sidebar when page headings are absent
  * Updated manual hero to a two-column layout with an inline stack illustration

* **Documentation**
  * Expanded README with an overview of related projects and short descriptions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/ai-engineering-from-scratch/pull/118?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->