### PR TITLE
fix(site): repo names mono regular in FIG_006 not italic serif

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -948,9 +948,9 @@
             <a href="https://github.com/rohitg00/agentmemory" target="_blank" rel="noopener" class="hero-repo-link">
               <g transform="translate(60, 180)">
                 <rect width="220" height="100" class="bp-tint hrepo-rect" stroke="currentColor" stroke-width="1.5"/>
-                <text x="14" y="28" class="mono bp-fill" font-size="9" letter-spacing="1.6">REPO · MEMORY SURFACE</text>
-                <text x="14" y="58" class="mono ink" font-size="17">agentmemory</text>
-                <text x="14" y="80" class="serif ink-mute" font-size="13">persistent memory for AI coding agents.</text>
+                <text x="14" y="26" class="mono bp-fill" font-size="9" letter-spacing="1.6">MEMORY SURFACE</text>
+                <text x="14" y="54" class="mono ink" font-size="17">agentmemory</text>
+                <text x="14" y="78" class="serif ink-mute" font-size="12">persistent memory for AI agents.</text>
                 <text x="206" y="94" text-anchor="end" class="mono bp-fill" font-size="11" data-eco-svg-stars="agentmemory">★ ...</text>
               </g>
             </a>
@@ -959,9 +959,9 @@
             <a href="https://github.com/rohitg00/agentbrain" target="_blank" rel="noopener" class="hero-repo-link">
               <g transform="translate(440, 30)">
                 <rect width="220" height="100" class="bp-tint hrepo-rect" stroke="currentColor" stroke-width="1.5"/>
-                <text x="14" y="28" class="mono bp-fill" font-size="9" letter-spacing="1.6">REPO · REASONING SURFACE</text>
-                <text x="14" y="58" class="mono ink" font-size="17">agentbrain</text>
-                <text x="14" y="80" class="serif ink-mute" font-size="13">evidence-first operating system for agents.</text>
+                <text x="14" y="26" class="mono bp-fill" font-size="9" letter-spacing="1.6">REASONING SURFACE</text>
+                <text x="14" y="54" class="mono ink" font-size="17">agentbrain</text>
+                <text x="14" y="78" class="serif ink-mute" font-size="12">evidence-first reasoning loop.</text>
                 <text x="206" y="94" text-anchor="end" class="mono bp-fill" font-size="11" data-eco-svg-stars="agentbrain">★ ...</text>
               </g>
             </a>
@@ -970,9 +970,9 @@
             <a href="https://github.com/rohitg00/akbp" target="_blank" rel="noopener" class="hero-repo-link">
               <g transform="translate(820, 180)">
                 <rect width="220" height="100" class="bp-tint hrepo-rect" stroke="currentColor" stroke-width="1.5"/>
-                <text x="14" y="28" class="mono bp-fill" font-size="9" letter-spacing="1.6">REPO · KNOWLEDGE SURFACE</text>
-                <text x="14" y="58" class="mono ink" font-size="17">akbp</text>
-                <text x="14" y="80" class="serif ink-mute" font-size="13">agent knowledge base protocol.</text>
+                <text x="14" y="26" class="mono bp-fill" font-size="9" letter-spacing="1.6">KNOWLEDGE SURFACE</text>
+                <text x="14" y="54" class="mono ink" font-size="17">akbp</text>
+                <text x="14" y="78" class="serif ink-mute" font-size="12">agent knowledge base protocol.</text>
                 <text x="206" y="94" text-anchor="end" class="mono bp-fill" font-size="11" data-eco-svg-stars="akbp">★ ...</text>
               </g>
             </a>

--- a/site/index.html
+++ b/site/index.html
@@ -774,7 +774,7 @@
               <g transform="translate(60, 16)">
                 <rect width="200" height="56" class="hbp-tint hrepo-rect" stroke="currentColor"/>
                 <text x="12" y="20" class="hmono hbp-fill" font-size="8" letter-spacing="1.4">REPO · REASONING</text>
-                <text x="12" y="42" class="hserif hink" font-size="16" font-style="italic">agentbrain</text>
+                <text x="12" y="42" class="hmono hink" font-size="13">agentbrain</text>
                 <text x="188" y="50" text-anchor="end" class="hmono hbp-fill" font-size="10" data-eco-svg-stars="agentbrain">★ ...</text>
               </g>
             </a>
@@ -806,7 +806,7 @@
               <g transform="translate(0, 262)">
                 <rect width="148" height="56" class="hbp-tint hrepo-rect" stroke="currentColor"/>
                 <text x="12" y="20" class="hmono hbp-fill" font-size="8" letter-spacing="1.4">REPO · MEMORY</text>
-                <text x="12" y="42" class="hserif hink" font-size="16" font-style="italic">agentmemory</text>
+                <text x="12" y="42" class="hmono hink" font-size="13">agentmemory</text>
                 <text x="136" y="50" text-anchor="end" class="hmono hbp-fill" font-size="10" data-eco-svg-stars="agentmemory">★ ...</text>
               </g>
             </a>
@@ -823,7 +823,7 @@
               <g transform="translate(172, 262)">
                 <rect width="148" height="56" class="hbp-tint hrepo-rect" stroke="currentColor"/>
                 <text x="12" y="20" class="hmono hbp-fill" font-size="8" letter-spacing="1.4">REPO · KNOWLEDGE</text>
-                <text x="12" y="42" class="hserif hink" font-size="16" font-style="italic">akbp</text>
+                <text x="12" y="42" class="hmono hink" font-size="13">akbp</text>
                 <text x="136" y="50" text-anchor="end" class="hmono hbp-fill" font-size="10" data-eco-svg-stars="akbp">★ ...</text>
               </g>
             </a>
@@ -949,7 +949,7 @@
               <g transform="translate(60, 180)">
                 <rect width="220" height="100" class="bp-tint hrepo-rect" stroke="currentColor" stroke-width="1.5"/>
                 <text x="14" y="28" class="mono bp-fill" font-size="9" letter-spacing="1.6">REPO · MEMORY SURFACE</text>
-                <text x="14" y="58" class="serif ink" font-size="22" font-style="italic">agentmemory</text>
+                <text x="14" y="58" class="mono ink" font-size="17">agentmemory</text>
                 <text x="14" y="80" class="serif ink-mute" font-size="13">persistent memory for AI coding agents.</text>
                 <text x="206" y="94" text-anchor="end" class="mono bp-fill" font-size="11" data-eco-svg-stars="agentmemory">★ ...</text>
               </g>
@@ -960,7 +960,7 @@
               <g transform="translate(440, 30)">
                 <rect width="220" height="100" class="bp-tint hrepo-rect" stroke="currentColor" stroke-width="1.5"/>
                 <text x="14" y="28" class="mono bp-fill" font-size="9" letter-spacing="1.6">REPO · REASONING SURFACE</text>
-                <text x="14" y="58" class="serif ink" font-size="22" font-style="italic">agentbrain</text>
+                <text x="14" y="58" class="mono ink" font-size="17">agentbrain</text>
                 <text x="14" y="80" class="serif ink-mute" font-size="13">evidence-first operating system for agents.</text>
                 <text x="206" y="94" text-anchor="end" class="mono bp-fill" font-size="11" data-eco-svg-stars="agentbrain">★ ...</text>
               </g>
@@ -971,7 +971,7 @@
               <g transform="translate(820, 180)">
                 <rect width="220" height="100" class="bp-tint hrepo-rect" stroke="currentColor" stroke-width="1.5"/>
                 <text x="14" y="28" class="mono bp-fill" font-size="9" letter-spacing="1.6">REPO · KNOWLEDGE SURFACE</text>
-                <text x="14" y="58" class="serif ink" font-size="22" font-style="italic">akbp</text>
+                <text x="14" y="58" class="mono ink" font-size="17">akbp</text>
                 <text x="14" y="80" class="serif ink-mute" font-size="13">agent knowledge base protocol.</text>
                 <text x="206" y="94" text-anchor="end" class="mono bp-fill" font-size="11" data-eco-svg-stars="akbp">★ ...</text>
               </g>


### PR DESCRIPTION
## Summary

- Italic serif at large sizes on lowercase technical identifiers (`agentmemory`, `agentbrain`, `akbp`) renders visually broken. Italic serif is meant for prose emphasis, not code-like nouns.
- Switched all six repo name lines (3 in the hero compact stack, 3 in the wide FIG_006 figure) from serif italic to mono regular at a moderate size.
- Matches the makingsoftware aesthetic where identifiers stay monospaced and prose stays serif.

## Diff

- Hero compact: `16px / serif italic` → `13px / mono regular`
- Wide FIG_006: `22px / serif italic` → `17px / mono regular`
- Repo box eyebrow (`REPO · MEMORY`) and star count remain mono blueprint as before.
- AGENT LOOP center text keeps its serif italic for `function · worker · trigger` (prose-like, appropriate).

## Test plan

- [ ] Visit `/` in both light and dark mode, confirm the hero compact stack repo names render in JetBrains Mono regular at ~13px.
- [ ] Scroll to the `#ecosystem` section, confirm wide FIG_006 repo names render in JetBrains Mono regular at ~17px.
- [ ] Hover/focus each repo box, confirm link tint and focus outline still trigger.
- [ ] Click each repo box, confirm it opens the correct GitHub repo in a new tab.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated homepage stack diagrams: repository names now use monospaced, non‑italic typography with reduced sizes for improved consistency and readability.
  * Shortened top-surface labels and simplified muted description lines in the agent stack figures for clearer, more compact diagram text.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/ai-engineering-from-scratch/pull/119?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->