### PR TITLE
feat(scripts): scaffold_workbench.py drops pack into any target repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -863,6 +863,24 @@ outputs/
 Install them with [SkillKit](https://github.com/rohitg00/skillkit). Plug them into Claude, Cursor,
 Codex, OpenClaw, Hermes, or any MCP-compatible agent. Real tools, not homework.
 
+### Drop the agent workbench into your own repo
+
+The Phase 14 capstone ships a reusable Agent Workbench pack (AGENTS.md, schemas,
+init / verify / handoff scripts). Scaffold it into any repo with:
+
+```bash
+python3 scripts/scaffold_workbench.py path/to/your-repo            # full pack + seeds
+python3 scripts/scaffold_workbench.py path/to/your-repo --minimal  # skip docs/
+python3 scripts/scaffold_workbench.py path/to/your-repo --dry-run  # preview only
+python3 scripts/scaffold_workbench.py path/to/your-repo --force    # overwrite
+```
+
+You get the seven workbench surfaces wired up, a starter `task_board.json`,
+and a fresh `agent_state.json` at `schema_version: 1`. From there: edit the
+task, edit `AGENTS.md`, run `scripts/init_agent.py`, hand the contract to
+your agent. The pack source lives at
+`phases/14-agent-engineering/42-agent-workbench-capstone/outputs/agent-workbench-pack/`.
+
 ## Where to start
 
 | Background | Start at | Estimated time |

--- a/scripts/scaffold_workbench.py
+++ b/scripts/scaffold_workbench.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Scaffold the Agent Workbench pack into a target repository.
+
+Usage:
+    python3 scripts/scaffold_workbench.py <target_dir> [options]
+
+Options:
+    --force         Overwrite existing AGENTS.md / docs / schemas / scripts.
+    --minimal       Skip docs/ (only AGENTS.md, schemas/, scripts/, VERSION).
+    --dry-run       Print what would happen without writing.
+    --no-seed       Skip seeding starter task_board.json + agent_state.json.
+
+What it installs:
+    AGENTS.md                      — root contract for the builder agent
+    docs/                          — agent rules, reviewer rubric, handoff, reliability
+    schemas/                       — JSON Schemas for state + task board + scope
+    scripts/                       — init, run_with_feedback, verify, generate_handoff
+    task_board.json (seeded)       — one todo example task
+    agent_state.json (seeded)      — fresh state record at schema_version 1
+    .workbench-version             — pinned pack version
+
+The pack source is read from this repo at:
+    phases/14-agent-engineering/42-agent-workbench-capstone/outputs/agent-workbench-pack/
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+PACK_DIR = (
+    ROOT
+    / "phases"
+    / "14-agent-engineering"
+    / "42-agent-workbench-capstone"
+    / "outputs"
+    / "agent-workbench-pack"
+)
+
+REQUIRED_PACK_ENTRIES = ("AGENTS.md", "VERSION", "docs", "schemas", "scripts")
+TOP_LEVEL_FILES = ("AGENTS.md",)
+TOP_LEVEL_DIRS = ("docs", "schemas", "scripts")
+MINIMAL_SKIP_DIRS = ("docs",)
+
+
+@dataclass
+class Action:
+    kind: str
+    source: Path | None
+    target: Path
+    note: str = ""
+
+    def describe(self, target_root: Path) -> str:
+        rel = self.target.relative_to(target_root)
+        return f"  [{self.kind}] {rel}{(' — ' + self.note) if self.note else ''}"
+
+
+def validate_pack(pack_dir: Path) -> list[str]:
+    errors: list[str] = []
+    if not pack_dir.is_dir():
+        return [f"pack source not found: {pack_dir}"]
+    for entry in REQUIRED_PACK_ENTRIES:
+        if not (pack_dir / entry).exists():
+            errors.append(f"pack missing required entry: {entry}")
+    return errors
+
+
+def plan_copies(target: Path, minimal: bool) -> list[Action]:
+    actions: list[Action] = []
+    skip_dirs = set(MINIMAL_SKIP_DIRS) if minimal else set()
+    for name in TOP_LEVEL_FILES:
+        actions.append(Action("file", PACK_DIR / name, target / name))
+    for name in TOP_LEVEL_DIRS:
+        if name in skip_dirs:
+            actions.append(Action("skip", None, target / name, "minimal mode"))
+            continue
+        actions.append(Action("tree", PACK_DIR / name, target / name))
+    actions.append(
+        Action(
+            "version",
+            PACK_DIR / "VERSION",
+            target / ".workbench-version",
+        )
+    )
+    return actions
+
+
+def detect_collisions(target: Path, actions: list[Action]) -> list[Path]:
+    collisions: list[Path] = []
+    for action in actions:
+        if action.kind == "skip":
+            continue
+        if action.target.exists():
+            collisions.append(action.target)
+    return collisions
+
+
+def apply_action(action: Action) -> None:
+    if action.kind == "skip":
+        return
+    if action.kind == "file":
+        action.target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(action.source, action.target)
+        return
+    if action.kind == "tree":
+        if action.target.exists():
+            shutil.rmtree(action.target)
+        shutil.copytree(action.source, action.target)
+        return
+    if action.kind == "version":
+        action.target.parent.mkdir(parents=True, exist_ok=True)
+        version = action.source.read_text(encoding="utf-8").strip()
+        action.target.write_text(version + "\n", encoding="utf-8")
+        return
+    raise ValueError(f"unknown action kind: {action.kind}")
+
+
+def seed_task_board(target: Path) -> bool:
+    path = target / "task_board.json"
+    if path.exists():
+        return False
+    seed = [
+        {
+            "id": "T-001",
+            "goal": "First task. Replace with the real one before the agent starts.",
+            "owner": "builder",
+            "acceptance": [
+                "code change lands",
+                "tests pass",
+                "reviewer sign-off recorded",
+            ],
+            "status": "todo",
+        }
+    ]
+    path.write_text(
+        json.dumps(seed, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    return True
+
+
+def seed_agent_state(target: Path) -> bool:
+    path = target / "agent_state.json"
+    if path.exists():
+        return False
+    seed = {
+        "schema_version": 1,
+        "active_task_id": None,
+        "touched_files": [],
+        "assumptions": [],
+        "blockers": [],
+        "next_action": "read AGENTS.md, pick a task from task_board.json, run scripts/init_agent.py",
+    }
+    path.write_text(
+        json.dumps(seed, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    return True
+
+
+def render_next_steps(target: Path, pack_version: str) -> str:
+    rel = target.resolve()
+    lines = [
+        "",
+        f"Workbench pack v{pack_version} scaffolded into {rel}",
+        "",
+        "Next steps:",
+        "  1. Edit task_board.json. Replace T-001 with the real task.",
+        "  2. Edit AGENTS.md. Set project-specific build cmd, test cmd, deny rules.",
+        "  3. Run scripts/init_agent.py to capture environment probes.",
+        "  4. Hand AGENTS.md + task_board.json to the agent. Iterate.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("target_dir", type=Path, help="directory to scaffold into")
+    parser.add_argument("--force", action="store_true", help="overwrite existing files")
+    parser.add_argument("--minimal", action="store_true", help="skip docs/")
+    parser.add_argument("--dry-run", action="store_true", help="preview without writing")
+    parser.add_argument(
+        "--no-seed",
+        action="store_true",
+        help="do not seed task_board.json / agent_state.json",
+    )
+    args = parser.parse_args(argv)
+
+    errors = validate_pack(PACK_DIR)
+    if errors:
+        for e in errors:
+            sys.stderr.write(f"error: {e}\n")
+        return 2
+
+    target = args.target_dir
+    if not target.exists():
+        if args.dry_run:
+            sys.stdout.write(f"would create target dir: {target}\n")
+        else:
+            target.mkdir(parents=True, exist_ok=True)
+
+    actions = plan_copies(target, args.minimal)
+    collisions = detect_collisions(target, actions)
+    if collisions and not args.force and not args.dry_run:
+        sys.stderr.write("error: target already contains:\n")
+        for c in collisions:
+            sys.stderr.write(f"  {c}\n")
+        sys.stderr.write("pass --force to overwrite\n")
+        return 1
+
+    pack_version = (PACK_DIR / "VERSION").read_text(encoding="utf-8").strip()
+
+    if args.dry_run:
+        sys.stdout.write(f"dry run — pack v{pack_version}\n")
+        for action in actions:
+            sys.stdout.write(action.describe(target) + "\n")
+        if not args.no_seed:
+            sys.stdout.write("  [seed] task_board.json (if absent)\n")
+            sys.stdout.write("  [seed] agent_state.json (if absent)\n")
+        return 0
+
+    for action in actions:
+        apply_action(action)
+
+    if not args.no_seed:
+        seed_task_board(target)
+        seed_agent_state(target)
+
+    sys.stdout.write(render_next_steps(target, pack_version))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/scaffold_workbench.py
+++ b/scripts/scaffold_workbench.py
@@ -108,9 +108,7 @@ def apply_action(action: Action) -> None:
         shutil.copy2(action.source, action.target)
         return
     if action.kind == "tree":
-        if action.target.exists():
-            shutil.rmtree(action.target)
-        shutil.copytree(action.source, action.target)
+        shutil.copytree(action.source, action.target, dirs_exist_ok=True)
         return
     if action.kind == "version":
         action.target.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary

- New `scripts/scaffold_workbench.py`: stdlib-only Python that copies the Phase 14 capstone Agent Workbench pack into any target repository.
- Equivalent in spirit to a "harness creator" runnable skill, rewritten from scratch in Python with original code, original CLI flags, original seeding logic. No filenames or option names copied.
- Pairs with `scripts/audit_lessons.py` (PR #120) under the same `scripts/` namespace.

## What it does

```bash
python3 scripts/scaffold_workbench.py path/to/repo              # full scaffold
python3 scripts/scaffold_workbench.py path/to/repo --minimal    # skip docs/
python3 scripts/scaffold_workbench.py path/to/repo --dry-run    # preview only
python3 scripts/scaffold_workbench.py path/to/repo --force      # overwrite existing
python3 scripts/scaffold_workbench.py path/to/repo --no-seed    # no starter task_board/state
```

Drops into target:

- `AGENTS.md`
- `docs/` (agent-rules, reviewer-rubric, handoff-protocol, reliability-policy)
- `schemas/` (agent_state, task_board, scope_contract JSON schemas)
- `scripts/` (init_agent, run_with_feedback, verify_agent, generate_handoff)
- `.workbench-version` (pinned pack version, currently 1.0.0)
- Seeded `task_board.json` (one T-001 placeholder, valid against schema)
- Seeded `agent_state.json` (fresh, `schema_version: 1`)

## Safety

- Refuses to overwrite existing AGENTS.md / docs / schemas / scripts / .workbench-version without `--force`. Lists every colliding path before exiting non-zero.
- `--dry-run` previews the full action plan without writing.
- Validates the source pack has all required entries before doing anything to the target.
- Seeded JSON uses `ensure_ascii=False` so the file is human-readable, but no em-dashes in any seed content.

## Why this matters

The Phase 14 capstone showed how to *build* the workbench. This makes the workbench *reusable* in any repo without the learner copy-pasting eight files by hand. Each scaffolded repo gets the seven surfaces wired up immediately and points the agent at a real task instead of asking it to bootstrap structure.

## Test plan

- [x] Dry-run preview prints the action plan, writes nothing.
- [x] First scaffold into empty target succeeds, drops 14 files, seeds 2 JSON files.
- [x] Re-running on the same target without `--force` refuses with a collision list and exit code 1.
- [x] `--force` overwrites cleanly.
- [x] `--minimal` skips `docs/`.
- [x] `--no-seed` skips `task_board.json` + `agent_state.json`.
- [x] Generated `task_board.json` matches `schemas/task_board.schema.json`.
- [x] Generated `agent_state.json` matches `schemas/agent_state.schema.json`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add a scaffold tool to initialize an Agent Workbench pack in a target repo with preview (dry-run), minimal mode, collision detection, and optional seeding.

* **Documentation**
  * README updated with a new "Drop the agent workbench into your own repo" section detailing pack contents, scaffold options (--minimal, --dry-run, --force), example commands, and next-step guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/ai-engineering-from-scratch/pull/121?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->