### PR TITLE
feat(scripts): build_catalog.py emits filesystem-truth catalog.json

### DIFF
--- a/.github/workflows/curriculum.yml
+++ b/.github/workflows/curriculum.yml
@@ -25,14 +25,17 @@ jobs:
   audit:
     name: invariant checks (warn-only)
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
       - name: run scripts/audit_lessons.py
+        continue-on-error: true
         run: python3 scripts/audit_lessons.py
+      - name: warn-only note
+        run: |
+          echo "::notice::audit results above are warn-only until the 11 backlog issues are fixed in a follow-up PR"
 
   catalog-drift:
     name: catalog.json drift check

--- a/.github/workflows/curriculum.yml
+++ b/.github/workflows/curriculum.yml
@@ -1,0 +1,53 @@
+name: curriculum
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "phases/**"
+      - "scripts/audit_lessons.py"
+      - "scripts/build_catalog.py"
+      - "catalog.json"
+      - ".github/workflows/curriculum.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "phases/**"
+      - "scripts/audit_lessons.py"
+      - "scripts/build_catalog.py"
+      - "catalog.json"
+      - ".github/workflows/curriculum.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: invariant checks (warn-only)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: run scripts/audit_lessons.py
+        run: python3 scripts/audit_lessons.py
+
+  catalog-drift:
+    name: catalog.json drift check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: rebuild catalog
+        run: python3 scripts/build_catalog.py --out /tmp/catalog.fresh.json
+      - name: diff against committed catalog.json
+        run: |
+          if ! diff -u catalog.json /tmp/catalog.fresh.json; then
+            echo "::error::catalog.json is stale. Run 'python3 scripts/build_catalog.py' and commit the result."
+            exit 1
+          fi
+          echo "catalog.json matches filesystem"

--- a/.github/workflows/curriculum.yml
+++ b/.github/workflows/curriculum.yml
@@ -26,8 +26,10 @@ jobs:
     name: invariant checks (warn-only)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.12"
       - name: run scripts/audit_lessons.py
@@ -41,8 +43,10 @@ jobs:
     name: catalog.json drift check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.12"
       - name: rebuild catalog

--- a/README.md
+++ b/README.md
@@ -897,6 +897,12 @@ what is actually on disk. Use it for site builds, downstream tooling, or to
 verify the README counts have not drifted. Schema is documented at the top of
 the script.
 
+A GitHub Action (`.github/workflows/curriculum.yml`) rebuilds `catalog.json`
+on every PR and fails the build if the committed file is stale. After editing
+any lesson, run `python3 scripts/build_catalog.py` and commit the result, or
+CI will reject the PR. The same workflow runs `audit_lessons.py` in
+warn-only mode (so existing drift does not block contributors).
+
 ## Where to start
 
 | Background | Start at | Estimated time |

--- a/README.md
+++ b/README.md
@@ -881,6 +881,22 @@ task, edit `AGENTS.md`, run `scripts/init_agent.py`, hand the contract to
 your agent. The pack source lives at
 `phases/14-agent-engineering/42-agent-workbench-capstone/outputs/agent-workbench-pack/`.
 
+### Browse the entire course as JSON
+
+`scripts/build_catalog.py` walks every phase, every lesson, every artifact on
+disk and writes `catalog.json` at the repo root. One file, every course truth.
+
+```bash
+python3 scripts/build_catalog.py               # writes <repo>/catalog.json
+python3 scripts/build_catalog.py --stdout      # to stdout, do not touch repo
+python3 scripts/build_catalog.py --out path/to/file.json
+```
+
+The catalog is filesystem-derived, not README-derived, so counts always match
+what is actually on disk. Use it for site builds, downstream tooling, or to
+verify the README counts have not drifted. Schema is documented at the top of
+the script.
+
 ## Where to start
 
 | Background | Start at | Estimated time |

--- a/catalog.json
+++ b/catalog.json
@@ -1,6 +1,5 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-20T13:27:26+00:00",
   "totals": {
     "phases": 20,
     "lessons": 436,

--- a/catalog.json
+++ b/catalog.json
@@ -1,0 +1,12730 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-05-20T13:27:26+00:00",
+  "totals": {
+    "phases": 20,
+    "lessons": 436,
+    "skills": 373,
+    "prompts": 99,
+    "agents": 0,
+    "code_files": 433
+  },
+  "phases": [
+    {
+      "num": 0,
+      "slug": "00-setup-and-tooling",
+      "title": "Setup And Tooling",
+      "lesson_count": 12,
+      "lessons": [
+        {
+          "num": 1,
+          "slug": "01-dev-environment",
+          "title": "Dev Environment",
+          "path": "phases/00-setup-and-tooling/01-dev-environment",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "verify.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-env-check",
+              "path": "phases/00-setup-and-tooling/01-dev-environment/outputs/prompt-env-check.md",
+              "version": "",
+              "description": "Diagnose and fix AI engineering environment setup issues",
+              "tags": []
+            }
+          ]
+        },
+        {
+          "num": 2,
+          "slug": "02-git-and-collaboration",
+          "title": "Git & Collaboration",
+          "path": "phases/00-setup-and-tooling/02-git-and-collaboration",
+          "has_docs": true,
+          "has_code": false,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [],
+          "outputs": []
+        },
+        {
+          "num": 3,
+          "slug": "03-gpu-setup-and-cloud",
+          "title": "GPU Setup & Cloud",
+          "path": "phases/00-setup-and-tooling/03-gpu-setup-and-cloud",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "gpu_check.py"
+          ],
+          "outputs": []
+        },
+        {
+          "num": 4,
+          "slug": "04-apis-and-keys",
+          "title": "APIs & Keys",
+          "path": "phases/00-setup-and-tooling/04-apis-and-keys",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "first_api_call.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-api-troubleshooter",
+              "path": "phases/00-setup-and-tooling/04-apis-and-keys/outputs/prompt-api-troubleshooter.md",
+              "version": "",
+              "description": "Diagnose and fix common AI API errors (auth, rate limits, timeouts)",
+              "tags": []
+            }
+          ]
+        },
+        {
+          "num": 5,
+          "slug": "05-jupyter-notebooks",
+          "title": "Jupyter Notebooks",
+          "path": "phases/00-setup-and-tooling/05-jupyter-notebooks",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "notebook_tips.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-notebook-helper",
+              "path": "phases/00-setup-and-tooling/05-jupyter-notebooks/outputs/prompt-notebook-helper.md",
+              "version": "",
+              "description": "Debug Jupyter notebook issues including kernel crashes, memory problems, and display failures",
+              "tags": []
+            }
+          ]
+        },
+        {
+          "num": 6,
+          "slug": "06-python-environments",
+          "title": "Python Environments",
+          "path": "phases/00-setup-and-tooling/06-python-environments",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [],
+          "outputs": []
+        },
+        {
+          "num": 7,
+          "slug": "07-docker-for-ai",
+          "title": "Docker for AI",
+          "path": "phases/00-setup-and-tooling/07-docker-for-ai",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [],
+          "outputs": []
+        },
+        {
+          "num": 8,
+          "slug": "08-editor-setup",
+          "title": "Editor Setup",
+          "path": "phases/00-setup-and-tooling/08-editor-setup",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [],
+          "outputs": []
+        },
+        {
+          "num": 9,
+          "slug": "09-data-management",
+          "title": "Data Management",
+          "path": "phases/00-setup-and-tooling/09-data-management",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "data_utils.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-data-helper",
+              "path": "phases/00-setup-and-tooling/09-data-management/outputs/prompt-data-helper.md",
+              "version": "",
+              "description": "Find and load the right dataset for an AI/ML task",
+              "tags": []
+            }
+          ]
+        },
+        {
+          "num": 10,
+          "slug": "10-terminal-and-shell",
+          "title": "Terminal & Shell",
+          "path": "phases/00-setup-and-tooling/10-terminal-and-shell",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [],
+          "outputs": []
+        },
+        {
+          "num": 11,
+          "slug": "11-linux-for-ai",
+          "title": "Linux for AI",
+          "path": "phases/00-setup-and-tooling/11-linux-for-ai",
+          "has_docs": true,
+          "has_code": false,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [],
+          "outputs": []
+        },
+        {
+          "num": 12,
+          "slug": "12-debugging-and-profiling",
+          "title": "Debugging and Profiling",
+          "path": "phases/00-setup-and-tooling/12-debugging-and-profiling",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "debug_tools.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-debug-ai-code",
+              "path": "phases/00-setup-and-tooling/12-debugging-and-profiling/outputs/prompt-debug-ai-code.md",
+              "version": "",
+              "description": "Diagnose AI-specific bugs including NaN loss, shape errors, training failures, and OOM",
+              "tags": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "num": 1,
+      "slug": "01-math-foundations",
+      "title": "Math Foundations",
+      "lesson_count": 22,
+      "lessons": [
+        {
+          "num": 1,
+          "slug": "01-linear-algebra-intuition",
+          "title": "Linear Algebra Intuition",
+          "path": "phases/01-math-foundations/01-linear-algebra-intuition",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "vectors.jl",
+            "vectors.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-linear-algebra-tutor",
+              "path": "phases/01-math-foundations/01-linear-algebra-intuition/outputs/prompt-linear-algebra-tutor.md",
+              "version": "",
+              "description": "Teach linear algebra through geometric intuition and AI applications",
+              "tags": []
+            }
+          ]
+        },
+        {
+          "num": 2,
+          "slug": "02-vectors-matrices-operations",
+          "title": "Vectors, Matrices & Operations",
+          "path": "phases/01-math-foundations/02-vectors-matrices-operations",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "matrices.jl",
+            "matrices.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-matrix-operations",
+              "path": "phases/01-math-foundations/02-vectors-matrices-operations/outputs/prompt-matrix-operations.md",
+              "version": "",
+              "description": "Teaches matrix operations through geometric intuition, connecting abstract math to neural network mechanics",
+              "tags": []
+            }
+          ]
+        },
+        {
+          "num": 3,
+          "slug": "03-matrix-transformations",
+          "title": "Matrix Transformations",
+          "path": "phases/01-math-foundations/03-matrix-transformations",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "transformations.jl",
+            "transformations.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-transformation-visualizer",
+              "path": "phases/01-math-foundations/03-matrix-transformations/outputs/prompt-transformation-visualizer.md",
+              "version": "",
+              "description": "Explain what a matrix transformation does geometrically given its entries",
+              "tags": []
+            }
+          ]
+        },
+        {
+          "num": 4,
+          "slug": "04-calculus-for-ml",
+          "title": "Calculus for Machine Learning",
+          "path": "phases/01-math-foundations/04-calculus-for-ml",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "derivatives.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "skill-gradient-computation",
+              "path": "phases/01-math-foundations/04-calculus-for-ml/outputs/skill-gradient-computation.md",
+              "version": "1.0.0",
+              "description": "Compute gradients of common ML loss functions and choose the right derivative approach",
+              "tags": [
+                "calculus",
+                "gradients",
+                "backpropagation"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 5,
+          "slug": "05-chain-rule-and-autodiff",
+          "title": "Chain Rule & Automatic Differentiation",
+          "path": "phases/01-math-foundations/05-chain-rule-and-autodiff",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "autodiff.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "skill-autodiff",
+              "path": "phases/01-math-foundations/05-chain-rule-and-autodiff/outputs/skill-autodiff.md",
+              "version": "",
+              "description": "Build, debug, and reason about automatic differentiation systems",
+              "tags": []
+            }
+          ]
+        },
+        {
+          "num": 6,
+          "slug": "06-probability-and-distributions",
+          "title": "Probability and Distributions",
+          "path": "phases/01-math-foundations/06-probability-and-distributions",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "probability.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "skill-probability-reasoning",
+              "path": "phases/01-math-foundations/06-probability-and-distributions/outputs/skill-probability-reasoning.md",
+              "version": "1.0.0",
+              "description": "Choose the right probability distribution for a given ML problem",
+              "tags": [
+                "probability",
+                "distributions",
+                "modeling"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 7,
+          "slug": "07-bayes-theorem",
+          "title": "Bayes' Theorem",
+          "path": "phases/01-math-foundations/07-bayes-theorem",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "bayes.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-bayesian-reasoning",
+              "path": "phases/01-math-foundations/07-bayes-theorem/outputs/prompt-bayesian-reasoning.md",
+              "version": "",
+              "description": "Walk through Bayesian reasoning step by step for any scenario",
+              "tags": []
+            }
+          ]
+        },
+        {
+          "num": 8,
+          "slug": "08-optimization",
+          "title": "Optimization",
+          "path": "phases/01-math-foundations/08-optimization",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "optimizers.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-optimizer-guide",
+              "path": "phases/01-math-foundations/08-optimization/outputs/prompt-optimizer-guide.md",
+              "version": "",
+              "description": "Guides the user through choosing the right optimizer for their specific machine learning problem",
+              "tags": []
+            }
+          ]
+        },
+        {
+          "num": 9,
+          "slug": "09-information-theory",
+          "title": "Information Theory",
+          "path": "phases/01-math-foundations/09-information-theory",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "information_theory.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "skill-information-theory",
+              "path": "phases/01-math-foundations/09-information-theory/outputs/skill-information-theory.md",
+              "version": "1.0.0",
+              "description": "Apply information theory concepts to ML loss functions, model evaluation, and feature selection",
+              "tags": [
+                "information-theory",
+                "entropy",
+                "loss-functions"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 10,
+          "slug": "10-dimensionality-reduction",
+          "title": "Dimensionality Reduction",
+          "path": "phases/01-math-foundations/10-dimensionality-reduction",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "dim_reduction.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "skill-dimensionality-reduction",
+              "path": "phases/01-math-foundations/10-dimensionality-reduction/outputs/skill-dimensionality-reduction.md",
+              "version": "",
+              "description": "Choose the right dimensionality reduction technique for a given task based on data size, goal, and downstream use",
+              "tags": []
+            }
+          ]
+        },
+        {
+          "num": 11,
+          "slug": "11-singular-value-decomposition",
+          "title": "Singular Value Decomposition",
+          "path": "phases/01-math-foundations/11-singular-value-decomposition",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "svd.jl",
+            "svd.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "skill-svd",
+              "path": "phases/01-math-foundations/11-singular-value-decomposition/outputs/skill-svd.md",
+              "version": "",
+              "description": "Apply SVD to real problems including compression, denoising, recommendations, and least-squares solving",
+              "tags": []
+            }
+          ]
+        },
+        {
+          "num": 12,
+          "slug": "12-tensor-operations",
+          "title": "Tensor Operations",
+          "path": "phases/01-math-foundations/12-tensor-operations",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "tensors.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-tensor-debugger",
+              "path": "phases/01-math-foundations/12-tensor-operations/outputs/prompt-tensor-debugger.md",
+              "version": "",
+              "description": "Step-by-step debugging prompt for tensor shape errors in deep learning code",
+              "tags": []
+            },
+            {
+              "type": "prompt",
+              "name": "prompt-tensor-shapes",
+              "path": "phases/01-math-foundations/12-tensor-operations/outputs/prompt-tensor-shapes.md",
+              "version": "",
+              "description": "Debug tensor shape mismatches and recommend fixes for common deep learning operations",
+              "tags": []
+            }
+          ]
+        },
+        {
+          "num": 13,
+          "slug": "13-numerical-stability",
+          "title": "Numerical Stability",
+          "path": "phases/01-math-foundations/13-numerical-stability",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "numerical.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-numerical-debugger",
+              "path": "phases/01-math-foundations/13-numerical-stability/outputs/prompt-numerical-debugger.md",
+              "version": "",
+              "description": "Diagnoses NaN, Inf, and numerical stability issues in neural network training",
+              "tags": []
+            }
+          ]
+        },
+        {
+          "num": 14,
+          "slug": "14-norms-and-distances",
+          "title": "Norms and Distances",
+          "path": "phases/01-math-foundations/14-norms-and-distances",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "distances.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-distance-chooser",
+              "path": "phases/01-math-foundations/14-norms-and-distances/outputs/prompt-distance-chooser.md",
+              "version": "",
+              "description": "Guides the user through choosing the right distance metric for their specific task",
+              "tags": []
+            }
+          ]
+        },
+        {
+          "num": 15,
+          "slug": "15-statistics-for-ml",
+          "title": "Statistics for Machine Learning",
+          "path": "phases/01-math-foundations/15-statistics-for-ml",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "statistics.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "skill-statistical-testing",
+              "path": "phases/01-math-foundations/15-statistics-for-ml/outputs/skill-statistical-testing.md",
+              "version": "1.0.0",
+              "description": "Choose the right statistical test for comparing ML models and evaluating experiments",
+              "tags": [
+                "statistics",
+                "hypothesis-testing",
+                "model-comparison"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 16,
+          "slug": "16-sampling-methods",
+          "title": "Sampling Methods",
+          "path": "phases/01-math-foundations/16-sampling-methods",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "sampling.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "skill-sampling-strategy",
+              "path": "phases/01-math-foundations/16-sampling-methods/outputs/skill-sampling-strategy.md",
+              "version": "1.0.0",
+              "description": "Choose the right sampling method for generation, estimation, or inference",
+              "tags": [
+                "sampling",
+                "mcmc",
+                "generation"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 17,
+          "slug": "17-linear-systems",
+          "title": "Linear Systems",
+          "path": "phases/01-math-foundations/17-linear-systems",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "linear_systems.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-linear-solver",
+              "path": "phases/01-math-foundations/17-linear-systems/outputs/prompt-linear-solver.md",
+              "version": "",
+              "description": "Recommend the right algorithm for solving a linear system Ax=b based on matrix properties",
+              "tags": []
+            }
+          ]
+        },
+        {
+          "num": 18,
+          "slug": "18-convex-optimization",
+          "title": "Convex Optimization",
+          "path": "phases/01-math-foundations/18-convex-optimization",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "convex.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "skill-convexity-checker",
+              "path": "phases/01-math-foundations/18-convex-optimization/outputs/skill-convexity-checker.md",
+              "version": "1.0.0",
+              "description": "Determine if an optimization problem is convex and choose the right solver",
+              "tags": [
+                "optimization",
+                "convexity",
+                "solvers"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 19,
+          "slug": "19-complex-numbers",
+          "title": "Complex Numbers for AI",
+          "path": "phases/01-math-foundations/19-complex-numbers",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "complex_numbers.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "skill-complex-arithmetic",
+              "path": "phases/01-math-foundations/19-complex-numbers/outputs/skill-complex-arithmetic.md",
+              "version": "",
+              "description": "Quick reference for complex number operations in ML and signal processing contexts",
+              "tags": []
+            }
+          ]
+        },
+        {
+          "num": 20,
+          "slug": "20-fourier-transform",
+          "title": "The Fourier Transform",
+          "path": "phases/01-math-foundations/20-fourier-transform",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "fourier.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-spectral-analyzer",
+              "path": "phases/01-math-foundations/20-fourier-transform/outputs/prompt-spectral-analyzer.md",
+              "version": "",
+              "description": "Guides analysis of frequency content in signals using Fourier transform techniques",
+              "tags": []
+            }
+          ]
+        },
+        {
+          "num": 21,
+          "slug": "21-graph-theory",
+          "title": "Graph Theory for Machine Learning",
+          "path": "phases/01-math-foundations/21-graph-theory",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "graph_theory.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "skill-graph-analysis",
+              "path": "phases/01-math-foundations/21-graph-theory/outputs/skill-graph-analysis.md",
+              "version": "",
+              "description": "Analyze graph-structured data and choose the right graph algorithm for ML tasks",
+              "tags": []
+            }
+          ]
+        },
+        {
+          "num": 22,
+          "slug": "22-stochastic-processes",
+          "title": "Stochastic Processes",
+          "path": "phases/01-math-foundations/22-stochastic-processes",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "stochastic.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-stochastic-process-advisor",
+              "path": "phases/01-math-foundations/22-stochastic-processes/outputs/prompt-stochastic-process-advisor.md",
+              "version": "",
+              "description": "Identify which stochastic process framework applies to a given problem and recommend implementation",
+              "tags": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "num": 2,
+      "slug": "02-ml-fundamentals",
+      "title": "ML Fundamentals",
+      "lesson_count": 18,
+      "lessons": [
+        {
+          "num": 1,
+          "slug": "01-what-is-machine-learning",
+          "title": "What Is Machine Learning",
+          "path": "phases/02-ml-fundamentals/01-what-is-machine-learning",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "ml_intro.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-ml-problem-framer",
+              "path": "phases/02-ml-fundamentals/01-what-is-machine-learning/outputs/prompt-ml-problem-framer.md",
+              "version": "",
+              "description": "Frame a real-world business problem as a machine learning task",
+              "tags": []
+            }
+          ]
+        },
+        {
+          "num": 2,
+          "slug": "02-linear-regression",
+          "title": "Linear Regression",
+          "path": "phases/02-ml-fundamentals/02-linear-regression",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "linear_regression.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "skill-regression",
+              "path": "phases/02-ml-fundamentals/02-linear-regression/outputs/skill-regression.md",
+              "version": "1.0.0",
+              "description": "Choose the right regression approach based on data characteristics and problem constraints",
+              "tags": [
+                "regression",
+                "linear-regression",
+                "polynomial-regression",
+                "ridge",
+                "regularization"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 3,
+          "slug": "03-logistic-regression",
+          "title": "Logistic Regression",
+          "path": "phases/02-ml-fundamentals/03-logistic-regression",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "logistic_regression.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "skill-classification-baseline",
+              "path": "phases/02-ml-fundamentals/03-logistic-regression/outputs/skill-classification-baseline.md",
+              "version": "1.0.0",
+              "description": "Establish a strong classification baseline before reaching for complex models",
+              "tags": [
+                "classification",
+                "logistic-regression",
+                "baseline",
+                "preprocessing"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 4,
+          "slug": "04-decision-trees",
+          "title": "Decision Trees and Random Forests",
+          "path": "phases/02-ml-fundamentals/04-decision-trees",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "trees.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-tree-interpreter",
+              "path": "phases/02-ml-fundamentals/04-decision-trees/outputs/prompt-tree-interpreter.md",
+              "version": "",
+              "description": "Interpret decision tree results and diagnose potential issues",
+              "tags": []
+            }
+          ]
+        },
+        {
+          "num": 5,
+          "slug": "05-support-vector-machines",
+          "title": "Support Vector Machines",
+          "path": "phases/02-ml-fundamentals/05-support-vector-machines",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "svm.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "skill-svm-kernel-chooser",
+              "path": "phases/02-ml-fundamentals/05-support-vector-machines/outputs/skill-svm-kernel-chooser.md",
+              "version": "1.0.0",
+              "description": "Choose the right SVM kernel and tune C and gamma for your problem",
+              "tags": [
+                "svm",
+                "kernel",
+                "classification",
+                "hyperparameter-tuning"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 6,
+          "slug": "06-knn-and-distances",
+          "title": "K-Nearest Neighbors and Distances",
+          "path": "phases/02-ml-fundamentals/06-knn-and-distances",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "knn.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-distance-metric-advisor",
+              "path": "phases/02-ml-fundamentals/06-knn-and-distances/outputs/prompt-distance-metric-advisor.md",
+              "version": "",
+              "description": "Recommend the right distance metric based on data type and problem characteristics",
+              "tags": []
+            }
+          ]
+        },
+        {
+          "num": 7,
+          "slug": "07-unsupervised-learning",
+          "title": "Unsupervised Learning",
+          "path": "phases/02-ml-fundamentals/07-unsupervised-learning",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "clustering.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "skill-clustering-guide",
+              "path": "phases/02-ml-fundamentals/07-unsupervised-learning/outputs/skill-clustering-guide.md",
+              "version": "1.0.0",
+              "description": "Choose the right clustering algorithm based on data shape, noise, and constraints",
+              "tags": [
+                "clustering",
+                "k-means",
+                "dbscan",
+                "hierarchical",
+                "gmm",
+                "unsupervised"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 8,
+          "slug": "08-feature-engineering",
+          "title": "Feature Engineering & Selection",
+          "path": "phases/02-ml-fundamentals/08-feature-engineering",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "features.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-feature-engineer",
+              "path": "phases/02-ml-fundamentals/08-feature-engineering/outputs/prompt-feature-engineer.md",
+              "version": "",
+              "description": "Systematic prompt for engineering features from raw tabular data",
+              "tags": []
+            }
+          ]
+        },
+        {
+          "num": 9,
+          "slug": "09-model-evaluation",
+          "title": "Model Evaluation",
+          "path": "phases/02-ml-fundamentals/09-model-evaluation",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "evaluation.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "skill-evaluation",
+              "path": "phases/02-ml-fundamentals/09-model-evaluation/outputs/skill-evaluation.md",
+              "version": "1.0.0",
+              "description": "Evaluation strategy checklist for classification and regression models",
+              "tags": [
+                "evaluation",
+                "metrics",
+                "cross-validation",
+                "model-selection"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 10,
+          "slug": "10-bias-variance",
+          "title": "Bias-Variance Tradeoff",
+          "path": "phases/02-ml-fundamentals/10-bias-variance",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "bias_variance.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-model-diagnostics",
+              "path": "phases/02-ml-fundamentals/10-bias-variance/outputs/prompt-model-diagnostics.md",
+              "version": "",
+              "description": "Diagnose model performance issues using train/test metrics and learning curves",
+              "tags": []
+            }
+          ]
+        },
+        {
+          "num": 11,
+          "slug": "11-ensemble-methods",
+          "title": "Ensemble Methods",
+          "path": "phases/02-ml-fundamentals/11-ensemble-methods",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "ensembles.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-ensemble-selector",
+              "path": "phases/02-ml-fundamentals/11-ensemble-methods/outputs/prompt-ensemble-selector.md",
+              "version": "",
+              "description": "Pick the right ensemble method for a given dataset and problem",
+              "tags": []
+            },
+            {
+              "type": "skill",
+              "name": "skill-ensemble-builder",
+              "path": "phases/02-ml-fundamentals/11-ensemble-methods/outputs/skill-ensemble-builder.md",
+              "version": "1.0.0",
+              "description": "Choose the right ensemble method and configure it for your problem",
+              "tags": [
+                "ensemble",
+                "bagging",
+                "boosting",
+                "random-forest",
+                "xgboost",
+                "stacking"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 12,
+          "slug": "12-hyperparameter-tuning",
+          "title": "Hyperparameter Tuning",
+          "path": "phases/02-ml-fundamentals/12-hyperparameter-tuning",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "tuning.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-tuning-strategy",
+              "path": "phases/02-ml-fundamentals/12-hyperparameter-tuning/outputs/prompt-tuning-strategy.md",
+              "version": "",
+              "description": "Recommend a hyperparameter tuning strategy based on model type, data size, and compute budget",
+              "tags": []
+            }
+          ]
+        },
+        {
+          "num": 13,
+          "slug": "13-ml-pipelines",
+          "title": "ML Pipelines",
+          "path": "phases/02-ml-fundamentals/13-ml-pipelines",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "pipeline.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-ml-pipeline",
+              "path": "phases/02-ml-fundamentals/13-ml-pipelines/outputs/prompt-ml-pipeline.md",
+              "version": "",
+              "description": "Build, debug, and deploy reproducible ML pipelines",
+              "tags": []
+            }
+          ]
+        },
+        {
+          "num": 14,
+          "slug": "14-naive-bayes",
+          "title": "Naive Bayes",
+          "path": "phases/02-ml-fundamentals/14-naive-bayes",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "naive_bayes.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "skill-naive-bayes-chooser",
+              "path": "phases/02-ml-fundamentals/14-naive-bayes/outputs/skill-naive-bayes-chooser.md",
+              "version": "",
+              "description": "Choose the right Naive Bayes variant for your classification task",
+              "tags": []
+            }
+          ]
+        },
+        {
+          "num": 15,
+          "slug": "15-time-series",
+          "title": "Time Series Fundamentals",
+          "path": "phases/02-ml-fundamentals/15-time-series",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "time_series.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-time-series-advisor",
+              "path": "phases/02-ml-fundamentals/15-time-series/outputs/prompt-time-series-advisor.md",
+              "version": "",
+              "description": "Frame time series problems and recommend approaches",
+              "tags": []
+            }
+          ]
+        },
+        {
+          "num": 16,
+          "slug": "16-anomaly-detection",
+          "title": "Anomaly Detection",
+          "path": "phases/02-ml-fundamentals/16-anomaly-detection",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "anomaly_detection.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "skill-anomaly-detector",
+              "path": "phases/02-ml-fundamentals/16-anomaly-detection/outputs/skill-anomaly-detector.md",
+              "version": "",
+              "description": "Choose the right anomaly detection approach for your problem",
+              "tags": []
+            }
+          ]
+        },
+        {
+          "num": 17,
+          "slug": "17-imbalanced-data",
+          "title": "Handling Imbalanced Data",
+          "path": "phases/02-ml-fundamentals/17-imbalanced-data",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "imbalanced.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "skill-imbalanced-data",
+              "path": "phases/02-ml-fundamentals/17-imbalanced-data/outputs/skill-imbalanced-data.md",
+              "version": "1.0.0",
+              "description": "Decision checklist for handling imbalanced classification problems",
+              "tags": [
+                "imbalanced-data",
+                "smote",
+                "class-weights",
+                "threshold-tuning",
+                "evaluation"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 18,
+          "slug": "18-feature-selection",
+          "title": "Feature Selection",
+          "path": "phases/02-ml-fundamentals/18-feature-selection",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "feature_selection.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "skill-feature-selector",
+              "path": "phases/02-ml-fundamentals/18-feature-selection/outputs/skill-feature-selector.md",
+              "version": "1.0.0",
+              "description": "Quick reference decision tree for choosing the right feature selection method",
+              "tags": [
+                "feature-selection",
+                "mutual-information",
+                "rfe",
+                "lasso",
+                "tree-importance"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "num": 3,
+      "slug": "03-deep-learning-core",
+      "title": "Deep Learning Core",
+      "lesson_count": 13,
+      "lessons": [
+        {
+          "num": 1,
+          "slug": "01-the-perceptron",
+          "title": "The Perceptron",
+          "path": "phases/03-deep-learning-core/01-the-perceptron",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "perceptron.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "skill-perceptron",
+              "path": "phases/03-deep-learning-core/01-the-perceptron/outputs/skill-perceptron.md",
+              "version": "1.0.0",
+              "description": "Understand the perceptron pattern and when to use single-layer vs multi-layer architectures",
+              "tags": [
+                "perceptron",
+                "neural-networks",
+                "classification",
+                "deep-learning"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 2,
+          "slug": "02-multi-layer-networks",
+          "title": "Multi-Layer Networks and Forward Pass",
+          "path": "phases/03-deep-learning-core/02-multi-layer-networks",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-network-architect",
+              "path": "phases/03-deep-learning-core/02-multi-layer-networks/outputs/prompt-network-architect.md",
+              "version": "",
+              "description": "Guides the user through designing neural network architectures by choosing layer counts, neuron counts, and activation functions for a given problem",
+              "tags": []
+            }
+          ]
+        },
+        {
+          "num": 3,
+          "slug": "03-backpropagation",
+          "title": "Backpropagation from Scratch",
+          "path": "phases/03-deep-learning-core/03-backpropagation",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-gradient-debugger",
+              "path": "phases/03-deep-learning-core/03-backpropagation/outputs/prompt-gradient-debugger.md",
+              "version": "",
+              "description": "Diagnose and fix gradient problems in neural networks -- vanishing gradients, exploding gradients, and NaN values",
+              "tags": []
+            }
+          ]
+        },
+        {
+          "num": 4,
+          "slug": "04-activation-functions",
+          "title": "Activation Functions",
+          "path": "phases/03-deep-learning-core/04-activation-functions",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-activation-selector",
+              "path": "phases/03-deep-learning-core/04-activation-functions/outputs/prompt-activation-selector.md",
+              "version": "",
+              "description": "A decision prompt for choosing the right activation function for any neural network architecture",
+              "tags": []
+            }
+          ]
+        },
+        {
+          "num": 5,
+          "slug": "05-loss-functions",
+          "title": "Loss Functions",
+          "path": "phases/03-deep-learning-core/05-loss-functions",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-loss-debugger",
+              "path": "phases/03-deep-learning-core/05-loss-functions/outputs/prompt-loss-debugger.md",
+              "version": "",
+              "description": "A diagnostic prompt for debugging loss curves and training failures",
+              "tags": []
+            },
+            {
+              "type": "prompt",
+              "name": "prompt-loss-function-selector",
+              "path": "phases/03-deep-learning-core/05-loss-functions/outputs/prompt-loss-function-selector.md",
+              "version": "",
+              "description": "A decision prompt for choosing the right loss function for any ML task",
+              "tags": []
+            }
+          ]
+        },
+        {
+          "num": 6,
+          "slug": "06-optimizers",
+          "title": "Optimizers",
+          "path": "phases/03-deep-learning-core/06-optimizers",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-optimizer-selector",
+              "path": "phases/03-deep-learning-core/06-optimizers/outputs/prompt-optimizer-selector.md",
+              "version": "",
+              "description": "A decision prompt for choosing the right optimizer and learning rate for any architecture",
+              "tags": []
+            }
+          ]
+        },
+        {
+          "num": 7,
+          "slug": "07-regularization",
+          "title": "Regularization",
+          "path": "phases/03-deep-learning-core/07-regularization",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-regularization-advisor",
+              "path": "phases/03-deep-learning-core/07-regularization/outputs/prompt-regularization-advisor.md",
+              "version": "",
+              "description": "A diagnostic prompt for choosing regularization strategies based on overfitting symptoms",
+              "tags": []
+            }
+          ]
+        },
+        {
+          "num": 8,
+          "slug": "08-weight-initialization",
+          "title": "Weight Initialization and Training Stability",
+          "path": "phases/03-deep-learning-core/08-weight-initialization",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-init-strategy",
+              "path": "phases/03-deep-learning-core/08-weight-initialization/outputs/prompt-init-strategy.md",
+              "version": "",
+              "description": "Diagnose weight initialization problems and recommend the right strategy for any neural network architecture",
+              "tags": []
+            }
+          ]
+        },
+        {
+          "num": 9,
+          "slug": "09-learning-rate-schedules",
+          "title": "Learning Rate Schedules and Warmup",
+          "path": "phases/03-deep-learning-core/09-learning-rate-schedules",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-lr-schedule-advisor",
+              "path": "phases/03-deep-learning-core/09-learning-rate-schedules/outputs/prompt-lr-schedule-advisor.md",
+              "version": "",
+              "description": "Recommend the right learning rate schedule and hyperparameters for any training setup",
+              "tags": []
+            }
+          ]
+        },
+        {
+          "num": 10,
+          "slug": "10-mini-framework",
+          "title": "Build Your Own Mini Framework",
+          "path": "phases/03-deep-learning-core/10-mini-framework",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-framework-architect",
+              "path": "phases/03-deep-learning-core/10-mini-framework/outputs/prompt-framework-architect.md",
+              "version": "",
+              "description": "Design neural network architectures using framework abstractions -- modules, containers, losses, and optimizers",
+              "tags": []
+            }
+          ]
+        },
+        {
+          "num": 11,
+          "slug": "11-intro-to-pytorch",
+          "title": "Introduction to PyTorch",
+          "path": "phases/03-deep-learning-core/11-intro-to-pytorch",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "pytorch_intro.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-pytorch-debugger",
+              "path": "phases/03-deep-learning-core/11-intro-to-pytorch/outputs/prompt-pytorch-debugger.md",
+              "version": "",
+              "description": "Diagnose and fix common PyTorch training failures from symptoms",
+              "tags": []
+            },
+            {
+              "type": "skill",
+              "name": "skill-pytorch-patterns",
+              "path": "phases/03-deep-learning-core/11-intro-to-pytorch/outputs/skill-pytorch-patterns.md",
+              "version": "1.0.0",
+              "description": "Reference patterns for PyTorch training, evaluation, and deployment",
+              "tags": [
+                "pytorch",
+                "training",
+                "deep-learning",
+                "gpu",
+                "patterns"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 12,
+          "slug": "12-intro-to-jax",
+          "title": "Introduction to JAX",
+          "path": "phases/03-deep-learning-core/12-intro-to-jax",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "jax_intro.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-jax-optimizer",
+              "path": "phases/03-deep-learning-core/12-intro-to-jax/outputs/prompt-jax-optimizer.md",
+              "version": "",
+              "description": "Choose and configure the right JAX/Optax optimizer for a given training scenario",
+              "tags": []
+            },
+            {
+              "type": "skill",
+              "name": "skill-jax-patterns",
+              "path": "phases/03-deep-learning-core/12-intro-to-jax/outputs/skill-jax-patterns.md",
+              "version": "1.0.0",
+              "description": "Functional programming patterns in JAX -- when and how to use grad, jit, vmap, and pmap",
+              "tags": [
+                "jax",
+                "functional-programming",
+                "autodiff",
+                "compilation",
+                "vectorization"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 13,
+          "slug": "13-debugging-neural-networks",
+          "title": "Debugging Neural Networks",
+          "path": "phases/03-deep-learning-core/13-debugging-neural-networks",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "debug_neural_nets.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-nn-debugger",
+              "path": "phases/03-deep-learning-core/13-debugging-neural-networks/outputs/prompt-nn-debugger.md",
+              "version": "",
+              "description": "Diagnose neural network training failures from symptoms -- loss curves, gradient stats, and activation patterns",
+              "tags": []
+            },
+            {
+              "type": "skill",
+              "name": "skill-debug-checklist",
+              "path": "phases/03-deep-learning-core/13-debugging-neural-networks/outputs/skill-debug-checklist.md",
+              "version": "1.0.0",
+              "description": "Decision-tree checklist for debugging neural network training failures",
+              "tags": [
+                "debugging",
+                "neural-networks",
+                "training",
+                "diagnostics",
+                "deep-learning"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "num": 4,
+      "slug": "04-computer-vision",
+      "title": "Computer Vision",
+      "lesson_count": 28,
+      "lessons": [
+        {
+          "num": 1,
+          "slug": "01-image-fundamentals",
+          "title": "Image Fundamentals — Pixels, Channels, Color Spaces",
+          "path": "phases/04-computer-vision/01-image-fundamentals",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-vision-preprocessing-audit",
+              "path": "phases/04-computer-vision/01-image-fundamentals/outputs/prompt-vision-preprocessing-audit.md",
+              "version": "",
+              "description": "Turn any model card or dataset card into a checklist of the preprocessing invariants a vision pipeline must honour",
+              "tags": []
+            },
+            {
+              "type": "skill",
+              "name": "skill-image-tensor-inspector",
+              "path": "phases/04-computer-vision/01-image-fundamentals/outputs/skill-image-tensor-inspector.md",
+              "version": "1.0.0",
+              "description": "Inspect any image-shaped tensor or array and report dtype, layout, range, and whether it looks raw, normalized, or standardized",
+              "tags": [
+                "computer-vision",
+                "debugging",
+                "preprocessing",
+                "tensors"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 2,
+          "slug": "02-convolutions-from-scratch",
+          "title": "Convolutions from Scratch",
+          "path": "phases/04-computer-vision/02-convolutions-from-scratch",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-cnn-architect",
+              "path": "phases/04-computer-vision/02-convolutions-from-scratch/outputs/prompt-cnn-architect.md",
+              "version": "",
+              "description": "Design a stack of Conv2d layers from input size, parameter budget, and target receptive field",
+              "tags": []
+            },
+            {
+              "type": "skill",
+              "name": "skill-conv-shape-calculator",
+              "path": "phases/04-computer-vision/02-convolutions-from-scratch/outputs/skill-conv-shape-calculator.md",
+              "version": "1.0.0",
+              "description": "Walk a CNN spec layer by layer and report output shape, receptive field, and parameter count for every block",
+              "tags": [
+                "computer-vision",
+                "cnn",
+                "architecture",
+                "debugging"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 3,
+          "slug": "03-cnns-lenet-to-resnet",
+          "title": "CNNs — LeNet to ResNet",
+          "path": "phases/04-computer-vision/03-cnns-lenet-to-resnet",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-backbone-selector",
+              "path": "phases/04-computer-vision/03-cnns-lenet-to-resnet/outputs/prompt-backbone-selector.md",
+              "version": "",
+              "description": "Pick the right vision backbone (LeNet, VGG, ResNet, MobileNet, EfficientNet-Lite, ConvNeXt, ViT) for a given task, dataset size, and compute budget",
+              "tags": []
+            },
+            {
+              "type": "skill",
+              "name": "skill-residual-block-reviewer",
+              "path": "phases/04-computer-vision/03-cnns-lenet-to-resnet/outputs/skill-residual-block-reviewer.md",
+              "version": "1.0.0",
+              "description": "Review a PyTorch residual block for skip-connection correctness, BN placement, activation order, and shape alignment",
+              "tags": [
+                "computer-vision",
+                "resnet",
+                "code-review",
+                "pytorch"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 4,
+          "slug": "04-image-classification",
+          "title": "Image Classification",
+          "path": "phases/04-computer-vision/04-image-classification",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-classifier-pipeline-auditor",
+              "path": "phases/04-computer-vision/04-image-classification/outputs/prompt-classifier-pipeline-auditor.md",
+              "version": "",
+              "description": "Audit a PyTorch image classification training script for the five invariants that cover most silent bugs",
+              "tags": []
+            },
+            {
+              "type": "skill",
+              "name": "skill-classification-diagnostics",
+              "path": "phases/04-computer-vision/04-image-classification/outputs/skill-classification-diagnostics.md",
+              "version": "1.0.0",
+              "description": "Given a confusion matrix and class names, surface per-class failures and propose the single most impactful fix",
+              "tags": [
+                "computer-vision",
+                "classification",
+                "evaluation",
+                "debugging"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 5,
+          "slug": "05-transfer-learning",
+          "title": "Transfer Learning & Fine-Tuning",
+          "path": "phases/04-computer-vision/05-transfer-learning",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-fine-tune-planner",
+              "path": "phases/04-computer-vision/05-transfer-learning/outputs/prompt-fine-tune-planner.md",
+              "version": "",
+              "description": "Pick feature extraction vs progressive vs end-to-end fine-tuning given dataset size, domain distance, and compute budget",
+              "tags": []
+            },
+            {
+              "type": "skill",
+              "name": "skill-freeze-inspector",
+              "path": "phases/04-computer-vision/05-transfer-learning/outputs/skill-freeze-inspector.md",
+              "version": "1.0.0",
+              "description": "Report which parameters are trainable, which BatchNorm layers are in eval mode, and whether the optimizer is actually consuming the trainable parameters",
+              "tags": [
+                "computer-vision",
+                "transfer-learning",
+                "debugging",
+                "pytorch"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 6,
+          "slug": "06-object-detection-yolo",
+          "title": "Object Detection — YOLO from Scratch",
+          "path": "phases/04-computer-vision/06-object-detection-yolo",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-detection-metric-reader",
+              "path": "phases/04-computer-vision/06-object-detection-yolo/outputs/prompt-detection-metric-reader.md",
+              "version": "",
+              "description": "Turn a precision/recall/AP/mAP row into a one-line diagnosis and the single most useful next experiment",
+              "tags": []
+            },
+            {
+              "type": "skill",
+              "name": "skill-anchor-designer",
+              "path": "phases/04-computer-vision/06-object-detection-yolo/outputs/skill-anchor-designer.md",
+              "version": "1.0.0",
+              "description": "Given a dataset of ground-truth boxes, run k-means on (w, h) and return anchor sets per FPN level plus coverage statistics",
+              "tags": [
+                "computer-vision",
+                "detection",
+                "anchors",
+                "kmeans"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 7,
+          "slug": "07-semantic-segmentation-unet",
+          "title": "Semantic Segmentation — U-Net",
+          "path": "phases/04-computer-vision/07-semantic-segmentation-unet",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-segmentation-task-picker",
+              "path": "phases/04-computer-vision/07-semantic-segmentation-unet/outputs/prompt-segmentation-task-picker.md",
+              "version": "",
+              "description": "Pick semantic vs instance vs panoptic segmentation and name the architecture for a given task",
+              "tags": []
+            },
+            {
+              "type": "skill",
+              "name": "skill-segmentation-mask-inspector",
+              "path": "phases/04-computer-vision/07-semantic-segmentation-unet/outputs/skill-segmentation-mask-inspector.md",
+              "version": "1.0.0",
+              "description": "Report class distribution, predicted-mask statistics, and the classes most likely to be under-predicted or boundary-blurred",
+              "tags": [
+                "computer-vision",
+                "segmentation",
+                "debugging",
+                "evaluation"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 8,
+          "slug": "08-instance-segmentation-mask-rcnn",
+          "title": "Instance Segmentation — Mask R-CNN",
+          "path": "phases/04-computer-vision/08-instance-segmentation-mask-rcnn",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-instance-vs-semantic-router",
+              "path": "phases/04-computer-vision/08-instance-segmentation-mask-rcnn/outputs/prompt-instance-vs-semantic-router.md",
+              "version": "",
+              "description": "Ask three questions and pick instance vs semantic vs panoptic segmentation plus the first model",
+              "tags": []
+            },
+            {
+              "type": "skill",
+              "name": "skill-mask-rcnn-head-swapper",
+              "path": "phases/04-computer-vision/08-instance-segmentation-mask-rcnn/outputs/skill-mask-rcnn-head-swapper.md",
+              "version": "1.0.0",
+              "description": "Generate the exact code for swapping box and mask heads on a torchvision Mask R-CNN for a custom num_classes",
+              "tags": [
+                "computer-vision",
+                "mask-rcnn",
+                "fine-tuning",
+                "torchvision"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 9,
+          "slug": "09-image-generation-gans",
+          "title": "Image Generation — GANs",
+          "path": "phases/04-computer-vision/09-image-generation-gans",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-gan-training-triage",
+              "path": "phases/04-computer-vision/09-image-generation-gans/outputs/prompt-gan-training-triage.md",
+              "version": "",
+              "description": "Read a description of GAN training curves and pick the failure mode plus the single recommended fix",
+              "tags": []
+            },
+            {
+              "type": "skill",
+              "name": "skill-dcgan-scaffold",
+              "path": "phases/04-computer-vision/09-image-generation-gans/outputs/skill-dcgan-scaffold.md",
+              "version": "1.0.0",
+              "description": "Write a complete DCGAN scaffold from z_dim, image_size, and num_channels, including training loop and sample saver",
+              "tags": [
+                "computer-vision",
+                "gan",
+                "dcgan",
+                "scaffolding"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 10,
+          "slug": "10-image-generation-diffusion",
+          "title": "Image Generation — Diffusion Models",
+          "path": "phases/04-computer-vision/10-image-generation-diffusion",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-diffusion-sampler-picker",
+              "path": "phases/04-computer-vision/10-image-generation-diffusion/outputs/prompt-diffusion-sampler-picker.md",
+              "version": "",
+              "description": "Pick DDPM, DDIM, DPM-Solver++, or Euler ancestral based on quality target, latency budget, and conditioning type",
+              "tags": []
+            },
+            {
+              "type": "skill",
+              "name": "skill-noise-schedule-designer",
+              "path": "phases/04-computer-vision/10-image-generation-diffusion/outputs/skill-noise-schedule-designer.md",
+              "version": "1.0.0",
+              "description": "Produce a linear, cosine, or sigmoid beta schedule given T and target corruption level, plus SNR plot",
+              "tags": [
+                "computer-vision",
+                "diffusion",
+                "noise-schedule",
+                "training"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 11,
+          "slug": "11-stable-diffusion",
+          "title": "Stable Diffusion — Architecture & Fine-Tuning",
+          "path": "phases/04-computer-vision/11-stable-diffusion",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-sd-pipeline-planner",
+              "path": "phases/04-computer-vision/11-stable-diffusion/outputs/prompt-sd-pipeline-planner.md",
+              "version": "",
+              "description": "Pick SD 1.5 / SDXL / SD3 / FLUX plus scheduler and precision given a latency budget, fidelity target, and licensing constraint",
+              "tags": []
+            },
+            {
+              "type": "skill",
+              "name": "skill-lora-training-setup",
+              "path": "phases/04-computer-vision/11-stable-diffusion/outputs/skill-lora-training-setup.md",
+              "version": "1.0.0",
+              "description": "Write a full LoRA training config for a custom dataset, including captions, rank, batch size, and learning rate",
+              "tags": [
+                "computer-vision",
+                "stable-diffusion",
+                "lora",
+                "fine-tuning"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 12,
+          "slug": "12-video-understanding",
+          "title": "Video Understanding — Temporal Modeling",
+          "path": "phases/04-computer-vision/12-video-understanding",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-video-architecture-picker",
+              "path": "phases/04-computer-vision/12-video-understanding/outputs/prompt-video-architecture-picker.md",
+              "version": "",
+              "description": "Pick 2D+pool / I3D / (2+1)D / spatio-temporal transformer based on appearance-vs-motion, dataset size, and compute budget",
+              "tags": []
+            },
+            {
+              "type": "skill",
+              "name": "skill-frame-sampler-auditor",
+              "path": "phases/04-computer-vision/12-video-understanding/outputs/skill-frame-sampler-auditor.md",
+              "version": "1.0.0",
+              "description": "Audit a video pipeline's frame sampler for off-by-one, short-clip handling, and crop consistency",
+              "tags": [
+                "computer-vision",
+                "video",
+                "sampling",
+                "debugging"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 13,
+          "slug": "13-3d-vision-nerf",
+          "title": "3D Vision — Point Clouds & NeRFs",
+          "path": "phases/04-computer-vision/13-3d-vision-nerf",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-3d-task-router",
+              "path": "phases/04-computer-vision/13-3d-vision-nerf/outputs/prompt-3d-task-router.md",
+              "version": "",
+              "description": "Route to the right 3D representation (point cloud, mesh, voxel, NeRF, Gaussian splat) based on task and input",
+              "tags": []
+            },
+            {
+              "type": "skill",
+              "name": "skill-point-cloud-loader",
+              "path": "phases/04-computer-vision/13-3d-vision-nerf/outputs/skill-point-cloud-loader.md",
+              "version": "1.0.0",
+              "description": "Write a PyTorch Dataset for .ply / .pcd / .xyz files with correct normalisation, centring, and point sampling",
+              "tags": [
+                "3d-vision",
+                "point-cloud",
+                "data-loading",
+                "pytorch"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 14,
+          "slug": "14-vision-transformers",
+          "title": "Vision Transformers (ViT)",
+          "path": "phases/04-computer-vision/14-vision-transformers",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-vit-vs-cnn-picker",
+              "path": "phases/04-computer-vision/14-vision-transformers/outputs/prompt-vit-vs-cnn-picker.md",
+              "version": "",
+              "description": "Pick between ViT, ConvNeXt, or Swin based on dataset size, compute, and inference stack",
+              "tags": []
+            },
+            {
+              "type": "skill",
+              "name": "skill-vit-patch-and-pos-embed-inspector",
+              "path": "phases/04-computer-vision/14-vision-transformers/outputs/skill-vit-patch-and-pos-embed-inspector.md",
+              "version": "1.0.0",
+              "description": "Verify a ViT's patch embedding and positional embedding shapes match the model's expected sequence length",
+              "tags": [
+                "vision-transformer",
+                "debugging",
+                "pytorch"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 15,
+          "slug": "15-real-time-edge",
+          "title": "Real-Time Vision — Edge Deployment",
+          "path": "phases/04-computer-vision/15-real-time-edge",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-edge-deployment-planner",
+              "path": "phases/04-computer-vision/15-real-time-edge/outputs/prompt-edge-deployment-planner.md",
+              "version": "",
+              "description": "Pick backbone, quantisation strategy, and runtime given target device and latency SLA",
+              "tags": []
+            },
+            {
+              "type": "skill",
+              "name": "skill-latency-profiler",
+              "path": "phases/04-computer-vision/15-real-time-edge/outputs/skill-latency-profiler.md",
+              "version": "1.0.0",
+              "description": "Write a complete latency-benchmarking script with warmup, synchronisation, percentiles, and memory tracking",
+              "tags": [
+                "edge",
+                "deployment",
+                "profiling",
+                "benchmarking"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 16,
+          "slug": "16-vision-pipeline-capstone",
+          "title": "Build a Complete Vision Pipeline — Capstone",
+          "path": "phases/04-computer-vision/16-vision-pipeline-capstone",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-vision-service-shape-reviewer",
+              "path": "phases/04-computer-vision/16-vision-pipeline-capstone/outputs/prompt-vision-service-shape-reviewer.md",
+              "version": "",
+              "description": "Review a vision service's code for contract/response shape violations and name the first breaking bug",
+              "tags": []
+            },
+            {
+              "type": "skill",
+              "name": "skill-pipeline-budget-planner",
+              "path": "phases/04-computer-vision/16-vision-pipeline-capstone/outputs/skill-pipeline-budget-planner.md",
+              "version": "1.0.0",
+              "description": "Given target latency and throughput, assign a time budget to every pipeline stage and flag which stage will miss its budget first",
+              "tags": [
+                "vision",
+                "pipeline",
+                "performance",
+                "deployment"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 17,
+          "slug": "17-self-supervised-vision",
+          "title": "Self-Supervised Vision — SimCLR, DINO, MAE",
+          "path": "phases/04-computer-vision/17-self-supervised-vision",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-ssl-pretraining-picker",
+              "path": "phases/04-computer-vision/17-self-supervised-vision/outputs/prompt-ssl-pretraining-picker.md",
+              "version": "",
+              "description": "Pick SimCLR / MAE / DINOv2 given dataset size, compute, and downstream task",
+              "tags": []
+            },
+            {
+              "type": "skill",
+              "name": "skill-linear-probe-runner",
+              "path": "phases/04-computer-vision/17-self-supervised-vision/outputs/skill-linear-probe-runner.md",
+              "version": "1.0.0",
+              "description": "Write the complete linear-probe evaluation for any frozen encoder and labelled dataset",
+              "tags": [
+                "self-supervised",
+                "evaluation",
+                "linear-probe",
+                "pytorch"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 18,
+          "slug": "18-open-vocab-clip",
+          "title": "Open-Vocabulary Vision — CLIP",
+          "path": "phases/04-computer-vision/18-open-vocab-clip",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-zero-shot-class-picker",
+              "path": "phases/04-computer-vision/18-open-vocab-clip/outputs/prompt-zero-shot-class-picker.md",
+              "version": "",
+              "description": "Design prompt templates for zero-shot CLIP given a list of classes and a domain",
+              "tags": []
+            },
+            {
+              "type": "skill",
+              "name": "skill-image-text-retriever",
+              "path": "phases/04-computer-vision/18-open-vocab-clip/outputs/skill-image-text-retriever.md",
+              "version": "1.0.0",
+              "description": "Build an image embedding index with any CLIP checkpoint; support query-by-text and query-by-image",
+              "tags": [
+                "clip",
+                "retrieval",
+                "faiss",
+                "zero-shot"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 19,
+          "slug": "19-ocr-document-understanding",
+          "title": "OCR & Document Understanding",
+          "path": "phases/04-computer-vision/19-ocr-document-understanding",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-ocr-stack-picker",
+              "path": "phases/04-computer-vision/19-ocr-document-understanding/outputs/prompt-ocr-stack-picker.md",
+              "version": "",
+              "description": "Pick Tesseract / PaddleOCR / Donut / VLM-OCR given document type, language, and structure",
+              "tags": []
+            },
+            {
+              "type": "skill",
+              "name": "skill-ctc-decoder",
+              "path": "phases/04-computer-vision/19-ocr-document-understanding/outputs/skill-ctc-decoder.md",
+              "version": "1.0.0",
+              "description": "Write greedy and beam-search CTC decoders from scratch, including length normalisation",
+              "tags": [
+                "ocr",
+                "ctc",
+                "decoding",
+                "sequence-models"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 20,
+          "slug": "20-image-retrieval-metric",
+          "title": "Image Retrieval & Metric Learning",
+          "path": "phases/04-computer-vision/20-image-retrieval-metric",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-retrieval-loss-picker",
+              "path": "phases/04-computer-vision/20-image-retrieval-metric/outputs/prompt-retrieval-loss-picker.md",
+              "version": "",
+              "description": "Pick triplet / InfoNCE / ProxyNCA for a given retrieval problem",
+              "tags": []
+            },
+            {
+              "type": "skill",
+              "name": "skill-recall-at-k-runner",
+              "path": "phases/04-computer-vision/20-image-retrieval-metric/outputs/skill-recall-at-k-runner.md",
+              "version": "1.0.0",
+              "description": "Write a clean evaluation harness for recall@K with train/val/gallery splits and proper data contract",
+              "tags": [
+                "retrieval",
+                "evaluation",
+                "recall",
+                "faiss"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 21,
+          "slug": "21-keypoint-pose",
+          "title": "Keypoint Detection & Pose Estimation",
+          "path": "phases/04-computer-vision/21-keypoint-pose",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-pose-stack-picker",
+              "path": "phases/04-computer-vision/21-keypoint-pose/outputs/prompt-pose-stack-picker.md",
+              "version": "",
+              "description": "Pick MediaPipe / YOLOv8-pose / HRNet / ViTPose given latency, crowd size, and 2D vs 3D need",
+              "tags": []
+            },
+            {
+              "type": "skill",
+              "name": "skill-heatmap-to-coords",
+              "path": "phases/04-computer-vision/21-keypoint-pose/outputs/skill-heatmap-to-coords.md",
+              "version": "1.0.0",
+              "description": "Write the sub-pixel heatmap-to-coordinate routine used by every production pose model",
+              "tags": [
+                "keypoint",
+                "pose",
+                "subpixel",
+                "inference"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 22,
+          "slug": "22-3d-gaussian-splatting",
+          "title": "3D Gaussian Splatting from Scratch",
+          "path": "phases/04-computer-vision/22-3d-gaussian-splatting",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-3dgs-capture-planner",
+              "path": "phases/04-computer-vision/22-3d-gaussian-splatting/outputs/prompt-3dgs-capture-planner.md",
+              "version": "",
+              "description": "Plan a photo capture session for 3DGS reconstruction given scene type and hardware",
+              "tags": []
+            },
+            {
+              "type": "skill",
+              "name": "skill-3dgs-export-router",
+              "path": "phases/04-computer-vision/22-3d-gaussian-splatting/outputs/skill-3dgs-export-router.md",
+              "version": "1.0.0",
+              "description": "Pick the right 3DGS export format (.ply / .splat / glTF KHR_gaussian_splatting / USD) given the downstream viewer or engine",
+              "tags": [
+                "3d-gaussian-splatting",
+                "export",
+                "glTF",
+                "OpenUSD",
+                "pipeline"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 23,
+          "slug": "23-diffusion-transformers-rectified-flow",
+          "title": "Diffusion Transformers & Rectified Flow",
+          "path": "phases/04-computer-vision/23-diffusion-transformers-rectified-flow",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-dit-model-picker",
+              "path": "phases/04-computer-vision/23-diffusion-transformers-rectified-flow/outputs/prompt-dit-model-picker.md",
+              "version": "",
+              "description": "Pick between SD3, SD3.5, FLUX.1-dev, FLUX.1-schnell, Z-Image, SD4 Turbo given quality, latency, and license",
+              "tags": []
+            },
+            {
+              "type": "skill",
+              "name": "skill-rectified-flow-trainer",
+              "path": "phases/04-computer-vision/23-diffusion-transformers-rectified-flow/outputs/skill-rectified-flow-trainer.md",
+              "version": "1.0.0",
+              "description": "Write a complete rectified-flow training loop with AdaLN DiT and Euler sampling",
+              "tags": [
+                "diffusion",
+                "rectified-flow",
+                "DiT",
+                "training"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 24,
+          "slug": "24-sam3-open-vocab-segmentation",
+          "title": "SAM 3 & Open-Vocabulary Segmentation",
+          "path": "phases/04-computer-vision/24-sam3-open-vocab-segmentation",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-open-vocab-stack-picker",
+              "path": "phases/04-computer-vision/24-sam3-open-vocab-segmentation/outputs/prompt-open-vocab-stack-picker.md",
+              "version": "",
+              "description": "Pick SAM 3 / Grounded SAM 2 / YOLO-World / SAM-MI based on latency, concept complexity, and licensing",
+              "tags": []
+            },
+            {
+              "type": "skill",
+              "name": "skill-concept-prompt-designer",
+              "path": "phases/04-computer-vision/24-sam3-open-vocab-segmentation/outputs/skill-concept-prompt-designer.md",
+              "version": "1.0.0",
+              "description": "Turn user utterances into well-formed SAM 3 concept prompts with splitting, disambiguation, and fallbacks",
+              "tags": [
+                "sam3",
+                "open-vocab",
+                "prompt-engineering",
+                "segmentation"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 25,
+          "slug": "25-vision-language-models",
+          "title": "Vision-Language Models — The ViT-MLP-LLM Pattern",
+          "path": "phases/04-computer-vision/25-vision-language-models",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-vlm-selector",
+              "path": "phases/04-computer-vision/25-vision-language-models/outputs/prompt-vlm-selector.md",
+              "version": "",
+              "description": "Pick Qwen3-VL / InternVL3.5 / LLaVA-Next / API given accuracy, latency, context length, and budget",
+              "tags": []
+            },
+            {
+              "type": "skill",
+              "name": "skill-cmer-monitor",
+              "path": "phases/04-computer-vision/25-vision-language-models/outputs/skill-cmer-monitor.md",
+              "version": "1.0.0",
+              "description": "Instrument a production VLM endpoint with Cross-Modal Error Rate monitoring, dashboards, and alerts",
+              "tags": [
+                "vlm",
+                "production",
+                "monitoring",
+                "hallucination"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 26,
+          "slug": "26-monocular-depth",
+          "title": "Monocular Depth & Geometry Estimation",
+          "path": "phases/04-computer-vision/26-monocular-depth",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-depth-model-picker",
+              "path": "phases/04-computer-vision/26-monocular-depth/outputs/prompt-depth-model-picker.md",
+              "version": "",
+              "description": "Pick Depth Anything V3 / Marigold / UniDepth / MiDaS given latency, metric-vs-relative need, and scene type",
+              "tags": []
+            },
+            {
+              "type": "skill",
+              "name": "skill-depth-to-pointcloud",
+              "path": "phases/04-computer-vision/26-monocular-depth/outputs/skill-depth-to-pointcloud.md",
+              "version": "1.0.0",
+              "description": "Build point clouds from depth maps with correct intrinsics handling and export to .ply",
+              "tags": [
+                "depth",
+                "point-cloud",
+                "3d",
+                "intrinsics"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 27,
+          "slug": "27-multi-object-tracking",
+          "title": "Multi-Object Tracking & Video Memory",
+          "path": "phases/04-computer-vision/27-multi-object-tracking",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-tracker-picker",
+              "path": "phases/04-computer-vision/27-multi-object-tracking/outputs/prompt-tracker-picker.md",
+              "version": "",
+              "description": "Pick SORT / ByteTrack / BoT-SORT / SAM 2 / SAM 3.1 given scene type, occlusion patterns, and latency budget",
+              "tags": []
+            },
+            {
+              "type": "skill",
+              "name": "skill-mot-evaluator",
+              "path": "phases/04-computer-vision/27-multi-object-tracking/outputs/skill-mot-evaluator.md",
+              "version": "1.0.0",
+              "description": "Write a complete evaluation harness for MOTA / IDF1 / HOTA against ground-truth tracks",
+              "tags": [
+                "mot",
+                "evaluation",
+                "tracking",
+                "metrics"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 28,
+          "slug": "28-world-models-video-diffusion",
+          "title": "World Models & Video Diffusion",
+          "path": "phases/04-computer-vision/28-world-models-video-diffusion",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-video-model-picker",
+              "path": "phases/04-computer-vision/28-world-models-video-diffusion/outputs/prompt-video-model-picker.md",
+              "version": "",
+              "description": "Pick Sora 2 / Runway Gen-5 / Wan-Video / HunyuanVideo / Cosmos for a given task, license, and latency target",
+              "tags": []
+            },
+            {
+              "type": "skill",
+              "name": "skill-physical-plausibility-checks",
+              "path": "phases/04-computer-vision/28-world-models-video-diffusion/outputs/skill-physical-plausibility-checks.md",
+              "version": "1.0.0",
+              "description": "Automated checks for object permanence, gravity, and continuity on any generated video before shipping",
+              "tags": [
+                "video-generation",
+                "quality",
+                "physics",
+                "evaluation"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "num": 5,
+      "slug": "05-nlp-foundations-to-advanced",
+      "title": "NLP Foundations To Advanced",
+      "lesson_count": 29,
+      "lessons": [
+        {
+          "num": 1,
+          "slug": "01-text-processing",
+          "title": "Text Processing — Tokenization, Stemming, Lemmatization",
+          "path": "phases/05-nlp-foundations-to-advanced/01-text-processing",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "preprocessing-advisor",
+              "path": "phases/05-nlp-foundations-to-advanced/01-text-processing/outputs/prompt-preprocessing-advisor.md",
+              "version": "",
+              "description": "Recommends a tokenization, stemming, and lemmatization setup for an NLP task.",
+              "tags": []
+            }
+          ]
+        },
+        {
+          "num": 2,
+          "slug": "02-bag-of-words-tfidf",
+          "title": "Bag of Words, TF-IDF, and Text Representation",
+          "path": "phases/05-nlp-foundations-to-advanced/02-bag-of-words-tfidf",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "vectorization-picker",
+              "path": "phases/05-nlp-foundations-to-advanced/02-bag-of-words-tfidf/outputs/prompt-vectorization-picker.md",
+              "version": "",
+              "description": "Given a text-classification task, recommend BoW, TF-IDF, embeddings, or a hybrid.",
+              "tags": []
+            }
+          ]
+        },
+        {
+          "num": 3,
+          "slug": "03-word-embeddings-word2vec",
+          "title": "Word Embeddings — Word2Vec from Scratch",
+          "path": "phases/05-nlp-foundations-to-advanced/03-word-embeddings-word2vec",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "embedding-probe",
+              "path": "phases/05-nlp-foundations-to-advanced/03-word-embeddings-word2vec/outputs/skill-embedding-probe.md",
+              "version": "1.0.0",
+              "description": "Inspect a word2vec model. Run analogies, find neighbors, diagnose quality.",
+              "tags": [
+                "nlp",
+                "embeddings",
+                "debugging"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 4,
+          "slug": "04-glove-fasttext-subword",
+          "title": "GloVe, FastText, and Subword Embeddings",
+          "path": "phases/05-nlp-foundations-to-advanced/04-glove-fasttext-subword",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "tokenizer-picker",
+              "path": "phases/05-nlp-foundations-to-advanced/04-glove-fasttext-subword/outputs/skill-tokenizer-picker.md",
+              "version": "1.0.0",
+              "description": "Pick a tokenization approach for a new language model or text pipeline.",
+              "tags": [
+                "nlp",
+                "tokenization",
+                "embeddings"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 5,
+          "slug": "05-sentiment-analysis",
+          "title": "Sentiment Analysis",
+          "path": "phases/05-nlp-foundations-to-advanced/05-sentiment-analysis",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "sentiment-baseline",
+              "path": "phases/05-nlp-foundations-to-advanced/05-sentiment-analysis/outputs/prompt-sentiment-baseline.md",
+              "version": "",
+              "description": "Design a sentiment analysis baseline for a new dataset.",
+              "tags": []
+            }
+          ]
+        },
+        {
+          "num": 6,
+          "slug": "06-named-entity-recognition",
+          "title": "Named Entity Recognition",
+          "path": "phases/05-nlp-foundations-to-advanced/06-named-entity-recognition",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "ner-picker",
+              "path": "phases/05-nlp-foundations-to-advanced/06-named-entity-recognition/outputs/skill-ner-picker.md",
+              "version": "1.0.0",
+              "description": "Pick the right NER approach for a given extraction task.",
+              "tags": [
+                "nlp",
+                "ner",
+                "extraction"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 7,
+          "slug": "07-pos-tagging-parsing",
+          "title": "POS Tagging and Syntactic Parsing",
+          "path": "phases/05-nlp-foundations-to-advanced/07-pos-tagging-parsing",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "grammar-pipeline",
+              "path": "phases/05-nlp-foundations-to-advanced/07-pos-tagging-parsing/outputs/skill-grammar-pipeline.md",
+              "version": "1.0.0",
+              "description": "Design a classical POS + dependency pipeline for a downstream NLP task.",
+              "tags": [
+                "nlp",
+                "pos",
+                "parsing"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 8,
+          "slug": "08-cnns-rnns-for-text",
+          "title": "CNNs and RNNs for Text",
+          "path": "phases/05-nlp-foundations-to-advanced/08-cnns-rnns-for-text",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "text-encoder-picker",
+              "path": "phases/05-nlp-foundations-to-advanced/08-cnns-rnns-for-text/outputs/prompt-text-encoder-picker.md",
+              "version": "",
+              "description": "Pick a text encoder architecture for a given constraint set.",
+              "tags": []
+            }
+          ]
+        },
+        {
+          "num": 9,
+          "slug": "09-sequence-to-sequence",
+          "title": "Sequence-to-Sequence Models",
+          "path": "phases/05-nlp-foundations-to-advanced/09-sequence-to-sequence",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "seq2seq-design",
+              "path": "phases/05-nlp-foundations-to-advanced/09-sequence-to-sequence/outputs/prompt-seq2seq-design.md",
+              "version": "",
+              "description": "Design a sequence-to-sequence pipeline for a given task.",
+              "tags": []
+            }
+          ]
+        },
+        {
+          "num": 10,
+          "slug": "10-attention-mechanism",
+          "title": "Attention Mechanism — The Breakthrough",
+          "path": "phases/05-nlp-foundations-to-advanced/10-attention-mechanism",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "attention-shapes",
+              "path": "phases/05-nlp-foundations-to-advanced/10-attention-mechanism/outputs/prompt-attention-shapes.md",
+              "version": "",
+              "description": "Debug shape bugs in attention implementations.",
+              "tags": []
+            }
+          ]
+        },
+        {
+          "num": 11,
+          "slug": "11-machine-translation",
+          "title": "Machine Translation",
+          "path": "phases/05-nlp-foundations-to-advanced/11-machine-translation",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "mt-evaluator",
+              "path": "phases/05-nlp-foundations-to-advanced/11-machine-translation/outputs/skill-mt-evaluator.md",
+              "version": "1.0.0",
+              "description": "Evaluate a machine translation output for shipping.",
+              "tags": [
+                "nlp",
+                "translation",
+                "evaluation"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 12,
+          "slug": "12-text-summarization",
+          "title": "Text Summarization",
+          "path": "phases/05-nlp-foundations-to-advanced/12-text-summarization",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "summary-picker",
+              "path": "phases/05-nlp-foundations-to-advanced/12-text-summarization/outputs/skill-summary-picker.md",
+              "version": "1.0.0",
+              "description": "Pick extractive or abstractive, name the library, add a factuality check.",
+              "tags": [
+                "nlp",
+                "summarization"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 13,
+          "slug": "13-question-answering",
+          "title": "Question Answering Systems",
+          "path": "phases/05-nlp-foundations-to-advanced/13-question-answering",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "qa-architect",
+              "path": "phases/05-nlp-foundations-to-advanced/13-question-answering/outputs/skill-qa-architect.md",
+              "version": "1.0.0",
+              "description": "Choose QA architecture, retrieval strategy, and evaluation plan.",
+              "tags": [
+                "nlp",
+                "qa",
+                "rag"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 14,
+          "slug": "14-information-retrieval-search",
+          "title": "Information Retrieval and Search",
+          "path": "phases/05-nlp-foundations-to-advanced/14-information-retrieval-search",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "retrieval-picker",
+              "path": "phases/05-nlp-foundations-to-advanced/14-information-retrieval-search/outputs/skill-retrieval-picker.md",
+              "version": "1.0.0",
+              "description": "Pick a retrieval stack for a given corpus and query pattern.",
+              "tags": [
+                "nlp",
+                "retrieval",
+                "rag",
+                "search"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 15,
+          "slug": "15-topic-modeling",
+          "title": "Topic Modeling — LDA and BERTopic",
+          "path": "phases/05-nlp-foundations-to-advanced/15-topic-modeling",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "topic-picker",
+              "path": "phases/05-nlp-foundations-to-advanced/15-topic-modeling/outputs/skill-topic-picker.md",
+              "version": "1.0.0",
+              "description": "Pick LDA or BERTopic for a corpus. Specify library, knobs, evaluation.",
+              "tags": [
+                "nlp",
+                "topic-modeling"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 16,
+          "slug": "16-text-generation-pre-transformer",
+          "title": "Text Generation Before Transformers — N-gram Language Models",
+          "path": "phases/05-nlp-foundations-to-advanced/16-text-generation-pre-transformer",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "lm-baseline",
+              "path": "phases/05-nlp-foundations-to-advanced/16-text-generation-pre-transformer/outputs/prompt-lm-baseline.md",
+              "version": "",
+              "description": "Build a reproducible n-gram language model baseline before training a neural LM.",
+              "tags": []
+            }
+          ]
+        },
+        {
+          "num": 17,
+          "slug": "17-chatbots-rule-to-neural",
+          "title": "Chatbots — Rule-Based to Neural to LLM Agents",
+          "path": "phases/05-nlp-foundations-to-advanced/17-chatbots-rule-to-neural",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "chatbot-architect",
+              "path": "phases/05-nlp-foundations-to-advanced/17-chatbots-rule-to-neural/outputs/skill-chatbot-architect.md",
+              "version": "1.0.0",
+              "description": "Design a chatbot stack for a given use case.",
+              "tags": [
+                "nlp",
+                "agents",
+                "chatbot"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 18,
+          "slug": "18-multilingual-nlp",
+          "title": "Multilingual NLP",
+          "path": "phases/05-nlp-foundations-to-advanced/18-multilingual-nlp",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "multilingual-picker",
+              "path": "phases/05-nlp-foundations-to-advanced/18-multilingual-nlp/outputs/skill-multilingual-picker.md",
+              "version": "1.0.0",
+              "description": "Pick source language, target model, and evaluation plan for a multilingual NLP task.",
+              "tags": [
+                "nlp",
+                "multilingual",
+                "cross-lingual"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 19,
+          "slug": "19-subword-tokenization",
+          "title": "Subword Tokenization — BPE, WordPiece, Unigram, SentencePiece",
+          "path": "phases/05-nlp-foundations-to-advanced/19-subword-tokenization",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "tokenizer-picker",
+              "path": "phases/05-nlp-foundations-to-advanced/19-subword-tokenization/outputs/skill-tokenizer-picker.md",
+              "version": "1.0.0",
+              "description": "Pick tokenizer algorithm, vocab size, library for a given corpus and deployment target.",
+              "tags": [
+                "nlp",
+                "tokenization"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 20,
+          "slug": "20-structured-outputs-constrained-decoding",
+          "title": "Structured Outputs & Constrained Decoding",
+          "path": "phases/05-nlp-foundations-to-advanced/20-structured-outputs-constrained-decoding",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "structured-output-picker",
+              "path": "phases/05-nlp-foundations-to-advanced/20-structured-outputs-constrained-decoding/outputs/skill-structured-output-picker.md",
+              "version": "1.0.0",
+              "description": "Choose a structured output approach, schema design, and validation plan.",
+              "tags": [
+                "nlp",
+                "llm",
+                "structured-output"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 21,
+          "slug": "21-nli-textual-entailment",
+          "title": "Natural Language Inference — Textual Entailment",
+          "path": "phases/05-nlp-foundations-to-advanced/21-nli-textual-entailment",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "nli-picker",
+              "path": "phases/05-nlp-foundations-to-advanced/21-nli-textual-entailment/outputs/skill-nli-picker.md",
+              "version": "1.0.0",
+              "description": "Pick an NLI model, label template, and evaluation setup for a classification / faithfulness / zero-shot task.",
+              "tags": [
+                "nlp",
+                "nli",
+                "zero-shot"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 22,
+          "slug": "22-embedding-models-deep-dive",
+          "title": "Embedding Models — The 2026 Deep Dive",
+          "path": "phases/05-nlp-foundations-to-advanced/22-embedding-models-deep-dive",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "embedding-picker",
+              "path": "phases/05-nlp-foundations-to-advanced/22-embedding-models-deep-dive/outputs/skill-embedding-picker.md",
+              "version": "1.0.0",
+              "description": "Pick embedding model, dimension, and retrieval mode for a given corpus and deployment.",
+              "tags": [
+                "nlp",
+                "embeddings",
+                "retrieval"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 23,
+          "slug": "23-chunking-strategies-rag",
+          "title": "Chunking Strategies for RAG",
+          "path": "phases/05-nlp-foundations-to-advanced/23-chunking-strategies-rag",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "chunker",
+              "path": "phases/05-nlp-foundations-to-advanced/23-chunking-strategies-rag/outputs/skill-chunker.md",
+              "version": "1.0.0",
+              "description": "Pick a chunking strategy, size, and overlap for a given corpus and query distribution.",
+              "tags": [
+                "nlp",
+                "rag",
+                "chunking"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 24,
+          "slug": "24-coreference-resolution",
+          "title": "Coreference Resolution",
+          "path": "phases/05-nlp-foundations-to-advanced/24-coreference-resolution",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "coref-picker",
+              "path": "phases/05-nlp-foundations-to-advanced/24-coreference-resolution/outputs/skill-coref-picker.md",
+              "version": "1.0.0",
+              "description": "Pick a coreference approach, evaluation plan, and integration strategy.",
+              "tags": [
+                "nlp",
+                "coref",
+                "information-extraction"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 25,
+          "slug": "25-entity-linking",
+          "title": "Entity Linking & Disambiguation",
+          "path": "phases/05-nlp-foundations-to-advanced/25-entity-linking",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "entity-linker",
+              "path": "phases/05-nlp-foundations-to-advanced/25-entity-linking/outputs/skill-entity-linker.md",
+              "version": "1.0.0",
+              "description": "Design an entity linking pipeline — KB, candidate generator, disambiguator, evaluation.",
+              "tags": [
+                "nlp",
+                "entity-linking",
+                "knowledge-graph"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 26,
+          "slug": "26-relation-extraction-kg",
+          "title": "Relation Extraction & Knowledge Graph Construction",
+          "path": "phases/05-nlp-foundations-to-advanced/26-relation-extraction-kg",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "re-designer",
+              "path": "phases/05-nlp-foundations-to-advanced/26-relation-extraction-kg/outputs/skill-re-designer.md",
+              "version": "1.0.0",
+              "description": "Design a relation extraction pipeline with provenance and canonicalization.",
+              "tags": [
+                "nlp",
+                "relation-extraction",
+                "knowledge-graph"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 27,
+          "slug": "27-llm-evaluation-frameworks",
+          "title": "LLM Evaluation — RAGAS, DeepEval, G-Eval",
+          "path": "phases/05-nlp-foundations-to-advanced/27-llm-evaluation-frameworks",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "eval-architect",
+              "path": "phases/05-nlp-foundations-to-advanced/27-llm-evaluation-frameworks/outputs/skill-eval-architect.md",
+              "version": "1.0.0",
+              "description": "Design an LLM evaluation plan with calibrated judge and CI gates.",
+              "tags": [
+                "nlp",
+                "evaluation",
+                "rag"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 28,
+          "slug": "28-long-context-evaluation",
+          "title": "Long-Context Evaluation — NIAH, RULER, LongBench, MRCR",
+          "path": "phases/05-nlp-foundations-to-advanced/28-long-context-evaluation",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "long-context-eval",
+              "path": "phases/05-nlp-foundations-to-advanced/28-long-context-evaluation/outputs/skill-long-context-eval.md",
+              "version": "1.0.0",
+              "description": "Design a long-context evaluation battery for a given model and use case.",
+              "tags": [
+                "nlp",
+                "long-context",
+                "evaluation"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 29,
+          "slug": "29-dialogue-state-tracking",
+          "title": "Dialogue State Tracking",
+          "path": "phases/05-nlp-foundations-to-advanced/29-dialogue-state-tracking",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "dst-designer",
+              "path": "phases/05-nlp-foundations-to-advanced/29-dialogue-state-tracking/outputs/skill-dst-designer.md",
+              "version": "1.0.0",
+              "description": "Design a dialogue state tracker — schema, extractor, update policy, evaluation.",
+              "tags": [
+                "nlp",
+                "dialogue",
+                "task-oriented"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "num": 6,
+      "slug": "06-speech-and-audio",
+      "title": "Speech And Audio",
+      "lesson_count": 17,
+      "lessons": [
+        {
+          "num": 1,
+          "slug": "01-audio-fundamentals",
+          "title": "Audio Fundamentals — Waveforms, Sampling, Fourier Transform",
+          "path": "phases/06-speech-and-audio/01-audio-fundamentals",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "audio-loader",
+              "path": "phases/06-speech-and-audio/01-audio-fundamentals/outputs/skill-audio-loader.md",
+              "version": "1.0.0",
+              "description": "Validate a raw audio file against a target model's expectations and resample it safely.",
+              "tags": [
+                "audio",
+                "speech",
+                "preprocessing"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 2,
+          "slug": "02-spectrograms-mel-features",
+          "title": "Spectrograms, Mel Scale & Audio Features",
+          "path": "phases/06-speech-and-audio/02-spectrograms-mel-features",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "feature-extractor",
+              "path": "phases/06-speech-and-audio/02-spectrograms-mel-features/outputs/skill-feature-extractor.md",
+              "version": "1.0.0",
+              "description": "Pick feature type, mel count, frame/hop, and normalization to match a downstream audio model.",
+              "tags": [
+                "audio",
+                "features",
+                "spectrogram",
+                "mel"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 3,
+          "slug": "03-audio-classification",
+          "title": "Audio Classification — From k-NN on MFCCs to AST and BEATs",
+          "path": "phases/06-speech-and-audio/03-audio-classification",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "classifier-designer",
+              "path": "phases/06-speech-and-audio/03-audio-classification/outputs/skill-classifier-designer.md",
+              "version": "1.0.0",
+              "description": "Pick architecture, augmentation, class-balance strategy, and eval metric for an audio classification task.",
+              "tags": [
+                "audio",
+                "classification",
+                "beats",
+                "ast"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 4,
+          "slug": "04-speech-recognition-asr",
+          "title": "Speech Recognition (ASR) — CTC, RNN-T, Attention",
+          "path": "phases/06-speech-and-audio/04-speech-recognition-asr",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "asr-picker",
+              "path": "phases/06-speech-and-audio/04-speech-recognition-asr/outputs/skill-asr-picker.md",
+              "version": "1.0.0",
+              "description": "Pick ASR model, decoding strategy, chunking, and LM fusion for a given deployment target.",
+              "tags": [
+                "audio",
+                "asr",
+                "speech-recognition"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 5,
+          "slug": "05-whisper-architecture-finetuning",
+          "title": "Whisper — Architecture & Fine-Tuning",
+          "path": "phases/06-speech-and-audio/05-whisper-architecture-finetuning",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "whisper-tuner",
+              "path": "phases/06-speech-and-audio/05-whisper-architecture-finetuning/outputs/skill-whisper-tuner.md",
+              "version": "1.0.0",
+              "description": "Design a Whisper fine-tune or inference pipeline for a given language, domain, and latency budget.",
+              "tags": [
+                "audio",
+                "whisper",
+                "asr",
+                "fine-tuning",
+                "lora"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 6,
+          "slug": "06-speaker-recognition-verification",
+          "title": "Speaker Recognition & Verification",
+          "path": "phases/06-speech-and-audio/06-speaker-recognition-verification",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "speaker-verifier",
+              "path": "phases/06-speech-and-audio/06-speaker-recognition-verification/outputs/skill-speaker-verifier.md",
+              "version": "1.0.0",
+              "description": "Design a speaker verification or diarization pipeline with model choice, enrollment protocol, and threshold tuning.",
+              "tags": [
+                "audio",
+                "speaker",
+                "verification",
+                "diarization"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 7,
+          "slug": "07-text-to-speech",
+          "title": "Text-to-Speech (TTS) — From Tacotron to F5 and Kokoro",
+          "path": "phases/06-speech-and-audio/07-text-to-speech",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "tts-designer",
+              "path": "phases/06-speech-and-audio/07-text-to-speech/outputs/skill-tts-designer.md",
+              "version": "1.0.0",
+              "description": "Pick TTS model, voice, text-normalization scope, and evaluation plan for a given language, style, and latency target.",
+              "tags": [
+                "audio",
+                "tts",
+                "speech-synthesis"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 8,
+          "slug": "08-voice-cloning-conversion",
+          "title": "Voice Cloning & Voice Conversion",
+          "path": "phases/06-speech-and-audio/08-voice-cloning-conversion",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "voice-cloner",
+              "path": "phases/06-speech-and-audio/08-voice-cloning-conversion/outputs/skill-voice-cloner.md",
+              "version": "1.0.0",
+              "description": "Pick cloning approach (zero-shot / conversion / adaptation), consent artifact, watermark, and safety filters for a voice-cloning deployment.",
+              "tags": [
+                "voice-cloning",
+                "voice-conversion",
+                "watermark",
+                "consent",
+                "safety"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 9,
+          "slug": "09-music-generation",
+          "title": "Music Generation — MusicGen, Stable Audio, Suno, and the Licensing Earthquake",
+          "path": "phases/06-speech-and-audio/09-music-generation",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "music-designer",
+              "path": "phases/06-speech-and-audio/09-music-generation/outputs/skill-music-designer.md",
+              "version": "1.0.0",
+              "description": "Pick a music-generation model, license strategy, length plan, and disclosure metadata for a deployment.",
+              "tags": [
+                "music-generation",
+                "musicgen",
+                "stable-audio",
+                "suno",
+                "licensing"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 10,
+          "slug": "10-audio-language-models",
+          "title": "Audio-Language Models — Qwen2.5-Omni, Audio Flamingo, GPT-4o Audio",
+          "path": "phases/06-speech-and-audio/10-audio-language-models",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "alm-picker",
+              "path": "phases/06-speech-and-audio/10-audio-language-models/outputs/skill-alm-picker.md",
+              "version": "1.0.0",
+              "description": "Pick an audio-language model, benchmark subset, output modality (text vs speech), and guardrails for an audio-understanding task.",
+              "tags": [
+                "alm",
+                "lalm",
+                "qwen-omni",
+                "audio-flamingo",
+                "gemini-audio",
+                "mmau"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 11,
+          "slug": "11-real-time-audio-processing",
+          "title": "Real-Time Audio Processing",
+          "path": "phases/06-speech-and-audio/11-real-time-audio-processing",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "realtime-voice-pipeline",
+              "path": "phases/06-speech-and-audio/11-real-time-audio-processing/outputs/skill-realtime-pipeline.md",
+              "version": "1.0.0",
+              "description": "Pick transport, VAD, streaming STT, LLM, streaming TTS, and orchestration for a target end-to-end latency.",
+              "tags": [
+                "voice-agent",
+                "livekit",
+                "pipecat",
+                "silero",
+                "streaming",
+                "latency"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 12,
+          "slug": "12-voice-assistant-pipeline",
+          "title": "Build a Voice Assistant Pipeline — The Phase 6 Capstone",
+          "path": "phases/06-speech-and-audio/12-voice-assistant-pipeline",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "voice-assistant-architect",
+              "path": "phases/06-speech-and-audio/12-voice-assistant-pipeline/outputs/skill-voice-assistant-architect.md",
+              "version": "1.0.0",
+              "description": "Produce a full-stack voice-assistant spec — components, latency budget, observability, compliance — for a given workload.",
+              "tags": [
+                "voice-assistant",
+                "architecture",
+                "livekit",
+                "pipecat",
+                "compliance"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 13,
+          "slug": "13-neural-audio-codecs",
+          "title": "Neural Audio Codecs — EnCodec, SNAC, Mimi, DAC and the Semantic-Acoustic Split",
+          "path": "phases/06-speech-and-audio/13-neural-audio-codecs",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "codec-picker",
+              "path": "phases/06-speech-and-audio/13-neural-audio-codecs/outputs/skill-codec-picker.md",
+              "version": "1.0.0",
+              "description": "Pick a neural audio codec (EnCodec / DAC / SNAC / Mimi) for a given generative or compression task.",
+              "tags": [
+                "codec",
+                "encodec",
+                "dac",
+                "snac",
+                "mimi",
+                "rvq",
+                "semantic-tokens"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 14,
+          "slug": "14-voice-activity-detection-turn-taking",
+          "title": "Voice Activity Detection & Turn-Taking — Silero, Cobra, and the Flush Trick",
+          "path": "phases/06-speech-and-audio/14-voice-activity-detection-turn-taking",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "vad-tuner",
+              "path": "phases/06-speech-and-audio/14-voice-activity-detection-turn-taking/outputs/skill-vad-tuner.md",
+              "version": "1.0.0",
+              "description": "Pick VAD model, threshold, silence hangover, pre-roll, and turn-detection strategy for a voice agent.",
+              "tags": [
+                "vad",
+                "silero",
+                "cobra",
+                "turn-detection",
+                "flush-trick"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 15,
+          "slug": "15-streaming-speech-to-speech-moshi-hibiki",
+          "title": "Streaming Speech-to-Speech — Moshi, Hibiki, and Full-Duplex Dialogue",
+          "path": "phases/06-speech-and-audio/15-streaming-speech-to-speech-moshi-hibiki",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "duplex-pipeline",
+              "path": "phases/06-speech-and-audio/15-streaming-speech-to-speech-moshi-hibiki/outputs/skill-duplex-pipeline.md",
+              "version": "1.0.0",
+              "description": "Pick full-duplex (Moshi) vs pipeline (VAD + STT + LLM + TTS) architecture for a voice-agent workload.",
+              "tags": [
+                "moshi",
+                "hibiki",
+                "full-duplex",
+                "voice-agent",
+                "streaming"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 16,
+          "slug": "16-anti-spoofing-audio-watermarking",
+          "title": "Voice Anti-Spoofing & Audio Watermarking — ASVspoof 5, AudioSeal, WaveVerify",
+          "path": "phases/06-speech-and-audio/16-anti-spoofing-audio-watermarking",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "spoof-defender",
+              "path": "phases/06-speech-and-audio/16-anti-spoofing-audio-watermarking/outputs/skill-spoof-defender.md",
+              "version": "1.0.0",
+              "description": "Pick detection model, watermark, provenance manifest, and operational playbook for a voice-generation / voice-auth deployment.",
+              "tags": [
+                "anti-spoofing",
+                "watermark",
+                "audioseal",
+                "asvspoof",
+                "c2pa",
+                "voice-fraud"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 17,
+          "slug": "17-audio-evaluation-metrics",
+          "title": "Audio Evaluation — WER, MOS, UTMOS, MMAU, FAD, and the Open Leaderboards",
+          "path": "phases/06-speech-and-audio/17-audio-evaluation-metrics",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "audio-evaluator",
+              "path": "phases/06-speech-and-audio/17-audio-evaluation-metrics/outputs/skill-audio-evaluator.md",
+              "version": "1.0.0",
+              "description": "Pick metrics, benchmarks, normalization rules, and reporting format for any audio model release.",
+              "tags": [
+                "evaluation",
+                "wer",
+                "mos",
+                "utmos",
+                "eer",
+                "der",
+                "fad",
+                "mmau",
+                "leaderboard"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "num": 7,
+      "slug": "07-transformers-deep-dive",
+      "title": "Transformers Deep Dive",
+      "lesson_count": 16,
+      "lessons": [
+        {
+          "num": 1,
+          "slug": "01-why-transformers",
+          "title": "Why Transformers — The Problems with RNNs",
+          "path": "phases/07-transformers-deep-dive/01-why-transformers",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "sequence-architecture-picker",
+              "path": "phases/07-transformers-deep-dive/01-why-transformers/outputs/skill-architecture-picker.md",
+              "version": "1.0.0",
+              "description": "Pick sequence architecture (RNN, transformer, SSM, hybrid) given length, throughput, and training budget.",
+              "tags": [
+                "transformers",
+                "architecture",
+                "rnn",
+                "ssm"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 2,
+          "slug": "02-self-attention-from-scratch",
+          "title": "Self-Attention from Scratch",
+          "path": "phases/07-transformers-deep-dive/02-self-attention-from-scratch",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "self_attention.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-attention-explainer",
+              "path": "phases/07-transformers-deep-dive/02-self-attention-from-scratch/outputs/prompt-attention-explainer.md",
+              "version": "",
+              "description": "Explain the attention mechanism through the database lookup analogy",
+              "tags": []
+            }
+          ]
+        },
+        {
+          "num": 3,
+          "slug": "03-multi-head-attention",
+          "title": "Multi-Head Attention",
+          "path": "phases/07-transformers-deep-dive/03-multi-head-attention",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "mha-configurator",
+              "path": "phases/07-transformers-deep-dive/03-multi-head-attention/outputs/skill-mha-configurator.md",
+              "version": "1.0.0",
+              "description": "Recommend head count, KV-head count, and projection strategy (MHA / MQA / GQA / MLA) for a new transformer.",
+              "tags": [
+                "transformers",
+                "attention",
+                "mha",
+                "gqa"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 4,
+          "slug": "04-positional-encoding",
+          "title": "Positional Encoding — Sinusoidal, RoPE, ALiBi",
+          "path": "phases/07-transformers-deep-dive/04-positional-encoding",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "positional-encoding-picker",
+              "path": "phases/07-transformers-deep-dive/04-positional-encoding/outputs/skill-positional-encoding-picker.md",
+              "version": "1.0.0",
+              "description": "Pick positional encoding (RoPE, ALiBi, sinusoidal) + scaling strategy given context length and training budget.",
+              "tags": [
+                "transformers",
+                "positional-encoding",
+                "rope",
+                "alibi"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 5,
+          "slug": "05-full-transformer",
+          "title": "The Full Transformer — Encoder + Decoder",
+          "path": "phases/07-transformers-deep-dive/05-full-transformer",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "transformer-block-reviewer",
+              "path": "phases/07-transformers-deep-dive/05-full-transformer/outputs/skill-transformer-block-reviewer.md",
+              "version": "1.0.0",
+              "description": "Review a transformer block implementation against 2026 defaults and flag drift.",
+              "tags": [
+                "transformers",
+                "architecture",
+                "review"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 6,
+          "slug": "06-bert-masked-language-modeling",
+          "title": "BERT — Masked Language Modeling",
+          "path": "phases/07-transformers-deep-dive/06-bert-masked-language-modeling",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "bert-finetuner",
+              "path": "phases/07-transformers-deep-dive/06-bert-masked-language-modeling/outputs/skill-bert-finetuner.md",
+              "version": "1.0.0",
+              "description": "Scope a BERT fine-tune for a new classification, extraction, or retrieval task.",
+              "tags": [
+                "bert",
+                "fine-tuning",
+                "nlp"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 7,
+          "slug": "07-gpt-causal-language-modeling",
+          "title": "GPT — Causal Language Modeling",
+          "path": "phases/07-transformers-deep-dive/07-gpt-causal-language-modeling",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "sampling-tuner",
+              "path": "phases/07-transformers-deep-dive/07-gpt-causal-language-modeling/outputs/skill-sampling-tuner.md",
+              "version": "1.0.0",
+              "description": "Pick decoding strategy (greedy / temperature / top-k / top-p / min-p / speculative) for a given generation task.",
+              "tags": [
+                "gpt",
+                "sampling",
+                "decoding",
+                "inference"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 8,
+          "slug": "08-t5-bart-encoder-decoder",
+          "title": "T5, BART — Encoder-Decoder Models",
+          "path": "phases/07-transformers-deep-dive/08-t5-bart-encoder-decoder",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "seq2seq-picker",
+              "path": "phases/07-transformers-deep-dive/08-t5-bart-encoder-decoder/outputs/skill-seq2seq-picker.md",
+              "version": "1.0.0",
+              "description": "Choose encoder-decoder vs decoder-only for a new sequence-to-sequence task.",
+              "tags": [
+                "transformers",
+                "t5",
+                "bart",
+                "seq2seq"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 9,
+          "slug": "09-vision-transformers",
+          "title": "Vision Transformers (ViT)",
+          "path": "phases/07-transformers-deep-dive/09-vision-transformers",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "vit-configurator",
+              "path": "phases/07-transformers-deep-dive/09-vision-transformers/outputs/skill-vit-configurator.md",
+              "version": "1.0.0",
+              "description": "Pick a ViT variant, patch size, and pretraining source for a new vision task.",
+              "tags": [
+                "transformers",
+                "vit",
+                "vision"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 10,
+          "slug": "10-audio-transformers-whisper",
+          "title": "Audio Transformers — Whisper Architecture",
+          "path": "phases/07-transformers-deep-dive/10-audio-transformers-whisper",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "asr-configurator",
+              "path": "phases/07-transformers-deep-dive/10-audio-transformers-whisper/outputs/skill-asr-configurator.md",
+              "version": "1.0.0",
+              "description": "Pick an ASR model (Whisper variant / Moonshine / faster-whisper) and decoding parameters for a new speech pipeline.",
+              "tags": [
+                "transformers",
+                "whisper",
+                "asr",
+                "speech"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 11,
+          "slug": "11-mixture-of-experts",
+          "title": "Mixture of Experts (MoE)",
+          "path": "phases/07-transformers-deep-dive/11-mixture-of-experts",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "moe-configurator",
+              "path": "phases/07-transformers-deep-dive/11-mixture-of-experts/outputs/skill-moe-configurator.md",
+              "version": "1.0.0",
+              "description": "Pick expert count, top-k, balancing strategy, and shared-expert layout for a new MoE transformer.",
+              "tags": [
+                "transformers",
+                "moe",
+                "mixture-of-experts",
+                "scaling"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 12,
+          "slug": "12-kv-cache-flash-attention",
+          "title": "KV Cache, Flash Attention & Inference Optimization",
+          "path": "phases/07-transformers-deep-dive/12-kv-cache-flash-attention",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "inference-optimizer",
+              "path": "phases/07-transformers-deep-dive/12-kv-cache-flash-attention/outputs/skill-inference-optimizer.md",
+              "version": "1.0.0",
+              "description": "Pick attention implementation, KV cache strategy, quantization, and speculative decoding for a new inference deployment.",
+              "tags": [
+                "transformers",
+                "inference",
+                "flash-attention",
+                "kv-cache"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 13,
+          "slug": "13-scaling-laws",
+          "title": "Scaling Laws",
+          "path": "phases/07-transformers-deep-dive/13-scaling-laws",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "training-budget-estimator",
+              "path": "phases/07-transformers-deep-dive/13-scaling-laws/outputs/skill-training-budget-estimator.md",
+              "version": "1.0.0",
+              "description": "Estimate (N, D, hours, GPU count) for a new transformer training run given compute budget and deployment constraints.",
+              "tags": [
+                "scaling-laws",
+                "training",
+                "chinchilla"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 14,
+          "slug": "14-build-a-transformer-capstone",
+          "title": "Build a Transformer from Scratch — The Capstone",
+          "path": "phases/07-transformers-deep-dive/14-build-a-transformer-capstone",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "transformer-review",
+              "path": "phases/07-transformers-deep-dive/14-build-a-transformer-capstone/outputs/skill-transformer-review.md",
+              "version": "1.0.0",
+              "description": "Review a transformer-from-scratch implementation against the 13 Phase 7 lessons.",
+              "tags": [
+                "transformers",
+                "review",
+                "capstone"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 15,
+          "slug": "15-attention-variants",
+          "title": "Attention Variants — Sliding Window, Sparse, Differential",
+          "path": "phases/07-transformers-deep-dive/15-attention-variants",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "attention-variant-picker",
+              "path": "phases/07-transformers-deep-dive/15-attention-variants/outputs/skill-attention-variant-picker.md",
+              "version": "1.0.0",
+              "description": "Pick a full / sliding-window / sparse / differential attention topology for a new model given context length, retrieval demands, and compute profile.",
+              "tags": [
+                "attention",
+                "transformer",
+                "long-context",
+                "inference",
+                "memory"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 16,
+          "slug": "16-speculative-decoding",
+          "title": "Speculative Decoding — Draft, Verify, Repeat",
+          "path": "phases/07-transformers-deep-dive/16-speculative-decoding",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "spec-decode-picker",
+              "path": "phases/07-transformers-deep-dive/16-speculative-decoding/outputs/skill-spec-decode-picker.md",
+              "version": "1.0.0",
+              "description": "Pick a speculative decoding strategy (vanilla / Medusa / EAGLE / lookahead) and tuning parameters for a new LLM inference workload.",
+              "tags": [
+                "inference",
+                "decoding",
+                "latency",
+                "speculative",
+                "optimization"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "num": 8,
+      "slug": "08-generative-ai",
+      "title": "Generative AI",
+      "lesson_count": 15,
+      "lessons": [
+        {
+          "num": 1,
+          "slug": "01-generative-models-taxonomy-history",
+          "title": "Generative Models — Taxonomy & History",
+          "path": "phases/08-generative-ai/01-generative-models-taxonomy-history",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "generative-model-chooser",
+              "path": "phases/08-generative-ai/01-generative-models-taxonomy-history/outputs/skill-model-chooser.md",
+              "version": "1.0.0",
+              "description": "Pick a generative-model family, backbone, and hosted alternative for a given task and budget.",
+              "tags": [
+                "generative",
+                "taxonomy"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 2,
+          "slug": "02-autoencoders-vae",
+          "title": "Autoencoders & Variational Autoencoders (VAE)",
+          "path": "phases/08-generative-ai/02-autoencoders-vae",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "vae-trainer",
+              "path": "phases/08-generative-ai/02-autoencoders-vae/outputs/skill-vae-trainer.md",
+              "version": "1.0.0",
+              "description": "Specify VAE architecture, latent size, beta schedule, and eval plan for a given dataset and downstream use.",
+              "tags": [
+                "vae",
+                "latent",
+                "generative"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 3,
+          "slug": "03-gans-generator-discriminator",
+          "title": "GANs — Generator vs Discriminator",
+          "path": "phases/08-generative-ai/03-gans-generator-discriminator",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "gan-debugger",
+              "path": "phases/08-generative-ai/03-gans-generator-discriminator/outputs/skill-gan-debugger.md",
+              "version": "1.0.0",
+              "description": "Diagnose failing GAN training from loss curves and sample grids; prescribe one-line fixes.",
+              "tags": [
+                "gan",
+                "adversarial",
+                "debugging"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 4,
+          "slug": "04-conditional-gans-pix2pix",
+          "title": "Conditional GANs & Pix2Pix",
+          "path": "phases/08-generative-ai/04-conditional-gans-pix2pix",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "img2img-chooser",
+              "path": "phases/08-generative-ai/04-conditional-gans-pix2pix/outputs/skill-img2img-chooser.md",
+              "version": "1.0.0",
+              "description": "Pick an image-to-image approach given paired vs unpaired data, domain specificity, and latency budget.",
+              "tags": [
+                "pix2pix",
+                "img2img",
+                "conditional"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 5,
+          "slug": "05-stylegan",
+          "title": "StyleGAN",
+          "path": "phases/08-generative-ai/05-stylegan",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "stylegan-inversion",
+              "path": "phases/08-generative-ai/05-stylegan/outputs/skill-stylegan-inversion.md",
+              "version": "1.0.0",
+              "description": "Choose an inversion and editing pipeline for a pretrained StyleGAN over a real photo.",
+              "tags": [
+                "stylegan",
+                "inversion",
+                "editing"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 6,
+          "slug": "06-diffusion-ddpm-from-scratch",
+          "title": "Diffusion Models — DDPM from Scratch",
+          "path": "phases/08-generative-ai/06-diffusion-ddpm-from-scratch",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "diffusion-trainer",
+              "path": "phases/08-generative-ai/06-diffusion-ddpm-from-scratch/outputs/skill-diffusion-trainer.md",
+              "version": "1.0.0",
+              "description": "Configure a diffusion training run: schedule, prediction target, sampler, and eval plan.",
+              "tags": [
+                "diffusion",
+                "ddpm",
+                "training"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 7,
+          "slug": "07-latent-diffusion-stable-diffusion",
+          "title": "Latent Diffusion & Stable Diffusion",
+          "path": "phases/08-generative-ai/07-latent-diffusion-stable-diffusion",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "sd-prompter",
+              "path": "phases/08-generative-ai/07-latent-diffusion-stable-diffusion/outputs/skill-sd-prompter.md",
+              "version": "1.0.0",
+              "description": "Configure Stable Diffusion / Flux inference for a given prompt, style, and quality bar.",
+              "tags": [
+                "stable-diffusion",
+                "flux",
+                "latent-diffusion"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 8,
+          "slug": "08-controlnet-lora-conditioning",
+          "title": "ControlNet, LoRA & Conditioning",
+          "path": "phases/08-generative-ai/08-controlnet-lora-conditioning",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "sd-toolkit-composer",
+              "path": "phases/08-generative-ai/08-controlnet-lora-conditioning/outputs/skill-sd-toolkit-composer.md",
+              "version": "1.0.0",
+              "description": "Compose ControlNets, LoRAs, and IP-Adapters on top of an SD / Flux base for a given set of inputs.",
+              "tags": [
+                "controlnet",
+                "lora",
+                "ip-adapter",
+                "diffusion"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 9,
+          "slug": "09-inpainting-outpainting-editing",
+          "title": "Inpainting, Outpainting & Image Editing",
+          "path": "phases/08-generative-ai/09-inpainting-outpainting-editing",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "editing-pipeline",
+              "path": "phases/08-generative-ai/09-inpainting-outpainting-editing/outputs/skill-editing-pipeline.md",
+              "version": "1.0.0",
+              "description": "Plan an image-editing pipeline from source + edit description to a ready-to-ship output.",
+              "tags": [
+                "inpaint",
+                "outpaint",
+                "edit",
+                "sam"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 10,
+          "slug": "10-video-generation",
+          "title": "Video Generation",
+          "path": "phases/08-generative-ai/10-video-generation",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "video-brief",
+              "path": "phases/08-generative-ai/10-video-generation/outputs/skill-video-brief.md",
+              "version": "1.0.0",
+              "description": "Translate a video brief into a model + prompt + shot plan for a 2026 video generator.",
+              "tags": [
+                "video",
+                "diffusion",
+                "sora",
+                "veo",
+                "kling"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 11,
+          "slug": "11-audio-generation",
+          "title": "Audio Generation",
+          "path": "phases/08-generative-ai/11-audio-generation",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "audio-brief",
+              "path": "phases/08-generative-ai/11-audio-generation/outputs/skill-audio-brief.md",
+              "version": "1.0.0",
+              "description": "Translate an audio brief into a model + prompt + eval plan across TTS, music, and SFX.",
+              "tags": [
+                "audio",
+                "tts",
+                "music",
+                "sfx",
+                "codec"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 12,
+          "slug": "12-3d-generation",
+          "title": "3D Generation",
+          "path": "phases/08-generative-ai/12-3d-generation",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "3d-pipeline",
+              "path": "phases/08-generative-ai/12-3d-generation/outputs/skill-3d-pipeline.md",
+              "version": "1.0.0",
+              "description": "Choose a 3D generation or reconstruction pipeline given input type, output format, and use case.",
+              "tags": [
+                "3d",
+                "gaussian-splatting",
+                "nerf",
+                "mesh"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 13,
+          "slug": "13-flow-matching-rectified-flows",
+          "title": "Flow Matching & Rectified Flows",
+          "path": "phases/08-generative-ai/13-flow-matching-rectified-flows",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "fm-tuner",
+              "path": "phases/08-generative-ai/13-flow-matching-rectified-flows/outputs/skill-fm-tuner.md",
+              "version": "1.0.0",
+              "description": "Convert a diffusion training plan into a flow-matching / rectified-flow config.",
+              "tags": [
+                "flow-matching",
+                "rectified-flow",
+                "diffusion"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 14,
+          "slug": "14-evaluation-fid-clip-score",
+          "title": "Evaluation — FID, CLIP Score, Human Preference",
+          "path": "phases/08-generative-ai/14-evaluation-fid-clip-score",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "eval-report",
+              "path": "phases/08-generative-ai/14-evaluation-fid-clip-score/outputs/skill-eval-report.md",
+              "version": "1.0.0",
+              "description": "Plan a full generative-model evaluation: sample quality, adherence, preference, failure audit.",
+              "tags": [
+                "evaluation",
+                "fid",
+                "clip",
+                "elo"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 19,
+          "slug": "19-visual-autoregressive-var",
+          "title": "Visual Autoregressive Modeling (VAR): Next-Scale Prediction",
+          "path": "phases/08-generative-ai/19-visual-autoregressive-var",
+          "has_docs": true,
+          "has_code": false,
+          "has_quiz": false,
+          "has_notebook": false,
+          "code_files": [],
+          "outputs": []
+        }
+      ]
+    },
+    {
+      "num": 9,
+      "slug": "09-reinforcement-learning",
+      "title": "Reinforcement Learning",
+      "lesson_count": 12,
+      "lessons": [
+        {
+          "num": 1,
+          "slug": "01-mdps-states-actions-rewards",
+          "title": "MDPs, States, Actions & Rewards",
+          "path": "phases/09-reinforcement-learning/01-mdps-states-actions-rewards",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "mdp-modeler",
+              "path": "phases/09-reinforcement-learning/01-mdps-states-actions-rewards/outputs/skill-mdp-modeler.md",
+              "version": "1.0.0",
+              "description": "Given a task description, produce a Markov Decision Process spec and flag formulation risks before training.",
+              "tags": [
+                "rl",
+                "mdp",
+                "modeling"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 2,
+          "slug": "02-dynamic-programming",
+          "title": "Dynamic Programming — Policy Iteration & Value Iteration",
+          "path": "phases/09-reinforcement-learning/02-dynamic-programming",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "dp-solver",
+              "path": "phases/09-reinforcement-learning/02-dynamic-programming/outputs/skill-dp-solver.md",
+              "version": "1.0.0",
+              "description": "Solve a small tabular MDP exactly via policy iteration or value iteration. Report convergence behavior.",
+              "tags": [
+                "rl",
+                "dynamic-programming",
+                "bellman"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 3,
+          "slug": "03-monte-carlo-methods",
+          "title": "Monte Carlo Methods — Learning from Complete Episodes",
+          "path": "phases/09-reinforcement-learning/03-monte-carlo-methods",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "mc-evaluator",
+              "path": "phases/09-reinforcement-learning/03-monte-carlo-methods/outputs/skill-mc-evaluator.md",
+              "version": "1.0.0",
+              "description": "Evaluate a policy via Monte Carlo rollouts and produce a convergence report with DP-comparison if available.",
+              "tags": [
+                "rl",
+                "monte-carlo",
+                "evaluation"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 4,
+          "slug": "04-q-learning-sarsa",
+          "title": "Temporal Difference — Q-Learning & SARSA",
+          "path": "phases/09-reinforcement-learning/04-q-learning-sarsa",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "td-agent",
+              "path": "phases/09-reinforcement-learning/04-q-learning-sarsa/outputs/skill-td-agent.md",
+              "version": "1.0.0",
+              "description": "Pick between Q-learning, SARSA, Expected SARSA for a tabular or small-feature RL task.",
+              "tags": [
+                "rl",
+                "td-learning",
+                "q-learning",
+                "sarsa"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 5,
+          "slug": "05-dqn",
+          "title": "Deep Q-Networks (DQN)",
+          "path": "phases/09-reinforcement-learning/05-dqn",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "dqn-trainer",
+              "path": "phases/09-reinforcement-learning/05-dqn/outputs/skill-dqn-trainer.md",
+              "version": "1.0.0",
+              "description": "Produce a DQN training config (buffer, target sync, ε schedule, reward clipping) for a discrete-action RL task.",
+              "tags": [
+                "rl",
+                "dqn",
+                "deep-rl"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 6,
+          "slug": "06-policy-gradients-reinforce",
+          "title": "Policy Gradient — REINFORCE from Scratch",
+          "path": "phases/09-reinforcement-learning/06-policy-gradients-reinforce",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "policy-gradient-trainer",
+              "path": "phases/09-reinforcement-learning/06-policy-gradients-reinforce/outputs/skill-policy-gradient-trainer.md",
+              "version": "1.0.0",
+              "description": "Produce a REINFORCE / actor-critic / PPO training config for a given task and diagnose variance issues.",
+              "tags": [
+                "rl",
+                "policy-gradient",
+                "reinforce"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 7,
+          "slug": "07-actor-critic-a2c-a3c",
+          "title": "Actor-Critic — A2C and A3C",
+          "path": "phases/09-reinforcement-learning/07-actor-critic-a2c-a3c",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "actor-critic-trainer",
+              "path": "phases/09-reinforcement-learning/07-actor-critic-a2c-a3c/outputs/skill-actor-critic-trainer.md",
+              "version": "1.0.0",
+              "description": "Produce an A2C / A3C / GAE configuration for a given environment, with advantage estimation and loss weights specified.",
+              "tags": [
+                "rl",
+                "actor-critic",
+                "gae"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 8,
+          "slug": "08-ppo",
+          "title": "Proximal Policy Optimization (PPO)",
+          "path": "phases/09-reinforcement-learning/08-ppo",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "ppo-trainer",
+              "path": "phases/09-reinforcement-learning/08-ppo/outputs/skill-ppo-trainer.md",
+              "version": "1.0.0",
+              "description": "Produce a PPO training config and a diagnostic plan for a given environment.",
+              "tags": [
+                "rl",
+                "ppo",
+                "policy-gradient"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 9,
+          "slug": "09-reward-modeling-rlhf",
+          "title": "Reward Modeling & RLHF",
+          "path": "phases/09-reinforcement-learning/09-reward-modeling-rlhf",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "rlhf-architect",
+              "path": "phases/09-reinforcement-learning/09-reward-modeling-rlhf/outputs/skill-rlhf-architect.md",
+              "version": "1.0.0",
+              "description": "Design an RLHF / DPO / GRPO alignment pipeline for a language model, including RM, KL, and data strategy.",
+              "tags": [
+                "rl",
+                "rlhf",
+                "alignment",
+                "llm"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 10,
+          "slug": "10-multi-agent-rl",
+          "title": "Multi-Agent RL",
+          "path": "phases/09-reinforcement-learning/10-multi-agent-rl",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "marl-architect",
+              "path": "phases/09-reinforcement-learning/10-multi-agent-rl/outputs/skill-marl-architect.md",
+              "version": "1.0.0",
+              "description": "Pick the right multi-agent RL regime (IPPO, CTDE, self-play, league) for a given task.",
+              "tags": [
+                "rl",
+                "multi-agent",
+                "marl",
+                "self-play"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 11,
+          "slug": "11-sim-to-real-transfer",
+          "title": "Sim-to-Real Transfer",
+          "path": "phases/09-reinforcement-learning/11-sim-to-real-transfer",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "sim2real-planner",
+              "path": "phases/09-reinforcement-learning/11-sim-to-real-transfer/outputs/skill-sim2real-planner.md",
+              "version": "1.0.0",
+              "description": "Plan a sim-to-real transfer pipeline for a given robot + task, covering DR, SI, and safety.",
+              "tags": [
+                "rl",
+                "sim2real",
+                "robotics",
+                "domain-randomization"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 12,
+          "slug": "12-rl-for-games",
+          "title": "RL for Games — AlphaZero, MuZero, and the LLM-Reasoning Era",
+          "path": "phases/09-reinforcement-learning/12-rl-for-games",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "game-rl-designer",
+              "path": "phases/09-reinforcement-learning/12-rl-for-games/outputs/skill-game-rl-designer.md",
+              "version": "1.0.0",
+              "description": "Design a game-RL or reasoning-RL training pipeline (AlphaZero / MuZero / GRPO) for a given domain.",
+              "tags": [
+                "rl",
+                "alphazero",
+                "muzero",
+                "grpo",
+                "self-play"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "num": 10,
+      "slug": "10-llms-from-scratch",
+      "title": "LLMs From Scratch",
+      "lesson_count": 25,
+      "lessons": [
+        {
+          "num": 1,
+          "slug": "01-tokenizers",
+          "title": "Tokenizers: BPE, WordPiece, SentencePiece",
+          "path": "phases/10-llms-from-scratch/01-tokenizers",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "bpe.py",
+            "bpe.rs",
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-tokenizer-analyzer",
+              "path": "phases/10-llms-from-scratch/01-tokenizers/outputs/prompt-tokenizer-analyzer.md",
+              "version": "",
+              "description": "Analyze tokenization efficiency for a given text across different models and tokenizer types",
+              "tags": []
+            },
+            {
+              "type": "skill",
+              "name": "skill-tokenizer",
+              "path": "phases/10-llms-from-scratch/01-tokenizers/outputs/skill-tokenizer.md",
+              "version": "1.0.0",
+              "description": "Choosing and building tokenizers for LLM projects",
+              "tags": [
+                "tokenizer",
+                "bpe",
+                "wordpiece",
+                "sentencepiece",
+                "llm",
+                "nlp"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 2,
+          "slug": "02-building-a-tokenizer",
+          "title": "Building a Tokenizer from Scratch",
+          "path": "phases/10-llms-from-scratch/02-building-a-tokenizer",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-tokenizer-builder",
+              "path": "phases/10-llms-from-scratch/02-building-a-tokenizer/outputs/prompt-tokenizer-builder.md",
+              "version": "1.0.0",
+              "description": "Build and debug production-quality tokenizers for LLM projects",
+              "tags": [
+                "tokenizer",
+                "bpe",
+                "byte-level",
+                "special-tokens",
+                "chat-template",
+                "multilingual"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 3,
+          "slug": "03-data-pipelines",
+          "title": "Data Pipelines for Pre-Training",
+          "path": "phases/10-llms-from-scratch/03-data-pipelines",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-data-quality-checker",
+              "path": "phases/10-llms-from-scratch/03-data-pipelines/outputs/prompt-data-quality-checker.md",
+              "version": "1.0.0",
+              "description": "Validate and debug data quality in LLM pre-training pipelines",
+              "tags": [
+                "data-pipeline",
+                "deduplication",
+                "quality-filter",
+                "pre-training",
+                "llm",
+                "data-cleaning"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 4,
+          "slug": "04-pre-training-mini-gpt",
+          "title": "Pre-Training a Mini GPT (124M Parameters)",
+          "path": "phases/10-llms-from-scratch/04-pre-training-mini-gpt",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-gpt-architecture-analyzer",
+              "path": "phases/10-llms-from-scratch/04-pre-training-mini-gpt/outputs/prompt-gpt-architecture-analyzer.md",
+              "version": "1.0.0",
+              "description": "Analyze architecture choices in any GPT-style transformer model",
+              "tags": [
+                "gpt",
+                "transformer",
+                "architecture",
+                "attention",
+                "kv-cache",
+                "scaling",
+                "pre-training"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 5,
+          "slug": "05-scaling-distributed",
+          "title": "Scaling: Distributed Training, FSDP, DeepSpeed",
+          "path": "phases/10-llms-from-scratch/05-scaling-distributed",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-distributed-training-planner",
+              "path": "phases/10-llms-from-scratch/05-scaling-distributed/outputs/prompt-distributed-training-planner.md",
+              "version": "1.0.0",
+              "description": "Plan a distributed training run given model size and available hardware",
+              "tags": [
+                "distributed-training",
+                "fsdp",
+                "deepspeed",
+                "tensor-parallelism",
+                "pipeline-parallelism",
+                "scaling"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 6,
+          "slug": "06-instruction-tuning-sft",
+          "title": "Instruction Tuning (SFT)",
+          "path": "phases/10-llms-from-scratch/06-instruction-tuning-sft",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-sft-data-curator",
+              "path": "phases/10-llms-from-scratch/06-instruction-tuning-sft/outputs/prompt-sft-data-curator.md",
+              "version": "1.0.0",
+              "description": "Design and curate instruction datasets for supervised fine-tuning",
+              "tags": [
+                "sft",
+                "instruction-tuning",
+                "fine-tuning",
+                "data-curation",
+                "alignment"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 7,
+          "slug": "07-rlhf",
+          "title": "RLHF: Reward Model + PPO",
+          "path": "phases/10-llms-from-scratch/07-rlhf",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-reward-model-designer",
+              "path": "phases/10-llms-from-scratch/07-rlhf/outputs/prompt-reward-model-designer.md",
+              "version": "1.0.0",
+              "description": "Design reward model training pipelines for RLHF alignment",
+              "tags": [
+                "rlhf",
+                "reward-model",
+                "ppo",
+                "alignment",
+                "human-feedback",
+                "preference-learning"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 8,
+          "slug": "08-dpo",
+          "title": "DPO: Direct Preference Optimization",
+          "path": "phases/10-llms-from-scratch/08-dpo",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-alignment-method-selector",
+              "path": "phases/10-llms-from-scratch/08-dpo/outputs/prompt-alignment-method-selector.md",
+              "version": "1.0.0",
+              "description": "Choose the right alignment method (SFT, RLHF, DPO, KTO, ORPO, SimPO) for your use case",
+              "tags": [
+                "alignment",
+                "dpo",
+                "rlhf",
+                "kto",
+                "orpo",
+                "simpo",
+                "preference-optimization",
+                "fine-tuning"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 9,
+          "slug": "09-constitutional-ai-self-improvement",
+          "title": "Constitutional AI and Self-Improvement",
+          "path": "phases/10-llms-from-scratch/09-constitutional-ai-self-improvement",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "self-improvement-auditor",
+              "path": "phases/10-llms-from-scratch/09-constitutional-ai-self-improvement/outputs/skill-self-improvement-auditor.md",
+              "version": "1.0.0",
+              "description": "Audit a proposed self-improvement or constitutional AI pipeline before it runs at scale.",
+              "tags": [
+                "alignment",
+                "cai",
+                "grpo",
+                "rlhf",
+                "self-improvement",
+                "reward-hacking"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 10,
+          "slug": "10-evaluation",
+          "title": "Evaluation: Benchmarks, Evals, LM Harness",
+          "path": "phases/10-llms-from-scratch/10-evaluation",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-eval-designer",
+              "path": "phases/10-llms-from-scratch/10-evaluation/outputs/prompt-eval-designer.md",
+              "version": "",
+              "description": "Design a custom evaluation suite for any LLM task, including test cases, scoring functions, and pass/fail thresholds",
+              "tags": []
+            },
+            {
+              "type": "skill",
+              "name": "skill-evaluation",
+              "path": "phases/10-llms-from-scratch/10-evaluation/outputs/skill-evaluation.md",
+              "version": "1.0.0",
+              "description": "Decision framework for choosing the right LLM evaluation strategy based on task type, budget, and requirements",
+              "tags": [
+                "evaluation",
+                "evals",
+                "benchmarks",
+                "llm-as-judge",
+                "elo",
+                "metrics"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 11,
+          "slug": "11-quantization",
+          "title": "Quantization: Making Models Fit",
+          "path": "phases/10-llms-from-scratch/11-quantization",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "skill-quantization",
+              "path": "phases/10-llms-from-scratch/11-quantization/outputs/skill-quantization.md",
+              "version": "1.0.0",
+              "description": "Choose the right quantization strategy for deploying LLMs based on hardware, quality, and latency constraints",
+              "tags": [
+                "quantization",
+                "inference",
+                "deployment",
+                "optimization",
+                "fp8",
+                "int4",
+                "int8",
+                "gptq",
+                "awq",
+                "gguf"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 12,
+          "slug": "12-inference-optimization",
+          "title": "Inference Optimization",
+          "path": "phases/10-llms-from-scratch/12-inference-optimization",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "skill-inference-optimization",
+              "path": "phases/10-llms-from-scratch/12-inference-optimization/outputs/skill-inference-optimization.md",
+              "version": "1.0.0",
+              "description": "Diagnose and optimize LLM inference serving throughput, latency, and cost",
+              "tags": [
+                "inference",
+                "kv-cache",
+                "batching",
+                "speculative-decoding",
+                "vllm",
+                "optimization"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 13,
+          "slug": "13-building-complete-llm-pipeline",
+          "title": "Building a Complete LLM Pipeline",
+          "path": "phases/10-llms-from-scratch/13-building-complete-llm-pipeline",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "llm-pipeline-reviewer",
+              "path": "phases/10-llms-from-scratch/13-building-complete-llm-pipeline/outputs/skill-llm-pipeline-reviewer.md",
+              "version": "1.0.0",
+              "description": "Review an end-to-end LLM training pipeline manifest before a multi-million-dollar run.",
+              "tags": [
+                "pipeline",
+                "training",
+                "manifest",
+                "eval-gate",
+                "cost",
+                "rollback"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 14,
+          "slug": "14-open-models-architecture-walkthroughs",
+          "title": "Open Models: Architecture Walkthroughs",
+          "path": "phases/10-llms-from-scratch/14-open-models-architecture-walkthroughs",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "open-model-picker",
+              "path": "phases/10-llms-from-scratch/14-open-models-architecture-walkthroughs/outputs/skill-open-model-picker.md",
+              "version": "1.0.0",
+              "description": "Pick an open LLM family, quantization, and inference stack for a given deployment target.",
+              "tags": [
+                "open-models",
+                "llama",
+                "deepseek",
+                "mixtral",
+                "qwen",
+                "gemma",
+                "moe",
+                "gqa",
+                "mla",
+                "quantization"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 15,
+          "slug": "15-speculative-decoding-eagle3",
+          "title": "Speculative Decoding and EAGLE-3",
+          "path": "phases/10-llms-from-scratch/15-speculative-decoding-eagle3",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "eagle3-tuner",
+              "path": "phases/10-llms-from-scratch/15-speculative-decoding-eagle3/outputs/skill-eagle3-tuner.md",
+              "version": "1.0.0",
+              "description": "Pick and tune a speculative decoding strategy (vanilla / Medusa / EAGLE-1/2/3 / lookahead) for a new inference workload.",
+              "tags": [
+                "speculative-decoding",
+                "eagle",
+                "eagle-3",
+                "medusa",
+                "inference",
+                "vllm",
+                "sglang",
+                "tensorrt-llm"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 16,
+          "slug": "16-differential-attention-v2",
+          "title": "Differential Attention (V2)",
+          "path": "phases/10-llms-from-scratch/16-differential-attention-v2",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "diff-attention-integrator",
+              "path": "phases/10-llms-from-scratch/16-differential-attention-v2/outputs/skill-diff-attention-integrator.md",
+              "version": "1.0.0",
+              "description": "Integration plan for adding Differential Attention V2 to a new pre-training run or LoRA fine-tune.",
+              "tags": [
+                "differential-attention",
+                "diff-transformer",
+                "long-context",
+                "flash-attention",
+                "pre-training",
+                "lora"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 17,
+          "slug": "17-native-sparse-attention",
+          "title": "Native Sparse Attention (DeepSeek NSA)",
+          "path": "phases/10-llms-from-scratch/17-native-sparse-attention",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "nsa-integrator",
+              "path": "phases/10-llms-from-scratch/17-native-sparse-attention/outputs/skill-nsa-integrator.md",
+              "version": "1.0.0",
+              "description": "Integration plan for Native Sparse Attention in a long-context pre-training run.",
+              "tags": [
+                "nsa",
+                "sparse-attention",
+                "long-context",
+                "pre-training",
+                "kernel-aligned",
+                "deepseek"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 18,
+          "slug": "18-multi-token-prediction",
+          "title": "Multi-Token Prediction (MTP)",
+          "path": "phases/10-llms-from-scratch/18-multi-token-prediction",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "mtp-planner",
+              "path": "phases/10-llms-from-scratch/18-multi-token-prediction/outputs/skill-mtp-planner.md",
+              "version": "1.0.0",
+              "description": "Plan a multi-token prediction integration for a new pre-training run.",
+              "tags": [
+                "mtp",
+                "multi-token-prediction",
+                "deepseek-v3",
+                "pre-training",
+                "speculative-decoding"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 18,
+          "slug": "18-synthetic-data-pipelines",
+          "title": "Synthetic Data Pipelines",
+          "path": "phases/10-llms-from-scratch/18-synthetic-data-pipelines",
+          "has_docs": false,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": false,
+          "code_files": [],
+          "outputs": []
+        },
+        {
+          "num": 19,
+          "slug": "19-dualpipe-parallelism",
+          "title": "DualPipe Parallelism",
+          "path": "phases/10-llms-from-scratch/19-dualpipe-parallelism",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "dualpipe-planner",
+              "path": "phases/10-llms-from-scratch/19-dualpipe-parallelism/outputs/skill-dualpipe-planner.md",
+              "version": "1.0.0",
+              "description": "Plan a pipeline parallelism strategy (1F1B, Zero Bubble, DualPipe, DualPipeV) for a training cluster.",
+              "tags": [
+                "pipeline-parallelism",
+                "dualpipe",
+                "dualpipev",
+                "zero-bubble",
+                "expert-parallelism",
+                "distributed-training"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 20,
+          "slug": "20-deepseek-v3-walkthrough",
+          "title": "DeepSeek-V3 Architecture Walkthrough",
+          "path": "phases/10-llms-from-scratch/20-deepseek-v3-walkthrough",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "deepseek-v3-reader",
+              "path": "phases/10-llms-from-scratch/20-deepseek-v3-walkthrough/outputs/skill-deepseek-v3-reader.md",
+              "version": "1.0.0",
+              "description": "Read a DeepSeek-family config and produce a component-by-component architecture analysis.",
+              "tags": [
+                "deepseek-v3",
+                "deepseek-r1",
+                "mla",
+                "moe",
+                "mtp",
+                "dualpipe",
+                "architecture"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 21,
+          "slug": "21-jamba-hybrid-ssm-transformer",
+          "title": "Jamba — Hybrid SSM-Transformer",
+          "path": "phases/10-llms-from-scratch/21-jamba-hybrid-ssm-transformer",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "hybrid-picker",
+              "path": "phases/10-llms-from-scratch/21-jamba-hybrid-ssm-transformer/outputs/skill-hybrid-picker.md",
+              "version": "1.0.0",
+              "description": "Pick between pure Transformer, Jamba-style hybrid, and pure SSM for a given workload.",
+              "tags": [
+                "jamba",
+                "mamba",
+                "ssm",
+                "hybrid",
+                "long-context",
+                "memory-budget",
+                "architecture"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 22,
+          "slug": "22-async-hogwild-inference",
+          "title": "Async and Hogwild! Inference",
+          "path": "phases/10-llms-from-scratch/22-async-hogwild-inference",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "parallel-inference-router",
+              "path": "phases/10-llms-from-scratch/22-async-hogwild-inference/outputs/skill-parallel-inference-router.md",
+              "version": "1.0.0",
+              "description": "Route a reasoning workload between voting, tree-of-thought, multi-agent, Hogwild!, and speculative decoding strategies.",
+              "tags": [
+                "parallel-inference",
+                "hogwild",
+                "speculative-decoding",
+                "tree-of-thought",
+                "multi-agent",
+                "reasoning"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 25,
+          "slug": "25-speculative-decoding",
+          "title": "Speculative Decoding and EAGLE",
+          "path": "phases/10-llms-from-scratch/25-speculative-decoding",
+          "has_docs": true,
+          "has_code": false,
+          "has_quiz": false,
+          "has_notebook": false,
+          "code_files": [],
+          "outputs": []
+        },
+        {
+          "num": 34,
+          "slug": "34-gradient-checkpointing",
+          "title": "Gradient Checkpointing and Activation Recomputation",
+          "path": "phases/10-llms-from-scratch/34-gradient-checkpointing",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": []
+        }
+      ]
+    },
+    {
+      "num": 11,
+      "slug": "11-llm-engineering",
+      "title": "LLM Engineering",
+      "lesson_count": 17,
+      "lessons": [
+        {
+          "num": 1,
+          "slug": "01-prompt-engineering",
+          "title": "Prompt Engineering: Techniques & Patterns",
+          "path": "phases/11-llm-engineering/01-prompt-engineering",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "prompt_engineering.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-prompt-optimizer",
+              "path": "phases/11-llm-engineering/01-prompt-engineering/outputs/prompt-prompt-optimizer.md",
+              "version": "",
+              "description": "Takes a draft prompt and rewrites it using proven prompt engineering patterns for maximum effectiveness across models",
+              "tags": []
+            },
+            {
+              "type": "skill",
+              "name": "skill-prompt-patterns",
+              "path": "phases/11-llm-engineering/01-prompt-engineering/outputs/skill-prompt-patterns.md",
+              "version": "1.0.0",
+              "description": "Decision framework for choosing the right prompt pattern based on task type, reliability requirements, and target model",
+              "tags": [
+                "prompt-engineering",
+                "patterns",
+                "llm",
+                "temperature",
+                "cross-model",
+                "few-shot",
+                "chain-of-thought"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 2,
+          "slug": "02-few-shot-cot",
+          "title": "Few-Shot, Chain-of-Thought, Tree-of-Thought",
+          "path": "phases/11-llm-engineering/02-few-shot-cot",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "advanced_prompting.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-reasoning-chain",
+              "path": "phases/11-llm-engineering/02-few-shot-cot/outputs/prompt-reasoning-chain.md",
+              "version": "",
+              "description": "Production-ready few-shot CoT prompt with self-consistency support for multi-step reasoning tasks",
+              "tags": []
+            },
+            {
+              "type": "skill",
+              "name": "skill-cot-patterns",
+              "path": "phases/11-llm-engineering/02-few-shot-cot/outputs/skill-cot-patterns.md",
+              "version": "1.0.0",
+              "description": "Decision framework for choosing the right reasoning technique based on task complexity, accuracy requirements, and cost constraints",
+              "tags": [
+                "chain-of-thought",
+                "few-shot",
+                "self-consistency",
+                "tree-of-thought",
+                "react",
+                "reasoning",
+                "prompting"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 3,
+          "slug": "03-structured-outputs",
+          "title": "Structured Outputs: JSON, Schema Validation, Constrained Decoding",
+          "path": "phases/11-llm-engineering/03-structured-outputs",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-structured-extractor",
+              "path": "phases/11-llm-engineering/03-structured-outputs/outputs/prompt-structured-extractor.md",
+              "version": "",
+              "description": "Extract structured data from unstructured text given a JSON Schema definition",
+              "tags": []
+            },
+            {
+              "type": "skill",
+              "name": "skill-structured-outputs",
+              "path": "phases/11-llm-engineering/03-structured-outputs/outputs/skill-structured-outputs.md",
+              "version": "1.0.0",
+              "description": "Decision framework for choosing the right structured output strategy based on provider, reliability, and complexity",
+              "tags": [
+                "structured-output",
+                "json",
+                "schema",
+                "constrained-decoding",
+                "pydantic",
+                "function-calling"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 4,
+          "slug": "04-embeddings",
+          "title": "Embeddings & Vector Representations",
+          "path": "phases/11-llm-engineering/04-embeddings",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "embeddings.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-embedding-advisor",
+              "path": "phases/11-llm-engineering/04-embeddings/outputs/prompt-embedding-advisor.md",
+              "version": "",
+              "description": "Choose embedding models, dimensions, and strategies for specific use cases",
+              "tags": []
+            },
+            {
+              "type": "skill",
+              "name": "skill-embedding-patterns",
+              "path": "phases/11-llm-engineering/04-embeddings/outputs/skill-embedding-patterns.md",
+              "version": "1.0.0",
+              "description": "Production patterns for embeddings, vector search, and similarity",
+              "tags": [
+                "embeddings",
+                "vectors",
+                "similarity",
+                "search",
+                "chunking",
+                "quantization"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 5,
+          "slug": "05-context-engineering",
+          "title": "Context Engineering: Windows, Budgets, Memory, and Retrieval",
+          "path": "phases/11-llm-engineering/05-context-engineering",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-context-optimizer",
+              "path": "phases/11-llm-engineering/05-context-engineering/outputs/prompt-context-optimizer.md",
+              "version": "",
+              "description": "Audit a context assembly strategy and recommend optimizations to reduce token waste and improve response quality",
+              "tags": []
+            },
+            {
+              "type": "skill",
+              "name": "skill-context-engineering",
+              "path": "phases/11-llm-engineering/05-context-engineering/outputs/skill-context-engineering.md",
+              "version": "1.0.0",
+              "description": "Decision framework for designing context assembly pipelines based on task type, window size, and latency budget",
+              "tags": [
+                "context-engineering",
+                "context-window",
+                "rag",
+                "memory",
+                "tool-selection",
+                "lost-in-the-middle"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 6,
+          "slug": "06-rag",
+          "title": "RAG (Retrieval-Augmented Generation)",
+          "path": "phases/11-llm-engineering/06-rag",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-rag-architect",
+              "path": "phases/11-llm-engineering/06-rag/outputs/prompt-rag-architect.md",
+              "version": "",
+              "description": "Design RAG systems for specific use cases with concrete architecture decisions",
+              "tags": []
+            },
+            {
+              "type": "skill",
+              "name": "skill-rag-pipeline",
+              "path": "phases/11-llm-engineering/06-rag/outputs/skill-rag-pipeline.md",
+              "version": "1.0.0",
+              "description": "Build and debug RAG pipelines from first principles",
+              "tags": [
+                "rag",
+                "retrieval",
+                "embeddings",
+                "vector-search",
+                "llm-engineering"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 7,
+          "slug": "07-advanced-rag",
+          "title": "Advanced RAG (Chunking, Reranking, Hybrid Search)",
+          "path": "phases/11-llm-engineering/07-advanced-rag",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-advanced-rag-debugger",
+              "path": "phases/11-llm-engineering/07-advanced-rag/outputs/prompt-advanced-rag-debugger.md",
+              "version": "",
+              "description": "Diagnose and fix RAG quality issues across retrieval, generation, and evaluation",
+              "tags": []
+            },
+            {
+              "type": "skill",
+              "name": "skill-advanced-rag",
+              "path": "phases/11-llm-engineering/07-advanced-rag/outputs/skill-advanced-rag.md",
+              "version": "1.0.0",
+              "description": "Build production-grade RAG with hybrid search, reranking, and evaluation",
+              "tags": [
+                "rag",
+                "hybrid-search",
+                "bm25",
+                "reranking",
+                "hyde",
+                "evaluation"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 8,
+          "slug": "08-fine-tuning-lora",
+          "title": "Fine-Tuning with LoRA & QLoRA",
+          "path": "phases/11-llm-engineering/08-fine-tuning-lora",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "lora.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-lora-advisor",
+              "path": "phases/11-llm-engineering/08-fine-tuning-lora/outputs/prompt-lora-advisor.md",
+              "version": "",
+              "description": "Decide LoRA rank, target modules, and hyperparameters for a specific fine-tuning task",
+              "tags": []
+            },
+            {
+              "type": "skill",
+              "name": "skill-fine-tuning-guide",
+              "path": "phases/11-llm-engineering/08-fine-tuning-lora/outputs/skill-fine-tuning-guide.md",
+              "version": "1.0.0",
+              "description": "Decision tree for when and how to fine-tune LLMs with LoRA and QLoRA",
+              "tags": [
+                "fine-tuning",
+                "lora",
+                "qlora",
+                "peft",
+                "llm-engineering"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 9,
+          "slug": "09-function-calling",
+          "title": "Function Calling & Tool Use",
+          "path": "phases/11-llm-engineering/09-function-calling",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "function_calling.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-tool-designer",
+              "path": "phases/11-llm-engineering/09-function-calling/outputs/prompt-tool-designer.md",
+              "version": "",
+              "description": "Design complete tool definitions (JSON Schema) for function calling from a natural language description",
+              "tags": []
+            },
+            {
+              "type": "skill",
+              "name": "skill-function-calling-patterns",
+              "path": "phases/11-llm-engineering/09-function-calling/outputs/skill-function-calling-patterns.md",
+              "version": "1.0.0",
+              "description": "Decision framework for implementing function calling in production -- tool design, error handling, security, and provider patterns",
+              "tags": [
+                "function-calling",
+                "tool-use",
+                "agents",
+                "mcp",
+                "security",
+                "openai",
+                "anthropic"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 10,
+          "slug": "10-evaluation",
+          "title": "Evaluation & Testing LLM Applications",
+          "path": "phases/11-llm-engineering/10-evaluation",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "eval_framework.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-eval-designer",
+              "path": "phases/11-llm-engineering/10-evaluation/outputs/prompt-eval-designer.md",
+              "version": "",
+              "description": "Design tailored evaluation rubrics and test suites for LLM applications from a description of the use case",
+              "tags": []
+            },
+            {
+              "type": "skill",
+              "name": "skill-eval-patterns",
+              "path": "phases/11-llm-engineering/10-evaluation/outputs/skill-eval-patterns.md",
+              "version": "1.0.0",
+              "description": "Decision framework for choosing evaluation strategies -- when to use which method, how to size test suites, and how to integrate evals into CI/CD",
+              "tags": [
+                "evaluation",
+                "testing",
+                "llm-as-judge",
+                "regression",
+                "confidence-intervals",
+                "ci-cd"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 11,
+          "slug": "11-caching-cost",
+          "title": "Caching, Rate Limiting & Cost Optimization",
+          "path": "phases/11-llm-engineering/11-caching-cost",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "caching_cost.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-cost-optimizer",
+              "path": "phases/11-llm-engineering/11-caching-cost/outputs/prompt-cost-optimizer.md",
+              "version": "",
+              "description": "Analyze an LLM application and recommend specific cost optimizations with projected savings",
+              "tags": []
+            },
+            {
+              "type": "skill",
+              "name": "skill-cost-patterns",
+              "path": "phases/11-llm-engineering/11-caching-cost/outputs/skill-cost-patterns.md",
+              "version": "1.0.0",
+              "description": "Decision framework for LLM cost optimization -- caching strategies, rate limiting, model routing, and budget controls",
+              "tags": [
+                "caching",
+                "cost-optimization",
+                "rate-limiting",
+                "model-routing",
+                "budget",
+                "llm-ops"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 12,
+          "slug": "12-guardrails",
+          "title": "Guardrails, Safety & Content Filtering",
+          "path": "phases/11-llm-engineering/12-guardrails",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "guardrails.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-safety-auditor",
+              "path": "phases/11-llm-engineering/12-guardrails/outputs/prompt-safety-auditor.md",
+              "version": "",
+              "description": "Audit any LLM application for safety vulnerabilities -- prompt injection, data leakage, jailbreaks, and output risks",
+              "tags": []
+            },
+            {
+              "type": "skill",
+              "name": "skill-guardrail-patterns",
+              "path": "phases/11-llm-engineering/12-guardrails/outputs/skill-guardrail-patterns.md",
+              "version": "1.0.0",
+              "description": "Decision framework for choosing and implementing guardrails in production -- tool selection, layering strategy, and cost-performance tradeoffs",
+              "tags": [
+                "guardrails",
+                "safety",
+                "content-filtering",
+                "prompt-injection",
+                "pii",
+                "moderation",
+                "llamaguard",
+                "nemo"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 13,
+          "slug": "13-production-app",
+          "title": "Building a Production LLM Application",
+          "path": "phases/11-llm-engineering/13-production-app",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "production_app.py"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-architecture-reviewer",
+              "path": "phases/11-llm-engineering/13-production-app/outputs/prompt-architecture-reviewer.md",
+              "version": "",
+              "description": "Review the architecture of any LLM application against a production readiness checklist -- identifies gaps, risks, and missing components",
+              "tags": []
+            },
+            {
+              "type": "skill",
+              "name": "skill-production-checklist",
+              "path": "phases/11-llm-engineering/13-production-app/outputs/skill-production-checklist.md",
+              "version": "1.0.0",
+              "description": "Decision framework for shipping LLM applications to production -- covers every component with specific thresholds and pass/fail criteria",
+              "tags": [
+                "production",
+                "deployment",
+                "llm",
+                "architecture",
+                "scaling",
+                "cost",
+                "observability",
+                "guardrails"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 14,
+          "slug": "14-model-context-protocol",
+          "title": "Model Context Protocol (MCP)",
+          "path": "phases/11-llm-engineering/14-model-context-protocol",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "mcp-server-designer",
+              "path": "phases/11-llm-engineering/14-model-context-protocol/outputs/skill-mcp-server-designer.md",
+              "version": "1.0.0",
+              "description": "Design and scaffold an MCP server with tools, resources, and safety defaults.",
+              "tags": [
+                "llm-engineering",
+                "mcp",
+                "tool-use"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 15,
+          "slug": "15-prompt-caching",
+          "title": "Prompt Caching and Context Caching",
+          "path": "phases/11-llm-engineering/15-prompt-caching",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "prompt-caching-planner",
+              "path": "phases/11-llm-engineering/15-prompt-caching/outputs/skill-prompt-caching-planner.md",
+              "version": "1.0.0",
+              "description": "Design a cache-friendly prompt layout and pick the right provider caching mode.",
+              "tags": [
+                "llm-engineering",
+                "caching",
+                "cost"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 16,
+          "slug": "16-langgraph-state-machines",
+          "title": "LangGraph — State Machines for Agents",
+          "path": "phases/11-llm-engineering/16-langgraph-state-machines",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": []
+        },
+        {
+          "num": 17,
+          "slug": "17-agent-framework-tradeoffs",
+          "title": "Agent Framework Tradeoffs — LangGraph vs CrewAI vs AutoGen vs Agno",
+          "path": "phases/11-llm-engineering/17-agent-framework-tradeoffs",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": []
+        }
+      ]
+    },
+    {
+      "num": 12,
+      "slug": "12-multimodal-ai",
+      "title": "Multimodal AI",
+      "lesson_count": 25,
+      "lessons": [
+        {
+          "num": 1,
+          "slug": "01-vision-transformer-patch-tokens",
+          "title": "Vision Transformers and the Patch-Token Primitive",
+          "path": "phases/12-multimodal-ai/01-vision-transformer-patch-tokens",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "patch-geometry-reader",
+              "path": "phases/12-multimodal-ai/01-vision-transformer-patch-tokens/outputs/skill-patch-geometry-reader.md",
+              "version": "1.0.0",
+              "description": "Read a ViT config and produce a patch-token, parameter, and VRAM analysis for downstream VLM planning.",
+              "tags": [
+                "vit",
+                "patch-tokens",
+                "dinov2",
+                "siglip",
+                "vlm-backbone"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 2,
+          "slug": "02-clip-contrastive-pretraining",
+          "title": "CLIP and Contrastive Vision-Language Pretraining",
+          "path": "phases/12-multimodal-ai/02-clip-contrastive-pretraining",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "clip-zero-shot",
+              "path": "phases/12-multimodal-ai/02-clip-contrastive-pretraining/outputs/skill-clip-zero-shot.md",
+              "version": "1.0.0",
+              "description": "Run zero-shot image classification with a CLIP / SigLIP checkpoint, producing ranked predictions with similarity scores.",
+              "tags": [
+                "clip",
+                "siglip",
+                "zero-shot",
+                "vision-language"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 3,
+          "slug": "03-blip2-qformer-bridge",
+          "title": "From CLIP to BLIP-2 — Q-Former as Modality Bridge",
+          "path": "phases/12-multimodal-ai/03-blip2-qformer-bridge",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "modality-bridge-picker",
+              "path": "phases/12-multimodal-ai/03-blip2-qformer-bridge/outputs/skill-modality-bridge-picker.md",
+              "version": "1.0.0",
+              "description": "Recommend Q-Former vs MLP projector vs Perceiver resampler for a VLM configuration given token budget, quality target, and training compute.",
+              "tags": [
+                "blip2",
+                "qformer",
+                "vlm",
+                "modality-bridge",
+                "architecture"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 4,
+          "slug": "04-flamingo-gated-cross-attention",
+          "title": "Flamingo and Gated Cross-Attention for Few-Shot VLMs",
+          "path": "phases/12-multimodal-ai/04-flamingo-gated-cross-attention",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "gated-bridge-diagnostic",
+              "path": "phases/12-multimodal-ai/04-flamingo-gated-cross-attention/outputs/skill-gated-bridge-diagnostic.md",
+              "version": "1.0.0",
+              "description": "Identify Flamingo-lineage design elements in an open VLM config and diagnose freezing / gating issues.",
+              "tags": [
+                "flamingo",
+                "idefics",
+                "openflamingo",
+                "gated-cross-attention",
+                "interleaved-inputs"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 5,
+          "slug": "05-llava-visual-instruction-tuning",
+          "title": "LLaVA and Visual Instruction Tuning",
+          "path": "phases/12-multimodal-ai/05-llava-visual-instruction-tuning",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "llava-vibes-eval",
+              "path": "phases/12-multimodal-ai/05-llava-visual-instruction-tuning/outputs/skill-llava-vibes-eval.md",
+              "version": "1.0.0",
+              "description": "Run a 10-prompt vibes-eval on a LLaVA-family VLM and produce a human-readable scorecard.",
+              "tags": [
+                "llava",
+                "vlm",
+                "vibes-eval",
+                "instruction-tuning"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 6,
+          "slug": "06-any-resolution-patch-n-pack",
+          "title": "Any-Resolution Vision: Patch-n'-Pack and NaFlex",
+          "path": "phases/12-multimodal-ai/06-any-resolution-patch-n-pack",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "resolution-budget-planner",
+              "path": "phases/12-multimodal-ai/06-any-resolution-patch-n-pack/outputs/skill-resolution-budget-planner.md",
+              "version": "1.0.0",
+              "description": "Pick between square-resize, AnyRes, M-RoPE, and NaFlex for a mixed-aspect-ratio VLM workload and emit a per-task token budget plan.",
+              "tags": [
+                "vlm",
+                "patch-n-pack",
+                "naflex",
+                "anyres",
+                "m-rope",
+                "token-budget"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 7,
+          "slug": "07-open-weight-vlm-recipes",
+          "title": "Open-Weight VLM Recipes: What Actually Matters",
+          "path": "phases/12-multimodal-ai/07-open-weight-vlm-recipes",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "vlm-recipe-picker",
+              "path": "phases/12-multimodal-ai/07-open-weight-vlm-recipes/outputs/skill-vlm-recipe-picker.md",
+              "version": "1.0.0",
+              "description": "Pick an open-weight VLM recipe (encoder, connector, LLM, data mix, resolution schedule) with ablation-table citations for every choice.",
+              "tags": [
+                "vlm",
+                "mm1",
+                "idefics2",
+                "molmo",
+                "cambrian",
+                "prismatic",
+                "ablation"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 8,
+          "slug": "08-llava-onevision-single-multi-video",
+          "title": "LLaVA-OneVision: Single-Image, Multi-Image, Video in One Model",
+          "path": "phases/12-multimodal-ai/08-llava-onevision-single-multi-video",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "onevision-budget-planner",
+              "path": "phases/12-multimodal-ai/08-llava-onevision-single-multi-video/outputs/skill-onevision-budget-planner.md",
+              "version": "1.0.0",
+              "description": "Allocate LLaVA-OneVision-style unified visual-token budgets across single-image, multi-image, and video scenarios for a target product mix.",
+              "tags": [
+                "llava-onevision",
+                "token-budget",
+                "curriculum",
+                "multi-image",
+                "video"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 9,
+          "slug": "09-qwen-vl-family-dynamic-fps",
+          "title": "Qwen-VL Family and Dynamic-FPS Video",
+          "path": "phases/12-multimodal-ai/09-qwen-vl-family-dynamic-fps",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "qwen-vl-pipeline-designer",
+              "path": "phases/12-multimodal-ai/09-qwen-vl-family-dynamic-fps/outputs/skill-qwen-vl-pipeline-designer.md",
+              "version": "1.0.0",
+              "description": "Configure a Qwen2.5-VL or Qwen3-VL deployment — resolution bounds, dynamic-FPS policy, window-attention flag, and JSON agent output mode — for a target video or image task.",
+              "tags": [
+                "qwen-vl",
+                "m-rope",
+                "dynamic-fps",
+                "json-agent",
+                "video-understanding"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 10,
+          "slug": "10-internvl3-native-multimodal",
+          "title": "InternVL3: Native Multimodal Pretraining",
+          "path": "phases/12-multimodal-ai/10-internvl3-native-multimodal",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "native-vs-posthoc-auditor",
+              "path": "phases/12-multimodal-ai/10-internvl3-native-multimodal/outputs/skill-native-vs-posthoc-auditor.md",
+              "version": "1.0.0",
+              "description": "Audit a proposed VLM training plan and recommend native multimodal pretraining or post-hoc adapter-on-LLM, with corpus-mix and alignment-debt analysis.",
+              "tags": [
+                "internvl3",
+                "native-pretraining",
+                "post-hoc",
+                "corpus-mix",
+                "alignment-debt"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 11,
+          "slug": "11-chameleon-early-fusion-tokens",
+          "title": "Chameleon and Early-Fusion Token-Only Multimodal Models",
+          "path": "phases/12-multimodal-ai/11-chameleon-early-fusion-tokens",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "tokenizer-vs-adapter-picker",
+              "path": "phases/12-multimodal-ai/11-chameleon-early-fusion-tokens/outputs/skill-tokenizer-vs-adapter-picker.md",
+              "version": "1.0.0",
+              "description": "Pick between Chameleon-style early fusion (shared-vocab tokenizer) and LLaVA-style late fusion (adapter on frozen LLM) for a VLM project.",
+              "tags": [
+                "chameleon",
+                "early-fusion",
+                "vq-vae",
+                "late-fusion",
+                "adapter"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 12,
+          "slug": "12-emu3-next-token-for-generation",
+          "title": "Emu3: Next-Token Prediction for Image and Video Generation",
+          "path": "phases/12-multimodal-ai/12-emu3-next-token-for-generation",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "token-gen-cost-analyzer",
+              "path": "phases/12-multimodal-ai/12-emu3-next-token-for-generation/outputs/skill-token-gen-cost-analyzer.md",
+              "version": "1.0.0",
+              "description": "Compute token counts, inference latency, and quality ceiling for Emu3-style next-token generation and pick between Emu3-family and diffusion.",
+              "tags": [
+                "emu3",
+                "next-token-prediction",
+                "video-gen",
+                "diffusion",
+                "cfg"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 13,
+          "slug": "13-transfusion-autoregressive-diffusion",
+          "title": "Transfusion: Autoregressive Text + Diffusion Image in One Transformer",
+          "path": "phases/12-multimodal-ai/13-transfusion-autoregressive-diffusion",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "two-loss-trainer-designer",
+              "path": "phases/12-multimodal-ai/13-transfusion-autoregressive-diffusion/outputs/skill-two-loss-trainer-designer.md",
+              "version": "1.0.0",
+              "description": "Design a Transfusion / MMDiT-style two-loss training setup (NTP on one modality, diffusion on another) with loss weights, mask design, and schedule.",
+              "tags": [
+                "transfusion",
+                "mmdit",
+                "two-loss",
+                "flow-matching",
+                "hybrid-attention"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 14,
+          "slug": "14-show-o-discrete-diffusion-unified",
+          "title": "Show-o and Discrete-Diffusion Unified Models",
+          "path": "phases/12-multimodal-ai/14-show-o-discrete-diffusion-unified",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "unified-gen-model-picker",
+              "path": "phases/12-multimodal-ai/14-show-o-discrete-diffusion-unified/outputs/skill-unified-gen-model-picker.md",
+              "version": "1.0.0",
+              "description": "Pick between Show-o / Transfusion / Emu3 / Janus-Pro families for a product that needs both multimodal understanding and generation with open weights.",
+              "tags": [
+                "show-o",
+                "masked-diffusion",
+                "unified",
+                "t2i",
+                "inpainting"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 15,
+          "slug": "15-janus-pro-decoupled-encoders",
+          "title": "Janus-Pro: Decoupled Encoders for Unified Multimodal Models",
+          "path": "phases/12-multimodal-ai/15-janus-pro-decoupled-encoders",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "decoupled-encoder-picker",
+              "path": "phases/12-multimodal-ai/15-janus-pro-decoupled-encoders/outputs/skill-decoupled-encoder-picker.md",
+              "version": "1.0.0",
+              "description": "Decide whether a unified VLM should decouple its visual encoders and pick between Janus-Pro, JanusFlow, and InternVL-U.",
+              "tags": [
+                "janus-pro",
+                "janusflow",
+                "internvl-u",
+                "decoupled-encoders",
+                "unified-model"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 16,
+          "slug": "16-mio-any-to-any-streaming",
+          "title": "MIO and Any-to-Any Streaming Multimodal Models",
+          "path": "phases/12-multimodal-ai/16-mio-any-to-any-streaming",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "any-to-any-pipeline-auditor",
+              "path": "phases/12-multimodal-ai/16-mio-any-to-any-streaming/outputs/skill-any-to-any-pipeline-auditor.md",
+              "version": "1.0.0",
+              "description": "Audit a conversational any-to-any design and compute the latency budget for a MIO / AnyGPT / Moshi-family stack.",
+              "tags": [
+                "mio",
+                "anygpt",
+                "moshi",
+                "any-to-any",
+                "streaming",
+                "ttfab"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 17,
+          "slug": "17-video-language-temporal-grounding",
+          "title": "Video-Language Models: Temporal Tokens and Grounding",
+          "path": "phases/12-multimodal-ai/17-video-language-temporal-grounding",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "video-vlm-frame-planner",
+              "path": "phases/12-multimodal-ai/17-video-language-temporal-grounding/outputs/skill-video-vlm-frame-planner.md",
+              "version": "1.0.0",
+              "description": "Plan frame sampling, per-frame pooling, output format, and benchmark targets for a video-language model deployment.",
+              "tags": [
+                "video-vlm",
+                "temporal-grounding",
+                "tmrope",
+                "dynamic-fps",
+                "benchmarks"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 18,
+          "slug": "18-long-video-million-token",
+          "title": "Long-Video Understanding at Million-Token Context",
+          "path": "phases/12-multimodal-ai/18-long-video-million-token",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "long-video-strategy-planner",
+              "path": "phases/12-multimodal-ai/18-long-video-million-token/outputs/skill-long-video-strategy-planner.md",
+              "version": "1.0.0",
+              "description": "Pick brute-context, ring-attention, token-compression, or agentic-retrieval for a long-video understanding task and compute latency + recall expectations.",
+              "tags": [
+                "long-video",
+                "gemini",
+                "ring-attention",
+                "videoagent",
+                "retrieval"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 19,
+          "slug": "19-audio-language-whisper-to-af3",
+          "title": "Audio-Language Models: the Whisper to Audio Flamingo 3 Arc",
+          "path": "phases/12-multimodal-ai/19-audio-language-whisper-to-af3",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "audio-llm-pipeline-picker",
+              "path": "phases/12-multimodal-ai/19-audio-language-whisper-to-af3/outputs/skill-audio-llm-pipeline-picker.md",
+              "version": "1.0.0",
+              "description": "Pick cascaded (Whisper + LLM) or end-to-end (AF3 / Qwen-Audio) for an audio task, plus the encoder and bridge config.",
+              "tags": [
+                "whisper",
+                "audio-flamingo-3",
+                "qwen-audio",
+                "cascaded",
+                "end-to-end"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 20,
+          "slug": "20-omni-models-thinker-talker",
+          "title": "Omni Models: Qwen2.5-Omni and the Thinker-Talker Split",
+          "path": "phases/12-multimodal-ai/20-omni-models-thinker-talker",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "omni-streaming-budget",
+              "path": "phases/12-multimodal-ai/20-omni-models-thinker-talker/outputs/skill-omni-streaming-budget.md",
+              "version": "1.0.0",
+              "description": "Size a Thinker-Talker streaming voice pipeline (Qwen-Omni / Moshi / Mini-Omni) for a target TTFAB and feature set.",
+              "tags": [
+                "qwen-omni",
+                "moshi",
+                "mini-omni",
+                "streaming",
+                "ttfab",
+                "thinker-talker"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 21,
+          "slug": "21-embodied-vlas-openvla-pi0-groot",
+          "title": "Embodied VLAs: RT-2, OpenVLA, π0, GR00T",
+          "path": "phases/12-multimodal-ai/21-embodied-vlas-openvla-pi0-groot",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "vla-action-format-picker",
+              "path": "phases/12-multimodal-ai/21-embodied-vlas-openvla-pi0-groot/outputs/skill-vla-action-format-picker.md",
+              "version": "1.0.0",
+              "description": "Pick an action format (discrete bin, FAST, flow-matching, dual-system) and VLA family (RT-2, OpenVLA, π0, GR00T) for a robot task.",
+              "tags": [
+                "vla",
+                "rt-2",
+                "openvla",
+                "pi0",
+                "groot",
+                "action-tokenization"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 22,
+          "slug": "22-document-diagram-understanding",
+          "title": "Document and Diagram Understanding",
+          "path": "phases/12-multimodal-ai/22-document-diagram-understanding",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "document-ai-stack-picker",
+              "path": "phases/12-multimodal-ai/22-document-diagram-understanding/outputs/skill-document-ai-stack-picker.md",
+              "version": "1.0.0",
+              "description": "Pick between OCR pipeline, OCR-free specialist, and VLM-native for a document-AI project based on domain, scale, and regulatory needs.",
+              "tags": [
+                "document-ai",
+                "ocr",
+                "donut",
+                "nougat",
+                "paligemma",
+                "vlm-native"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 23,
+          "slug": "23-colpali-vision-native-rag",
+          "title": "ColPali and Vision-Native Document RAG",
+          "path": "phases/12-multimodal-ai/23-colpali-vision-native-rag",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "vision-rag-designer",
+              "path": "phases/12-multimodal-ai/23-colpali-vision-native-rag/outputs/skill-vision-rag-designer.md",
+              "version": "1.0.0",
+              "description": "Design a vision-native document RAG using ColPali / ColQwen2 / VisRAG, with storage estimate and generator-pick.",
+              "tags": [
+                "colpali",
+                "colqwen2",
+                "visrag",
+                "late-interaction",
+                "vidore"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 24,
+          "slug": "24-multimodal-rag-cross-modal",
+          "title": "Multimodal RAG and Cross-Modal Retrieval",
+          "path": "phases/12-multimodal-ai/24-multimodal-rag-cross-modal",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "multimodal-rag-designer",
+              "path": "phases/12-multimodal-ai/24-multimodal-rag-cross-modal/outputs/skill-multimodal-rag-designer.md",
+              "version": "1.0.0",
+              "description": "Design a production multimodal RAG across text, images, audio, video with retrievers, fusion strategy, and grounded generator.",
+              "tags": [
+                "multimodal-rag",
+                "cross-modal-retrieval",
+                "fusion",
+                "grounded-generation"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 25,
+          "slug": "25-multimodal-agents-computer-use",
+          "title": "Multimodal Agents and Computer-Use (Capstone)",
+          "path": "phases/12-multimodal-ai/25-multimodal-agents-computer-use",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "multimodal-agent-designer",
+              "path": "phases/12-multimodal-ai/25-multimodal-agents-computer-use/outputs/skill-multimodal-agent-designer.md",
+              "version": "1.0.0",
+              "description": "Design a multimodal agent (computer-use, GUI grounding, web or mobile) with action schema, memory strategy, and benchmark evaluation plan.",
+              "tags": [
+                "multimodal-agents",
+                "computer-use",
+                "gui-grounding",
+                "visualwebarena",
+                "agentvista"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "num": 13,
+      "slug": "13-tools-and-protocols",
+      "title": "Tools And Protocols",
+      "lesson_count": 23,
+      "lessons": [
+        {
+          "num": 1,
+          "slug": "01-the-tool-interface",
+          "title": "The Tool Interface — Why Agents Need Structured I/O",
+          "path": "phases/13-tools-and-protocols/01-the-tool-interface",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "tool-interface-reviewer",
+              "path": "phases/13-tools-and-protocols/01-the-tool-interface/outputs/skill-tool-interface-reviewer.md",
+              "version": "1.0.0",
+              "description": "Audit a tool definition (name + description + JSON Schema + executor outline) for loop fitness before it ships to an LLM.",
+              "tags": [
+                "tool-calling",
+                "function-calling",
+                "json-schema",
+                "tool-design"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 2,
+          "slug": "02-function-calling-deep-dive",
+          "title": "Function Calling Deep Dive — OpenAI, Anthropic, Gemini",
+          "path": "phases/13-tools-and-protocols/02-function-calling-deep-dive",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "provider-portability-audit",
+              "path": "phases/13-tools-and-protocols/02-function-calling-deep-dive/outputs/skill-provider-portability-audit.md",
+              "version": "1.0.0",
+              "description": "Audit a function-calling integration against one provider for what breaks when ported to the other two.",
+              "tags": [
+                "function-calling",
+                "openai",
+                "anthropic",
+                "gemini",
+                "portability"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 3,
+          "slug": "03-parallel-and-streaming-tool-calls",
+          "title": "Parallel Tool Calls and Streaming with Tools",
+          "path": "phases/13-tools-and-protocols/03-parallel-and-streaming-tool-calls",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "parallel-call-safety-check",
+              "path": "phases/13-tools-and-protocols/03-parallel-and-streaming-tool-calls/outputs/skill-parallel-call-safety-check.md",
+              "version": "1.0.0",
+              "description": "Audit a tool registry for safe parallelization. Mark each tool parallel_safe, note ordering dependencies, and flag downstream rate-limit risk.",
+              "tags": [
+                "parallel-tool-calls",
+                "streaming",
+                "correlation",
+                "rate-limits"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 4,
+          "slug": "04-structured-output",
+          "title": "Structured Output — JSON Schema, Pydantic, Zod, Constrained Decoding",
+          "path": "phases/13-tools-and-protocols/04-structured-output",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "structured-output-designer",
+              "path": "phases/13-tools-and-protocols/04-structured-output/outputs/skill-structured-output-designer.md",
+              "version": "1.0.0",
+              "description": "Design a strict-mode-compatible JSON Schema plus Pydantic model for a free-text extraction target, with typed refusal and retry handling stubbed in.",
+              "tags": [
+                "structured-output",
+                "json-schema",
+                "pydantic",
+                "strict-mode",
+                "extraction"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 5,
+          "slug": "05-tool-schema-design",
+          "title": "Tool Schema Design — Naming, Descriptions, Parameter Constraints",
+          "path": "phases/13-tools-and-protocols/05-tool-schema-design",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "tool-schema-linter",
+              "path": "phases/13-tools-and-protocols/05-tool-schema-design/outputs/skill-tool-schema-linter.md",
+              "version": "1.0.0",
+              "description": "Audit a tool registry against production design rules for names, descriptions, parameters, and shape. Can run in CI on every tool-registry change.",
+              "tags": [
+                "tool-design",
+                "linter",
+                "selection-accuracy",
+                "naming"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 6,
+          "slug": "06-mcp-fundamentals",
+          "title": "MCP Fundamentals — Primitives, Lifecycle, JSON-RPC Base",
+          "path": "phases/13-tools-and-protocols/06-mcp-fundamentals",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "mcp-handshake-tracer",
+              "path": "phases/13-tools-and-protocols/06-mcp-fundamentals/outputs/skill-mcp-handshake-tracer.md",
+              "version": "1.0.0",
+              "description": "Given a pcap-style transcript of an MCP client-server conversation, annotate every message with its primitive, lifecycle phase, and capability dependency.",
+              "tags": [
+                "mcp",
+                "json-rpc",
+                "lifecycle",
+                "capabilities"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 7,
+          "slug": "07-building-an-mcp-server",
+          "title": "Building an MCP Server — Python + TypeScript SDKs",
+          "path": "phases/13-tools-and-protocols/07-building-an-mcp-server",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "mcp-server-scaffolder",
+              "path": "phases/13-tools-and-protocols/07-building-an-mcp-server/outputs/skill-mcp-server-scaffolder.md",
+              "version": "1.0.0",
+              "description": "Scaffold a domain-specific MCP server with the right tools/resources/prompts split and SDK graduation path.",
+              "tags": [
+                "mcp",
+                "server",
+                "fastmcp",
+                "scaffold"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 8,
+          "slug": "08-building-an-mcp-client",
+          "title": "Building an MCP Client — Discovery, Invocation, Session Management",
+          "path": "phases/13-tools-and-protocols/08-building-an-mcp-client",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "mcp-client-harness",
+              "path": "phases/13-tools-and-protocols/08-building-an-mcp-client/outputs/skill-mcp-client-harness.md",
+              "version": "1.0.0",
+              "description": "Given a declarative list of MCP servers (name, command, args), scaffold a multi-server client with handshake, namespace merge, and routing.",
+              "tags": [
+                "mcp",
+                "client",
+                "multi-server",
+                "routing",
+                "namespace"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 9,
+          "slug": "09-mcp-transports",
+          "title": "MCP Transports — stdio vs Streamable HTTP vs SSE Migration",
+          "path": "phases/13-tools-and-protocols/09-mcp-transports",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "mcp-transport-migrator",
+              "path": "phases/13-tools-and-protocols/09-mcp-transports/outputs/skill-mcp-transport-migrator.md",
+              "version": "1.0.0",
+              "description": "Produce a migration plan from legacy HTTP+SSE to Streamable HTTP with session id continuity and Origin validation.",
+              "tags": [
+                "mcp",
+                "streamable-http",
+                "sse-migration",
+                "session-id",
+                "origin"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 10,
+          "slug": "10-mcp-resources-and-prompts",
+          "title": "MCP Resources and Prompts — Context Exposure Beyond Tools",
+          "path": "phases/13-tools-and-protocols/10-mcp-resources-and-prompts",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "primitive-splitter",
+              "path": "phases/13-tools-and-protocols/10-mcp-resources-and-prompts/outputs/skill-primitive-splitter.md",
+              "version": "1.0.0",
+              "description": "Categorize each capability in an MCP server draft as tool, resource, or prompt with rationale.",
+              "tags": [
+                "mcp",
+                "primitives",
+                "resources",
+                "prompts"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 11,
+          "slug": "11-mcp-sampling",
+          "title": "MCP Sampling — Server-Requested LLM Completions and Agent Loops",
+          "path": "phases/13-tools-and-protocols/11-mcp-sampling",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "sampling-loop-designer",
+              "path": "phases/13-tools-and-protocols/11-mcp-sampling/outputs/skill-sampling-loop-designer.md",
+              "version": "1.0.0",
+              "description": "Design a server-hosted agent loop using MCP sampling with the right modelPreferences, rate limits, and safety confirmations.",
+              "tags": [
+                "mcp",
+                "sampling",
+                "agent-loop",
+                "model-preferences"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 12,
+          "slug": "12-mcp-roots-and-elicitation",
+          "title": "Roots and Elicitation — Scoping and Mid-Flight User Input",
+          "path": "phases/13-tools-and-protocols/12-mcp-roots-and-elicitation",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "elicitation-form-designer",
+              "path": "phases/13-tools-and-protocols/12-mcp-roots-and-elicitation/outputs/skill-elicitation-form-designer.md",
+              "version": "1.0.0",
+              "description": "Design the elicitation form schema and message template for a tool that needs mid-call user confirmation or disambiguation.",
+              "tags": [
+                "mcp",
+                "elicitation",
+                "user-input",
+                "forms"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 13,
+          "slug": "13-mcp-async-tasks",
+          "title": "Async Tasks (SEP-1686) — Call-Now, Fetch-Later for Long-Running Work",
+          "path": "phases/13-tools-and-protocols/13-mcp-async-tasks",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "task-store-designer",
+              "path": "phases/13-tools-and-protocols/13-mcp-async-tasks/outputs/skill-task-store-designer.md",
+              "version": "1.0.0",
+              "description": "Design the task store for a long-running MCP tool: state shape, ttl, durability, cancellation, crash recovery.",
+              "tags": [
+                "mcp",
+                "tasks",
+                "durable-store",
+                "long-running",
+                "sep-1686"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 14,
+          "slug": "14-mcp-apps",
+          "title": "MCP Apps — Interactive UI Resources via `ui://`",
+          "path": "phases/13-tools-and-protocols/14-mcp-apps",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "mcp-apps-spec",
+              "path": "phases/13-tools-and-protocols/14-mcp-apps/outputs/skill-mcp-apps-spec.md",
+              "version": "1.0.0",
+              "description": "Produce the full MCP Apps contract for a tool that needs an interactive UI resource.",
+              "tags": [
+                "mcp",
+                "apps",
+                "ui-resources",
+                "csp",
+                "iframe-sandbox"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 15,
+          "slug": "15-mcp-security-tool-poisoning",
+          "title": "MCP Security I — Tool Poisoning, Rug Pulls, Cross-Server Shadowing",
+          "path": "phases/13-tools-and-protocols/15-mcp-security-tool-poisoning",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "mcp-threat-model",
+              "path": "phases/13-tools-and-protocols/15-mcp-security-tool-poisoning/outputs/skill-mcp-threat-model.md",
+              "version": "1.0.0",
+              "description": "Produce a threat model for an MCP deployment naming the applicable attack classes, defenses in place, and Rule-of-Two violations.",
+              "tags": [
+                "mcp",
+                "security",
+                "tool-poisoning",
+                "threat-model",
+                "rule-of-two"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 16,
+          "slug": "16-mcp-security-oauth-2-1",
+          "title": "MCP Security II — OAuth 2.1, Resource Indicators, Incremental Scopes",
+          "path": "phases/13-tools-and-protocols/16-mcp-security-oauth-2-1",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "oauth-scope-planner",
+              "path": "phases/13-tools-and-protocols/16-mcp-security-oauth-2-1/outputs/skill-oauth-scope-planner.md",
+              "version": "1.0.0",
+              "description": "Design the OAuth 2.1 scope set, pinning rules, and step-up policy for a remote MCP server.",
+              "tags": [
+                "oauth",
+                "pkce",
+                "resource-indicators",
+                "step-up",
+                "sep-835"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 17,
+          "slug": "17-mcp-gateways-and-registries",
+          "title": "MCP Gateways and Registries — Enterprise Control Planes",
+          "path": "phases/13-tools-and-protocols/17-mcp-gateways-and-registries",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "gateway-bootstrap",
+              "path": "phases/13-tools-and-protocols/17-mcp-gateways-and-registries/outputs/skill-gateway-bootstrap.md",
+              "version": "1.0.0",
+              "description": "Produce a gateway configuration spec given users, backends, and compliance constraints.",
+              "tags": [
+                "mcp",
+                "gateway",
+                "rbac",
+                "audit",
+                "policy"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 18,
+          "slug": "18-mcp-auth-production",
+          "title": "MCP Auth in Production — DCR, JWKS Rotation, Audience-Pinned Tokens on iii Primitives",
+          "path": "phases/13-tools-and-protocols/18-mcp-auth-production",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "mcp-auth-iii-wiring",
+              "path": "phases/13-tools-and-protocols/18-mcp-auth-production/outputs/skill-mcp-auth-iii.md",
+              "version": "1.0.0",
+              "description": "Wire production MCP authorization (RFC 8414, 7591, 8707, 7636 PKCE, 9728) onto iii primitives — registerTrigger for HTTP/cron, registerFunction for validation, state::* for JWKS cache.",
+              "tags": [
+                "mcp",
+                "oauth",
+                "dcr",
+                "jwks",
+                "iii",
+                "rfc8414",
+                "rfc7591",
+                "rfc8707",
+                "rfc7636",
+                "rfc9728"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 19,
+          "slug": "19-a2a-protocol",
+          "title": "A2A — Agent-to-Agent Protocol",
+          "path": "phases/13-tools-and-protocols/19-a2a-protocol",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "a2a-agent-spec",
+              "path": "phases/13-tools-and-protocols/19-a2a-protocol/outputs/skill-a2a-agent-spec.md",
+              "version": "1.0.0",
+              "description": "Produce the Agent Card and skills schema for an agent that should be callable over A2A.",
+              "tags": [
+                "a2a",
+                "agent-card",
+                "task-lifecycle",
+                "delegation"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 20,
+          "slug": "20-opentelemetry-genai",
+          "title": "OpenTelemetry GenAI — Tracing Tool Calls End-to-End",
+          "path": "phases/13-tools-and-protocols/20-opentelemetry-genai",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "otel-genai-instrumentation",
+              "path": "phases/13-tools-and-protocols/20-opentelemetry-genai/outputs/skill-otel-genai-instrumentation.md",
+              "version": "1.0.0",
+              "description": "Produce an instrumentation plan for an agent codebase to emit OTel GenAI spans end-to-end.",
+              "tags": [
+                "otel",
+                "observability",
+                "gen-ai",
+                "tracing"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 21,
+          "slug": "21-llm-routing-layer",
+          "title": "LLM Routing Layer — LiteLLM, OpenRouter, Portkey",
+          "path": "phases/13-tools-and-protocols/21-llm-routing-layer",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "routing-config-designer",
+              "path": "phases/13-tools-and-protocols/21-llm-routing-layer/outputs/skill-routing-config-designer.md",
+              "version": "1.0.0",
+              "description": "Given a workload profile, pick LiteLLM / OpenRouter / Portkey and produce a routing config.",
+              "tags": [
+                "routing",
+                "litellm",
+                "openrouter",
+                "portkey",
+                "fallback"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 22,
+          "slug": "22-skills-and-agent-sdks",
+          "title": "Skills and Agent SDKs — Anthropic Skills, AGENTS.md, OpenAI Apps SDK",
+          "path": "phases/13-tools-and-protocols/22-skills-and-agent-sdks",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "agent-bundle",
+              "path": "phases/13-tools-and-protocols/22-skills-and-agent-sdks/outputs/skill-agent-bundle.md",
+              "version": "1.0.0",
+              "description": "Produce a portable SKILL.md + AGENTS.md + MCP-server blueprint for a workflow, loadable across Claude Code, Cursor, Codex, and compatible agents.",
+              "tags": [
+                "skills",
+                "agents-md",
+                "apps-sdk",
+                "cross-agent",
+                "portability"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 23,
+          "slug": "23-capstone-tool-ecosystem",
+          "title": "Capstone — Build a Complete Tool Ecosystem",
+          "path": "phases/13-tools-and-protocols/23-capstone-tool-ecosystem",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "ecosystem-blueprint",
+              "path": "phases/13-tools-and-protocols/23-capstone-tool-ecosystem/outputs/skill-ecosystem-blueprint.md",
+              "version": "1.0.0",
+              "description": "Produce a full Phase 13 ecosystem architecture given a product need; name primitives, security posture, telemetry, and packaging.",
+              "tags": [
+                "mcp",
+                "capstone",
+                "ecosystem",
+                "architecture",
+                "a2a",
+                "otel"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "num": 14,
+      "slug": "14-agent-engineering",
+      "title": "Agent Engineering",
+      "lesson_count": 42,
+      "lessons": [
+        {
+          "num": 1,
+          "slug": "01-the-agent-loop",
+          "title": "The Agent Loop: Observe, Think, Act",
+          "path": "phases/14-agent-engineering/01-the-agent-loop",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "agent-loop",
+              "path": "phases/14-agent-engineering/01-the-agent-loop/outputs/skill-agent-loop.md",
+              "version": "1.0.0",
+              "description": "Write a correct, minimal ReAct agent loop in any target language/runtime with tools, stop condition, and turn budget.",
+              "tags": [
+                "react",
+                "agent-loop",
+                "tools",
+                "observability",
+                "stop-condition"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 2,
+          "slug": "02-rewoo-plan-and-execute",
+          "title": "ReWOO and Plan-and-Execute: Decoupled Planning",
+          "path": "phases/14-agent-engineering/02-rewoo-plan-and-execute",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "rewoo-planner",
+              "path": "phases/14-agent-engineering/02-rewoo-plan-and-execute/outputs/skill-rewoo-planner.md",
+              "version": "1.0.0",
+              "description": "Generate a validated ReWOO plan DAG from a user request and tool catalog.",
+              "tags": [
+                "rewoo",
+                "plan-and-execute",
+                "planning",
+                "dag",
+                "distillation"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 3,
+          "slug": "03-reflexion-verbal-rl",
+          "title": "Reflexion: Verbal Reinforcement Learning",
+          "path": "phases/14-agent-engineering/03-reflexion-verbal-rl",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "reflexion-buffer",
+              "path": "phases/14-agent-engineering/03-reflexion-verbal-rl/outputs/skill-reflexion-buffer.md",
+              "version": "1.0.0",
+              "description": "Maintain an episodic-memory buffer of reflections for verbal RL with TTL, dedup, and scoped scope.",
+              "tags": [
+                "reflexion",
+                "episodic-memory",
+                "self-healing",
+                "verbal-rl",
+                "sleep-time"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 4,
+          "slug": "04-tree-of-thoughts-lats",
+          "title": "Tree of Thoughts and LATS: Deliberate Search",
+          "path": "phases/14-agent-engineering/04-tree-of-thoughts-lats",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "search-policy",
+              "path": "phases/14-agent-engineering/04-tree-of-thoughts-lats/outputs/skill-search-policy.md",
+              "version": "1.0.0",
+              "description": "Pick a search strategy (ReAct, ToT, LATS, evolutionary) given task shape, token budget, and evaluator quality.",
+              "tags": [
+                "tree-of-thoughts",
+                "lats",
+                "mcts",
+                "search",
+                "value-function"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 5,
+          "slug": "05-self-refine-and-critic",
+          "title": "Self-Refine and CRITIC: Iterative Output Improvement",
+          "path": "phases/14-agent-engineering/05-self-refine-and-critic",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "refine-loop",
+              "path": "phases/14-agent-engineering/05-self-refine-and-critic/outputs/skill-refine-loop.md",
+              "version": "1.0.0",
+              "description": "Configure an evaluator-optimizer (Self-Refine / CRITIC) loop given task, verifier availability, and iteration budget.",
+              "tags": [
+                "self-refine",
+                "critic",
+                "evaluator-optimizer",
+                "guardrails",
+                "iteration"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 6,
+          "slug": "06-tool-use-and-function-calling",
+          "title": "Tool Use and Function Calling",
+          "path": "phases/14-agent-engineering/06-tool-use-and-function-calling",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "tool-registry",
+              "path": "phases/14-agent-engineering/06-tool-use-and-function-calling/outputs/skill-tool-registry.md",
+              "version": "1.0.0",
+              "description": "Build a production tool catalog and registry with JSON Schema validation, parallel dispatch, and observability.",
+              "tags": [
+                "function-calling",
+                "tools",
+                "schema",
+                "validation",
+                "bfcl",
+                "parallel-tools"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 7,
+          "slug": "07-memory-virtual-context-memgpt",
+          "title": "Memory: Virtual Context and MemGPT",
+          "path": "phases/14-agent-engineering/07-memory-virtual-context-memgpt",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "virtual-memory",
+              "path": "phases/14-agent-engineering/07-memory-virtual-context-memgpt/outputs/skill-virtual-memory.md",
+              "version": "1.0.0",
+              "description": "Scaffold a MemGPT-shaped two-tier memory system (main context + archival store + memory tools) for any target runtime with correct eviction, citation, and untrusted-input handling.",
+              "tags": [
+                "memory",
+                "memgpt",
+                "virtual-context",
+                "archival",
+                "citations"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 8,
+          "slug": "08-memory-blocks-sleep-time-compute",
+          "title": "Memory Blocks and Sleep-Time Compute (Letta)",
+          "path": "phases/14-agent-engineering/08-memory-blocks-sleep-time-compute",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "memory-blocks",
+              "path": "phases/14-agent-engineering/08-memory-blocks-sleep-time-compute/outputs/skill-memory-blocks.md",
+              "version": "1.0.0",
+              "description": "Generate a Letta-shaped three-tier memory system (core blocks, recall, archival) with a sleep-time consolidation agent off the critical path.",
+              "tags": [
+                "memory",
+                "letta",
+                "blocks",
+                "sleep-time",
+                "consolidation"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 9,
+          "slug": "09-hybrid-memory-mem0",
+          "title": "Hybrid Memory: Vector + Graph + KV (Mem0)",
+          "path": "phases/14-agent-engineering/09-hybrid-memory-mem0",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "hybrid-memory",
+              "path": "phases/14-agent-engineering/09-hybrid-memory-mem0/outputs/skill-hybrid-memory.md",
+              "version": "1.0.0",
+              "description": "Generate a Mem0-shaped three-store memory system (vector + KV + graph) with a fusion scorer, scope taxonomy, and temporal invalidation.",
+              "tags": [
+                "memory",
+                "mem0",
+                "vector",
+                "graph",
+                "kv",
+                "fusion",
+                "scope"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 10,
+          "slug": "10-skill-libraries-voyager",
+          "title": "Skill Libraries and Lifelong Learning (Voyager)",
+          "path": "phases/14-agent-engineering/10-skill-libraries-voyager",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "skill-library",
+              "path": "phases/14-agent-engineering/10-skill-libraries-voyager/outputs/skill-skill-library.md",
+              "version": "1.0.0",
+              "description": "Generate a Voyager-shaped skill library with registration, retrieval by similarity, compositional execution, and failure-driven refinement.",
+              "tags": [
+                "voyager",
+                "skills",
+                "library",
+                "composition",
+                "refinement"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 11,
+          "slug": "11-planning-htn-and-evolutionary",
+          "title": "Planning with HTN and Evolutionary Search",
+          "path": "phases/14-agent-engineering/11-planning-htn-and-evolutionary",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "hybrid-planner",
+              "path": "phases/14-agent-engineering/11-planning-htn-and-evolutionary/outputs/skill-hybrid-planner.md",
+              "version": "1.0.0",
+              "description": "Build a hybrid planner — ChatHTN for provably-sound plans, AlphaEvolve for code search with a machine-checkable evaluator — and pick the right one for the problem.",
+              "tags": [
+                "planning",
+                "htn",
+                "chathtn",
+                "alphaevolve",
+                "evolutionary-search"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 12,
+          "slug": "12-anthropic-workflow-patterns",
+          "title": "Anthropic's Workflow Patterns: Simple Over Complex",
+          "path": "phases/14-agent-engineering/12-anthropic-workflow-patterns",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "workflow-picker",
+              "path": "phases/14-agent-engineering/12-anthropic-workflow-patterns/outputs/skill-workflow-picker.md",
+              "version": "1.0.0",
+              "description": "Pick the right pattern (prompt chain, router, parallel, orchestrator-workers, evaluator-optimizer, or full agent) for a given task and produce the minimal implementation.",
+              "tags": [
+                "anthropic",
+                "workflows",
+                "agents",
+                "patterns",
+                "minimal"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 13,
+          "slug": "13-langgraph-stateful-graphs",
+          "title": "LangGraph: Stateful Graphs and Durable Execution",
+          "path": "phases/14-agent-engineering/13-langgraph-stateful-graphs",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "state-graph",
+              "path": "phases/14-agent-engineering/13-langgraph-stateful-graphs/outputs/skill-state-graph.md",
+              "version": "1.0.0",
+              "description": "Build a LangGraph-shaped state machine with typed state, conditional edges, per-node checkpointing, and durable resume.",
+              "tags": [
+                "langgraph",
+                "state-machine",
+                "durable",
+                "checkpointing",
+                "human-in-the-loop"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 14,
+          "slug": "14-autogen-actor-model",
+          "title": "AutoGen v0.4: Actor Model and Agent Framework",
+          "path": "phases/14-agent-engineering/14-autogen-actor-model",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "actor-runtime",
+              "path": "phases/14-agent-engineering/14-autogen-actor-model/outputs/skill-actor-runtime.md",
+              "version": "1.0.0",
+              "description": "Build an AutoGen v0.4-shaped actor runtime with private state, inbox-per-actor, message-only IPC, fault isolation, and a dead-letter queue.",
+              "tags": [
+                "autogen",
+                "actor-model",
+                "messaging",
+                "fault-isolation",
+                "dead-letter"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 15,
+          "slug": "15-crewai-role-based-crews",
+          "title": "CrewAI: Role-Based Crews and Flows",
+          "path": "phases/14-agent-engineering/15-crewai-role-based-crews",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "crew-or-flow",
+              "path": "phases/14-agent-engineering/15-crewai-role-based-crews/outputs/skill-crew-or-flow.md",
+              "version": "1.0.0",
+              "description": "Pick CrewAI Crew or Flow for a given task, and scaffold the minimal implementation.",
+              "tags": [
+                "crewai",
+                "crews",
+                "flows",
+                "multi-agent",
+                "role-based"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 16,
+          "slug": "16-openai-agents-sdk",
+          "title": "OpenAI Agents SDK: Handoffs, Guardrails, Tracing",
+          "path": "phases/14-agent-engineering/16-openai-agents-sdk",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "agents-sdk-scaffold",
+              "path": "phases/14-agent-engineering/16-openai-agents-sdk/outputs/skill-agents-sdk-scaffold.md",
+              "version": "1.0.0",
+              "description": "Scaffold an OpenAI Agents SDK app with a triage agent, handoffs, input/output/tool guardrails, session store, and a trace processor.",
+              "tags": [
+                "openai",
+                "agents-sdk",
+                "handoffs",
+                "guardrails",
+                "tracing",
+                "session"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 17,
+          "slug": "17-claude-agent-sdk",
+          "title": "Claude Agent SDK: Subagents and Session Store",
+          "path": "phases/14-agent-engineering/17-claude-agent-sdk",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "claude-agent-scaffold",
+              "path": "phases/14-agent-engineering/17-claude-agent-sdk/outputs/skill-claude-agent-scaffold.md",
+              "version": "1.0.0",
+              "description": "Scaffold a Claude Agent SDK app with subagents, lifecycle hooks, session store, MCP server attachment, and W3C trace propagation.",
+              "tags": [
+                "claude-agent-sdk",
+                "subagents",
+                "hooks",
+                "session-store",
+                "mcp"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 18,
+          "slug": "18-agno-and-mastra-runtimes",
+          "title": "Agno and Mastra: Production Runtimes",
+          "path": "phases/14-agent-engineering/18-agno-and-mastra-runtimes",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "runtime-picker",
+              "path": "phases/14-agent-engineering/18-agno-and-mastra-runtimes/outputs/skill-runtime-picker.md",
+              "version": "1.0.0",
+              "description": "Pick a production agent runtime (Agno, Mastra, LangGraph, provider SDK) for a given stack, latency budget, and operational shape.",
+              "tags": [
+                "agno",
+                "mastra",
+                "langgraph",
+                "runtime",
+                "selection"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 19,
+          "slug": "19-benchmarks-swebench-gaia",
+          "title": "Benchmarks: SWE-bench, GAIA, AgentBench",
+          "path": "phases/14-agent-engineering/19-benchmarks-swebench-gaia",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "benchmark-harness",
+              "path": "phases/14-agent-engineering/19-benchmarks-swebench-gaia/outputs/skill-benchmark-harness.md",
+              "version": "1.0.0",
+              "description": "Build a SWE-bench-style harness for a codebase with FAIL_TO_PASS / PASS_TO_PASS gating, contamination checks, and step-count metrics.",
+              "tags": [
+                "swe-bench",
+                "gaia",
+                "agentbench",
+                "harness",
+                "evaluation"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 20,
+          "slug": "20-benchmarks-webarena-osworld",
+          "title": "Benchmarks: WebArena and OSWorld",
+          "path": "phases/14-agent-engineering/20-benchmarks-webarena-osworld",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "web-desktop-harness",
+              "path": "phases/14-agent-engineering/20-benchmarks-webarena-osworld/outputs/skill-web-desktop-harness.md",
+              "version": "1.0.0",
+              "description": "Build a WebArena/OSWorld-style harness with execution-based evaluation and trajectory-efficiency metrics.",
+              "tags": [
+                "webarena",
+                "osworld",
+                "harness",
+                "trajectory-efficiency"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 21,
+          "slug": "21-computer-use-agents",
+          "title": "Computer Use: Claude, OpenAI CUA, Gemini",
+          "path": "phases/14-agent-engineering/21-computer-use-agents",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "computer-use-safety",
+              "path": "phases/14-agent-engineering/21-computer-use-agents/outputs/skill-computer-use-safety.md",
+              "version": "1.0.0",
+              "description": "Build per-step safety classifier + confirmation gate for a computer-use agent, with allowlist navigation and injection-marker filtering.",
+              "tags": [
+                "computer-use",
+                "safety",
+                "claude",
+                "openai-cua",
+                "gemini"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 22,
+          "slug": "22-voice-agents-pipecat-livekit",
+          "title": "Voice Agents: Pipecat and LiveKit",
+          "path": "phases/14-agent-engineering/22-voice-agents-pipecat-livekit",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "voice-pipeline",
+              "path": "phases/14-agent-engineering/22-voice-agents-pipecat-livekit/outputs/skill-voice-pipeline.md",
+              "version": "1.0.0",
+              "description": "Scaffold a Pipecat-shaped voice pipeline (VAD + STT + LLM + TTS + transport) with barge-in, confidence gating, and latency budget enforcement.",
+              "tags": [
+                "voice",
+                "pipecat",
+                "livekit",
+                "webrtc",
+                "latency"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 23,
+          "slug": "23-otel-genai-conventions",
+          "title": "OpenTelemetry GenAI Semantic Conventions",
+          "path": "phases/14-agent-engineering/23-otel-genai-conventions",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "otel-genai",
+              "path": "phases/14-agent-engineering/23-otel-genai-conventions/outputs/skill-otel-genai.md",
+              "version": "1.0.0",
+              "description": "Instrument an agent with OpenTelemetry GenAI semantic conventions — invoke_agent, chat, tool_call spans with correct attributes and opt-in content capture.",
+              "tags": [
+                "opentelemetry",
+                "genai",
+                "observability",
+                "tracing",
+                "semantic-conventions"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 24,
+          "slug": "24-agent-observability-platforms",
+          "title": "Agent Observability: Langfuse, Phoenix, Opik",
+          "path": "phases/14-agent-engineering/24-agent-observability-platforms",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "obs-platform-wiring",
+              "path": "phases/14-agent-engineering/24-agent-observability-platforms/outputs/skill-obs-platform-wiring.md",
+              "version": "1.0.0",
+              "description": "Pick an observability platform (Langfuse, Phoenix, Opik, Datadog) and wire traces + evals + prompt versions into an existing agent.",
+              "tags": [
+                "observability",
+                "langfuse",
+                "phoenix",
+                "opik",
+                "datadog",
+                "tracing"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 25,
+          "slug": "25-multi-agent-debate",
+          "title": "Multi-Agent Debate and Collaboration",
+          "path": "phases/14-agent-engineering/25-multi-agent-debate",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "debate",
+              "path": "phases/14-agent-engineering/25-multi-agent-debate/outputs/skill-debate.md",
+              "version": "1.0.0",
+              "description": "Scaffold a multi-agent debate with N debaters, R rounds, configurable topology (full mesh, star, ring), and a convergence rule.",
+              "tags": [
+                "debate",
+                "multi-agent",
+                "society-of-minds",
+                "sparse-topology"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 26,
+          "slug": "26-failure-modes-agentic",
+          "title": "Failure Modes: Why Agents Break",
+          "path": "phases/14-agent-engineering/26-failure-modes-agentic",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "failure-detector",
+              "path": "phases/14-agent-engineering/26-failure-modes-agentic/outputs/skill-failure-detector.md",
+              "version": "1.0.0",
+              "description": "Generate failure-mode detectors for agent traces, wired to a trace store, tagging the five industry-recurring modes plus domain-specific signatures.",
+              "tags": [
+                "failure-modes",
+                "masft",
+                "detection",
+                "observability"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 27,
+          "slug": "27-prompt-injection-defense",
+          "title": "Prompt Injection and the PVE Defense",
+          "path": "phases/14-agent-engineering/27-prompt-injection-defense",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "injection-defense",
+              "path": "phases/14-agent-engineering/27-prompt-injection-defense/outputs/skill-injection-defense.md",
+              "version": "1.0.0",
+              "description": "Build a PVE (Prompt-Validator-Executor) layer with source-tagged content, injection-marker scanning, and allowlist navigation for any agent runtime.",
+              "tags": [
+                "security",
+                "prompt-injection",
+                "pve",
+                "greshake",
+                "source-tag"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 28,
+          "slug": "28-orchestration-patterns",
+          "title": "Orchestration Patterns: Supervisor, Swarm, Hierarchical",
+          "path": "phases/14-agent-engineering/28-orchestration-patterns",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "orchestration-picker",
+              "path": "phases/14-agent-engineering/28-orchestration-patterns/outputs/skill-orchestration-picker.md",
+              "version": "1.0.0",
+              "description": "Pick an orchestration topology (supervisor, swarm, hierarchical, debate, or none) for a given problem and implement it minimally.",
+              "tags": [
+                "orchestration",
+                "supervisor",
+                "swarm",
+                "hierarchical",
+                "debate"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 29,
+          "slug": "29-production-runtimes",
+          "title": "Production Runtimes: Queue, Event, Cron",
+          "path": "phases/14-agent-engineering/29-production-runtimes",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "runtime-shape",
+              "path": "phases/14-agent-engineering/29-production-runtimes/outputs/skill-runtime-shape.md",
+              "version": "1.0.0",
+              "description": "Pick a production runtime shape (request-response, streaming, queue, event, cron, durable) and wire observability.",
+              "tags": [
+                "production",
+                "runtime",
+                "queue",
+                "event",
+                "durable",
+                "observability"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 30,
+          "slug": "30-eval-driven-agent-development",
+          "title": "Eval-Driven Agent Development",
+          "path": "phases/14-agent-engineering/30-eval-driven-agent-development",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "eval-suite",
+              "path": "phases/14-agent-engineering/30-eval-driven-agent-development/outputs/skill-eval-suite.md",
+              "version": "1.0.0",
+              "description": "Build a three-layer eval suite (static benchmarks, custom offline, online production) with evaluator-optimizer loop and CI gates.",
+              "tags": [
+                "evaluation",
+                "ci",
+                "regression",
+                "benchmarks",
+                "llm-judge"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 31,
+          "slug": "31-agent-workbench-why-models-fail",
+          "title": "Agent Workbench Engineering: Why Capable Models Still Fail",
+          "path": "phases/14-agent-engineering/31-agent-workbench-why-models-fail",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "workbench-audit",
+              "path": "phases/14-agent-engineering/31-agent-workbench-why-models-fail/outputs/skill-workbench-audit.md",
+              "version": "1.0.0",
+              "description": "Audit a repo for the seven agent workbench surfaces and report which are missing, partial, or healthy before any agent work begins.",
+              "tags": [
+                "workbench",
+                "audit",
+                "reliability",
+                "agent-engineering"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 32,
+          "slug": "32-minimal-agent-workbench",
+          "title": "The Minimal Agent Workbench",
+          "path": "phases/14-agent-engineering/32-minimal-agent-workbench",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "minimal-workbench",
+              "path": "phases/14-agent-engineering/32-minimal-agent-workbench/outputs/skill-minimal-workbench.md",
+              "version": "1.0.0",
+              "description": "Lay down the three-file minimum viable agent workbench for any repo — short AGENTS.md router, durable agent_state.json, and a JSON task_board.json keyed to the project's current backlog.",
+              "tags": [
+                "workbench",
+                "agents-md",
+                "state",
+                "task-board",
+                "scaffold"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 33,
+          "slug": "33-instructions-as-executable-constraints",
+          "title": "Agent Instructions as Executable Constraints",
+          "path": "phases/14-agent-engineering/33-instructions-as-executable-constraints",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "rule-set-builder",
+              "path": "phases/14-agent-engineering/33-instructions-as-executable-constraints/outputs/skill-rule-set-builder.md",
+              "version": "1.0.0",
+              "description": "Interview a project owner, classify their existing prose instructions into five operational categories, and emit a versioned agent-rules.md plus a Python checker stub.",
+              "tags": [
+                "rules",
+                "instructions",
+                "constraints",
+                "checker",
+                "workbench"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 34,
+          "slug": "34-repo-memory-and-state",
+          "title": "Repo Memory and Durable State",
+          "path": "phases/14-agent-engineering/34-repo-memory-and-state",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "state-schema",
+              "path": "phases/14-agent-engineering/34-repo-memory-and-state/outputs/skill-state-schema.md",
+              "version": "1.0.0",
+              "description": "Generate project-specific JSON Schemas for agent state and task board, a Python StateManager with atomic writes, and a migration scaffold so schema bumps cannot corrupt the workbench.",
+              "tags": [
+                "state",
+                "schema",
+                "json-schema",
+                "atomic-writes",
+                "migrations"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 35,
+          "slug": "35-initialization-scripts",
+          "title": "Initialization Scripts for Agents",
+          "path": "phases/14-agent-engineering/35-initialization-scripts",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "init-script",
+              "path": "phases/14-agent-engineering/35-initialization-scripts/outputs/skill-init-script.md",
+              "version": "1.0.0",
+              "description": "Interview a project and emit a deterministic init_agent.py with five probes plus a CI workflow that refuses to launch the agent if any probe fails.",
+              "tags": [
+                "init",
+                "probes",
+                "ci",
+                "workbench",
+                "fail-loud"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 36,
+          "slug": "36-scope-contracts",
+          "title": "Scope Contracts and Task Boundaries",
+          "path": "phases/14-agent-engineering/36-scope-contracts",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "scope-contract",
+              "path": "phases/14-agent-engineering/36-scope-contracts/outputs/skill-scope-contract.md",
+              "version": "1.0.0",
+              "description": "Generate per-task scope contracts with allowed/forbidden globs, acceptance criteria, and rollback plan, plus a CI-ready glob-aware checker that runs on every agent diff.",
+              "tags": [
+                "scope",
+                "contract",
+                "globs",
+                "diff-check",
+                "ci"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 37,
+          "slug": "37-runtime-feedback-loops",
+          "title": "Runtime Feedback Loops",
+          "path": "phases/14-agent-engineering/37-runtime-feedback-loops",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "feedback-runner",
+              "path": "phases/14-agent-engineering/37-runtime-feedback-loops/outputs/skill-feedback-runner.md",
+              "version": "1.0.0",
+              "description": "Wrap shell commands with deterministic stdout/stderr/exit/duration capture, persist a JSONL record per command, and refuse to advance the agent loop when feedback is missing.",
+              "tags": [
+                "feedback",
+                "subprocess",
+                "runner",
+                "jsonl",
+                "loop-control"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 38,
+          "slug": "38-verification-gates",
+          "title": "Verification Gates",
+          "path": "phases/14-agent-engineering/38-verification-gates",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "verification-gate",
+              "path": "phases/14-agent-engineering/38-verification-gates/outputs/skill-verification-gate.md",
+              "version": "1.0.0",
+              "description": "Generate a deterministic verification gate that combines scope, rule, and feedback artifacts into a single verification_report.json per task, plus CI wiring that refuses to merge without a green verdict.",
+              "tags": [
+                "verification",
+                "gate",
+                "deterministic",
+                "ci",
+                "override-log"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 39,
+          "slug": "39-reviewer-agent",
+          "title": "Reviewer Agent: Separate Builder from Marker",
+          "path": "phases/14-agent-engineering/39-reviewer-agent",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "reviewer-agent",
+              "path": "phases/14-agent-engineering/39-reviewer-agent/outputs/skill-reviewer-agent.md",
+              "version": "1.0.0",
+              "description": "Stand up a reviewer agent role with a five-dimension rubric that reads builder artifacts, produces a structured review report, and starts human review from a written page instead of a blank one.",
+              "tags": [
+                "reviewer",
+                "rubric",
+                "role-separation",
+                "second-loop",
+                "review-report"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 40,
+          "slug": "40-multi-session-handoff",
+          "title": "Multi-Session Handoff",
+          "path": "phases/14-agent-engineering/40-multi-session-handoff",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "handoff-generator",
+              "path": "phases/14-agent-engineering/40-multi-session-handoff/outputs/skill-handoff-generator.md",
+              "version": "1.0.0",
+              "description": "Generate end-of-session handoff packets from workbench artifacts, producing both human-readable Markdown and machine-readable JSON keyed to the seven canonical fields.",
+              "tags": [
+                "handoff",
+                "generator",
+                "session-end",
+                "packet",
+                "next-action"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 41,
+          "slug": "41-workbench-for-real-repos",
+          "title": "The Workbench on a Real Repo",
+          "path": "phases/14-agent-engineering/41-workbench-for-real-repos",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "workbench-benchmark",
+              "path": "phases/14-agent-engineering/41-workbench-for-real-repos/outputs/skill-workbench-benchmark.md",
+              "version": "1.0.0",
+              "description": "Run the same task through prompt-only and workbench-guided pipelines on a project's own sample app and emit a five-outcome before/after report.",
+              "tags": [
+                "benchmark",
+                "before-after",
+                "evaluation",
+                "workbench",
+                "sample-app"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 42,
+          "slug": "42-agent-workbench-capstone",
+          "title": "Capstone: Ship a Reusable Agent Workbench Pack",
+          "path": "phases/14-agent-engineering/42-agent-workbench-capstone",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": false,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "workbench-pack",
+              "path": "phases/14-agent-engineering/42-agent-workbench-capstone/outputs/skill-workbench-pack.md",
+              "version": "1.0.0",
+              "description": "Generate a project-tuned drop-in agent workbench pack — rules sharpened to the team's history, scope globs matched to the repo, rubric dimensions extended with one domain-specific entry.",
+              "tags": [
+                "capstone",
+                "workbench-pack",
+                "installer",
+                "schemas",
+                "drop-in"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "num": 15,
+      "slug": "15-autonomous-systems",
+      "title": "Autonomous Systems",
+      "lesson_count": 22,
+      "lessons": [
+        {
+          "num": 1,
+          "slug": "01-long-horizon-agents",
+          "title": "The Shift from Chatbots to Long-Horizon Agents",
+          "path": "phases/15-autonomous-systems/01-long-horizon-agents",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "horizon-reality-check",
+              "path": "phases/15-autonomous-systems/01-long-horizon-agents/outputs/skill-horizon-reality-check.md",
+              "version": "1.0.0",
+              "description": "Given a task you want to hand to an agent, decide whether the current frontier's horizon covers it with enough margin.",
+              "tags": [
+                "autonomous-agents",
+                "metr",
+                "time-horizon",
+                "reliability",
+                "deployment"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 2,
+          "slug": "02-star-family-reasoning",
+          "title": "STaR, V-STaR, Quiet-STaR — Self-Taught Reasoning",
+          "path": "phases/15-autonomous-systems/02-star-family-reasoning",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "star-loop-reviewer",
+              "path": "phases/15-autonomous-systems/02-star-family-reasoning/outputs/skill-star-loop-reviewer.md",
+              "version": "1.0.0",
+              "description": "Audit a proposed self-taught reasoning pipeline (STaR-family) before you commit training compute to it.",
+              "tags": [
+                "star",
+                "vstar",
+                "quiet-star",
+                "self-improvement",
+                "reasoning",
+                "bootstrap"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 3,
+          "slug": "03-alphaevolve-evolutionary-coding",
+          "title": "AlphaEvolve — Evolutionary Coding Agents",
+          "path": "phases/15-autonomous-systems/03-alphaevolve-evolutionary-coding",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "evaluator-rigor-audit",
+              "path": "phases/15-autonomous-systems/03-alphaevolve-evolutionary-coding/outputs/skill-evaluator-rigor-audit.md",
+              "version": "1.0.0",
+              "description": "Audit a proposed AlphaEvolve-style evolutionary coding loop's evaluator before committing any compute to the search.",
+              "tags": [
+                "alphaevolve",
+                "evolutionary-coding",
+                "evaluator",
+                "reward-hacking",
+                "deepmind"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 4,
+          "slug": "04-darwin-godel-machine",
+          "title": "Darwin Godel Machine — Open-Ended Self-Modifying Agents",
+          "path": "phases/15-autonomous-systems/04-darwin-godel-machine",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "dgm-evaluator-firewall",
+              "path": "phases/15-autonomous-systems/04-darwin-godel-machine/outputs/skill-dgm-evaluator-firewall.md",
+              "version": "1.0.0",
+              "description": "Specify the evaluator separation a Darwin-Godel-Machine-style self-modifying agent loop needs to avoid documented reward hacking.",
+              "tags": [
+                "dgm",
+                "self-modification",
+                "reward-hacking",
+                "evaluator",
+                "sandbox"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 5,
+          "slug": "05-ai-scientist-v2",
+          "title": "AI Scientist v2 — Workshop-Level Autonomous Research",
+          "path": "phases/15-autonomous-systems/05-ai-scientist-v2",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "ai-scientist-sandbox-review",
+              "path": "phases/15-autonomous-systems/05-ai-scientist-v2/outputs/skill-ai-scientist-sandbox-review.md",
+              "version": "1.0.0",
+              "description": "Two-gate review checklist for research-loop agent outputs before anything leaves the sandbox.",
+              "tags": [
+                "ai-scientist",
+                "research-agent",
+                "sandbox",
+                "peer-review",
+                "disclosure"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 6,
+          "slug": "06-automated-alignment-research",
+          "title": "Automated Alignment Research (Anthropic AAR)",
+          "path": "phases/15-autonomous-systems/06-automated-alignment-research",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "aar-deployment-review",
+              "path": "phases/15-autonomous-systems/06-automated-alignment-research/outputs/skill-aar-deployment-review.md",
+              "version": "1.0.0",
+              "description": "Pre-deployment review of an automated-alignment-research pipeline, including sandbox isolation and log integrity.",
+              "tags": [
+                "aar",
+                "alignment-research",
+                "sandbox",
+                "log-integrity",
+                "rsp"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 7,
+          "slug": "07-recursive-self-improvement",
+          "title": "Recursive Self-Improvement — Capability vs Alignment",
+          "path": "phases/15-autonomous-systems/07-recursive-self-improvement",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "rsi-cycle-pause-spec",
+              "path": "phases/15-autonomous-systems/07-recursive-self-improvement/outputs/skill-rsi-cycle-pause-spec.md",
+              "version": "1.0.0",
+              "description": "Specify the conditions under which an RSI pipeline must pause and wait for human review before the next cycle.",
+              "tags": [
+                "rsi",
+                "self-improvement",
+                "alignment",
+                "pause-threshold",
+                "rsp"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 8,
+          "slug": "08-bounded-self-improvement",
+          "title": "Bounded Self-Improvement Designs",
+          "path": "phases/15-autonomous-systems/08-bounded-self-improvement",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "bounded-loop-review",
+              "path": "phases/15-autonomous-systems/08-bounded-self-improvement/outputs/skill-bounded-loop-review.md",
+              "version": "1.0.0",
+              "description": "Audit a proposed bounded self-improvement loop against the four-primitive stack (invariants, anchor, multi-objective, regression detection).",
+              "tags": [
+                "bounded-self-improvement",
+                "invariants",
+                "alignment-anchor",
+                "rsi-safety"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 9,
+          "slug": "09-coding-agent-landscape",
+          "title": "The Autonomous Coding Agent Landscape (2026)",
+          "path": "phases/15-autonomous-systems/09-coding-agent-landscape",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "coding-scaffold-audit",
+              "path": "phases/15-autonomous-systems/09-coding-agent-landscape/outputs/skill-scaffold-audit.md",
+              "version": "1.0.0",
+              "description": "Audit a proposed coding-agent scaffold (retrieval, verifier loop, sandbox, benchmark fit) before adopting it for production code changes.",
+              "tags": [
+                "coding-agent",
+                "scaffolding",
+                "swe-bench",
+                "codeact",
+                "openhands"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 10,
+          "slug": "10-claude-code-permission-modes",
+          "title": "Claude Code as an Autonomous Agent: Permission Modes and Auto Mode",
+          "path": "phases/15-autonomous-systems/10-claude-code-permission-modes",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "permission-mode-picker",
+              "path": "phases/15-autonomous-systems/10-claude-code-permission-modes/outputs/skill-permission-mode-picker.md",
+              "version": "1.0.0",
+              "description": "Match a Claude Code task to the correct permission mode, budget caps, and required isolation before starting a run.",
+              "tags": [
+                "claude-code",
+                "permission-modes",
+                "auto-mode",
+                "budgets",
+                "isolation"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 11,
+          "slug": "11-browser-agents",
+          "title": "Browser Agents and Long-Horizon Web Tasks",
+          "path": "phases/15-autonomous-systems/11-browser-agents",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "browser-agent-trust-boundary",
+              "path": "phases/15-autonomous-systems/11-browser-agents/outputs/skill-browser-agent-trust-boundary.md",
+              "version": "1.0.0",
+              "description": "Scope a proposed browser-agent deployment — trust zones, authorized writes, required defenses — before the agent touches a real site.",
+              "tags": [
+                "browser-agents",
+                "prompt-injection",
+                "trust-boundary",
+                "osworld",
+                "webarena"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 12,
+          "slug": "12-durable-execution",
+          "title": "Long-Running Background Agents: Durable Execution",
+          "path": "phases/15-autonomous-systems/12-durable-execution",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "durable-execution-review",
+              "path": "phases/15-autonomous-systems/12-durable-execution/outputs/skill-durable-execution-review.md",
+              "version": "1.0.0",
+              "description": "Review a proposed long-running agent deployment for correct durable-execution shape (activities, determinism, checkpoint backend, human-input state, HITL-on-resume).",
+              "tags": [
+                "durable-execution",
+                "workflows",
+                "checkpointing",
+                "temporal",
+                "langgraph",
+                "agents-sdk"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 13,
+          "slug": "13-cost-governors",
+          "title": "Action Budgets, Iteration Caps, and Cost Governors",
+          "path": "phases/15-autonomous-systems/13-cost-governors",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "agent-budget-audit",
+              "path": "phases/15-autonomous-systems/13-cost-governors/outputs/skill-agent-budget-audit.md",
+              "version": "1.0.0",
+              "description": "Audit an agent deployment's cost-governor stack and flag missing layers before enabling unattended runs.",
+              "tags": [
+                "cost-governors",
+                "denial-of-wallet",
+                "budgets",
+                "claude-code-sdk",
+                "agent-governance"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 14,
+          "slug": "14-kill-switches-canaries",
+          "title": "Kill Switches, Circuit Breakers, and Canary Tokens",
+          "path": "phases/15-autonomous-systems/14-kill-switches-canaries",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "tripwire-design",
+              "path": "phases/15-autonomous-systems/14-kill-switches-canaries/outputs/skill-tripwire-design.md",
+              "version": "1.0.0",
+              "description": "Review a proposed agent detector stack (kill switch, circuit breakers, canary tokens) and flag missing tripwires before the first autonomous run.",
+              "tags": [
+                "kill-switch",
+                "circuit-breaker",
+                "canary",
+                "honeytoken",
+                "detection-and-response"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 15,
+          "slug": "15-propose-then-commit",
+          "title": "Human-in-the-Loop: Propose-Then-Commit",
+          "path": "phases/15-autonomous-systems/15-propose-then-commit",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "hitl-design",
+              "path": "phases/15-autonomous-systems/15-propose-then-commit/outputs/skill-hitl-design.md",
+              "version": "1.0.0",
+              "description": "Review a proposed Human-in-the-Loop workflow for propose-then-commit shape and flag missing metadata, idempotency, verification, or challenge-and-response layers.",
+              "tags": [
+                "hitl",
+                "propose-then-commit",
+                "idempotency",
+                "langgraph",
+                "cloudflare",
+                "agent-framework",
+                "eu-ai-act"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 16,
+          "slug": "16-checkpoints-rollback",
+          "title": "Checkpoints and Rollback",
+          "path": "phases/15-autonomous-systems/16-checkpoints-rollback",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "rollback-rehearsal",
+              "path": "phases/15-autonomous-systems/16-checkpoints-rollback/outputs/skill-rollback-rehearsal.md",
+              "version": "1.0.0",
+              "description": "Design a rollback-rehearsal test for a proposed autonomous workflow and audit the checkpoint backend for audit-trail persistence.",
+              "tags": [
+                "checkpointing",
+                "rollback",
+                "idempotency",
+                "eu-ai-act-article-14",
+                "durable-execution"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 17,
+          "slug": "17-constitutional-ai",
+          "title": "Constitutional AI and Rule Overrides",
+          "path": "phases/15-autonomous-systems/17-constitutional-ai",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "constitution-review",
+              "path": "phases/15-autonomous-systems/17-constitutional-ai/outputs/skill-constitution-review.md",
+              "version": "1.0.0",
+              "description": "Audit a deployment's constitutional layer — hardcoded prohibitions, soft-coded defaults, operator-adjustable bounds, and four-tier hierarchy resolution.",
+              "tags": [
+                "constitutional-ai",
+                "rule-override",
+                "hierarchy",
+                "cai",
+                "rlaif",
+                "hardcoded-prohibition"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 18,
+          "slug": "18-llama-guard",
+          "title": "Llama Guard and Input/Output Classification",
+          "path": "phases/15-autonomous-systems/18-llama-guard",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "classifier-stack-audit",
+              "path": "phases/15-autonomous-systems/18-llama-guard/outputs/skill-classifier-stack-audit.md",
+              "version": "1.0.0",
+              "description": "Audit a deployment's input/output classifier stack (model, taxonomy, input rails, output rails, dialog rails) and flag adversarial-attack gaps.",
+              "tags": [
+                "llama-guard",
+                "nemo-guardrails",
+                "input-rails",
+                "output-rails",
+                "colang",
+                "adversarial-attacks"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 19,
+          "slug": "19-anthropic-rsp",
+          "title": "Anthropic Responsible Scaling Policy v3.0",
+          "path": "phases/15-autonomous-systems/19-anthropic-rsp",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "scaling-policy-review",
+              "path": "phases/15-autonomous-systems/19-anthropic-rsp/outputs/skill-scaling-policy-review.md",
+              "version": "1.0.0",
+              "description": "Review a frontier-lab scaling policy (Anthropic RSP, OpenAI Preparedness, DeepMind FSF, internal) against the RSP v3.0 reference shape.",
+              "tags": [
+                "rsp",
+                "scaling-policy",
+                "ai-rd-4",
+                "pause-commitment",
+                "saferai",
+                "governance"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 20,
+          "slug": "20-openai-preparedness-deepmind-fsf",
+          "title": "OpenAI Preparedness Framework and DeepMind Frontier Safety Framework",
+          "path": "phases/15-autonomous-systems/20-openai-preparedness-deepmind-fsf",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "cross-policy-diff",
+              "path": "phases/15-autonomous-systems/20-openai-preparedness-deepmind-fsf/outputs/skill-cross-policy-diff.md",
+              "version": "1.0.0",
+              "description": "Produce a cross-policy comparison for a specific capability using the OpenAI Preparedness Framework v2, Anthropic RSP v3.0, and DeepMind FSF v3 as reference.",
+              "tags": [
+                "preparedness-framework",
+                "fsf",
+                "rsp",
+                "cross-policy",
+                "scaling-policy"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 21,
+          "slug": "21-metr-external-evaluation",
+          "title": "METR Time Horizons and External Capability Evaluation",
+          "path": "phases/15-autonomous-systems/21-metr-external-evaluation",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "horizon-interpretation",
+              "path": "phases/15-autonomous-systems/21-metr-external-evaluation/outputs/skill-horizon-interpretation.md",
+              "version": "1.0.0",
+              "description": "Review a vendor's time-horizon claim and produce a gap analysis between benchmark claim and deployment reality.",
+              "tags": [
+                "metr",
+                "time-horizon",
+                "hcast",
+                "re-bench",
+                "eval-vs-deploy",
+                "external-evaluation"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 22,
+          "slug": "22-cais-caisi-societal-risk",
+          "title": "CAIS, CAISI, and Societal-Scale Risk",
+          "path": "phases/15-autonomous-systems/22-cais-caisi-societal-risk",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "societal-risk-review",
+              "path": "phases/15-autonomous-systems/22-cais-caisi-societal-risk/outputs/skill-societal-risk-review.md",
+              "version": "1.0.0",
+              "description": "Review a deployment for societal-scale-risk posture using the CAIS four-risk framework and CAISI / SB-53 regulatory context.",
+              "tags": [
+                "cais",
+                "caisi",
+                "four-risk-framework",
+                "organizational-risk",
+                "sb-53",
+                "societal-risk"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "num": 16,
+      "slug": "16-multi-agent-and-swarms",
+      "title": "Multi Agent And Swarms",
+      "lesson_count": 25,
+      "lessons": [
+        {
+          "num": 1,
+          "slug": "01-why-multi-agent",
+          "title": "Why Multi-Agent?",
+          "path": "phases/16-multi-agent-and-swarms/01-why-multi-agent",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "single_vs_multi.ts"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-multi-agent-decision",
+              "path": "phases/16-multi-agent-and-swarms/01-why-multi-agent/outputs/prompt-multi-agent-decision.md",
+              "version": "",
+              "description": "Decide whether a task needs a multi-agent system or a single agent",
+              "tags": []
+            }
+          ]
+        },
+        {
+          "num": 2,
+          "slug": "02-fipa-acl-heritage",
+          "title": "Heritage of FIPA-ACL and Speech Acts",
+          "path": "phases/16-multi-agent-and-swarms/02-fipa-acl-heritage",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "fipa-mapper",
+              "path": "phases/16-multi-agent-and-swarms/02-fipa-acl-heritage/outputs/skill-fipa-mapper.md",
+              "version": "1.0.0",
+              "description": "Map any 2026 agent-protocol spec (MCP, A2A, ACP, ANP, CA-MCP, NLIP, or a new one) onto FIPA-ACL performatives and interaction protocols to decide what is genuine novelty and what is reinvention.",
+              "tags": [
+                "multi-agent",
+                "protocols",
+                "FIPA",
+                "speech-acts",
+                "interoperability"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 3,
+          "slug": "03-communication-protocols",
+          "title": "Communication Protocols",
+          "path": "phases/16-multi-agent-and-swarms/03-communication-protocols",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": true,
+          "has_notebook": false,
+          "code_files": [
+            "main.ts"
+          ],
+          "outputs": [
+            {
+              "type": "prompt",
+              "name": "prompt-protocol-selector",
+              "path": "phases/16-multi-agent-and-swarms/03-communication-protocols/outputs/prompt-protocol-selector.md",
+              "version": "",
+              "description": "Helps choose the right agent communication protocol (MCP, A2A, ACP, ANP) based on system requirements",
+              "tags": []
+            }
+          ]
+        },
+        {
+          "num": 4,
+          "slug": "04-primitive-model",
+          "title": "The Multi-Agent Primitive Model",
+          "path": "phases/16-multi-agent-and-swarms/04-primitive-model",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "primitive-mapper",
+              "path": "phases/16-multi-agent-and-swarms/04-primitive-model/outputs/skill-primitive-mapper.md",
+              "version": "1.0.0",
+              "description": "Map any multi-agent framework or codebase to the four primitive axes (agent, handoff, shared state, orchestrator).",
+              "tags": [
+                "multi-agent",
+                "primitives",
+                "framework-comparison",
+                "architecture"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 5,
+          "slug": "05-supervisor-orchestrator-pattern",
+          "title": "Supervisor / Orchestrator-Worker Pattern",
+          "path": "phases/16-multi-agent-and-swarms/05-supervisor-orchestrator-pattern",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "supervisor-designer",
+              "path": "phases/16-multi-agent-and-swarms/05-supervisor-orchestrator-pattern/outputs/skill-supervisor-designer.md",
+              "version": "1.0.0",
+              "description": "Design a supervisor/orchestrator-worker system for a given research-style query, specifying lead prompt, worker roles, decomposition rules, and synthesis template.",
+              "tags": [
+                "multi-agent",
+                "supervisor",
+                "orchestrator",
+                "anthropic-research",
+                "langgraph"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 6,
+          "slug": "06-hierarchical-architecture",
+          "title": "Hierarchical Architecture and Its Failure Mode",
+          "path": "phases/16-multi-agent-and-swarms/06-hierarchical-architecture",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "hierarchy-fitness",
+              "path": "phases/16-multi-agent-and-swarms/06-hierarchical-architecture/outputs/skill-hierarchy-fitness.md",
+              "version": "1.0.0",
+              "description": "Decide whether a multi-agent task fits hierarchical, flat supervisor, or sequential. Surface the failure modes that matter.",
+              "tags": [
+                "multi-agent",
+                "hierarchy",
+                "crewai",
+                "langgraph",
+                "decomposition-drift"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 7,
+          "slug": "07-society-of-mind-debate",
+          "title": "Society of Mind and Multi-Agent Debate",
+          "path": "phases/16-multi-agent-and-swarms/07-society-of-mind-debate",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "debate-configurator",
+              "path": "phases/16-multi-agent-and-swarms/07-society-of-mind-debate/outputs/skill-debate-configurator.md",
+              "version": "1.0.0",
+              "description": "Configure a multi-agent debate for a given task, estimating quality gain and token cost before running.",
+              "tags": [
+                "multi-agent",
+                "debate",
+                "society-of-mind",
+                "consensus"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 8,
+          "slug": "08-role-specialization",
+          "title": "Role Specialization — Planner, Critic, Executor, Verifier",
+          "path": "phases/16-multi-agent-and-swarms/08-role-specialization",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "role-designer",
+              "path": "phases/16-multi-agent-and-swarms/08-role-specialization/outputs/skill-role-designer.md",
+              "version": "1.0.0",
+              "description": "Produce a role roster for a multi-agent system, naming the planner/executor/critic/verifier for a given task with explicit I/O schemas.",
+              "tags": [
+                "multi-agent",
+                "role-specialization",
+                "metagpt",
+                "chatdev",
+                "verification"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 9,
+          "slug": "09-parallel-swarm-networks",
+          "title": "Parallel / Swarm / Networked Architectures",
+          "path": "phases/16-multi-agent-and-swarms/09-parallel-swarm-networks",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "swarm-fit",
+              "path": "phases/16-multi-agent-and-swarms/09-parallel-swarm-networks/outputs/skill-swarm-fit.md",
+              "version": "1.0.0",
+              "description": "Decide whether a task fits a swarm (decentralized) architecture or a supervisor (centralized) one.",
+              "tags": [
+                "multi-agent",
+                "swarm",
+                "decentralized",
+                "langgraph",
+                "matrix"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 10,
+          "slug": "10-group-chat-speaker-selection",
+          "title": "Group Chat and Speaker Selection",
+          "path": "phases/16-multi-agent-and-swarms/10-group-chat-speaker-selection",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "groupchat-selector",
+              "path": "phases/16-multi-agent-and-swarms/10-group-chat-speaker-selection/outputs/skill-groupchat-selector.md",
+              "version": "1.0.0",
+              "description": "Configure an AutoGen/AG2-style GroupChat selector for a task, naming the selector variant, termination, and anti-hot-speaker rules.",
+              "tags": [
+                "multi-agent",
+                "groupchat",
+                "autogen",
+                "ag2",
+                "speaker-selection"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 11,
+          "slug": "11-handoffs-and-routines",
+          "title": "Handoffs and Routines — Stateless Orchestration",
+          "path": "phases/16-multi-agent-and-swarms/11-handoffs-and-routines",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "handoff-designer",
+              "path": "phases/16-multi-agent-and-swarms/11-handoffs-and-routines/outputs/skill-handoff-designer.md",
+              "version": "1.0.0",
+              "description": "Design a handoff topology for a Swarm/Agents-SDK-style system: which agents exist, which handoffs they can call, what context transfers.",
+              "tags": [
+                "multi-agent",
+                "swarm",
+                "handoff",
+                "openai-agents-sdk"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 12,
+          "slug": "12-a2a-protocol",
+          "title": "A2A — The Agent-to-Agent Protocol",
+          "path": "phases/16-multi-agent-and-swarms/12-a2a-protocol",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "a2a-integrator",
+              "path": "phases/16-multi-agent-and-swarms/12-a2a-protocol/outputs/skill-a2a-integrator.md",
+              "version": "1.0.0",
+              "description": "Design an A2A integration between two agents — Agent Card, task schemas, auth, streaming or polling.",
+              "tags": [
+                "multi-agent",
+                "a2a",
+                "protocol",
+                "interoperability",
+                "google"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 13,
+          "slug": "13-shared-memory-blackboard",
+          "title": "Shared Memory and Blackboard Patterns",
+          "path": "phases/16-multi-agent-and-swarms/13-shared-memory-blackboard",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "memory-auditor",
+              "path": "phases/16-multi-agent-and-swarms/13-shared-memory-blackboard/outputs/skill-memory-auditor.md",
+              "version": "1.0.0",
+              "description": "Audit a multi-agent system's shared-memory design for provenance, versioning, verifier separation, and projection schema. Flag memory-poisoning exposure before production.",
+              "tags": [
+                "multi-agent",
+                "shared-state",
+                "blackboard",
+                "memory-poisoning",
+                "provenance"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 14,
+          "slug": "14-consensus-and-bft",
+          "title": "Consensus and Byzantine Fault Tolerance for Agents",
+          "path": "phases/16-multi-agent-and-swarms/14-consensus-and-bft",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "consensus-designer",
+              "path": "phases/16-multi-agent-and-swarms/14-consensus-and-bft/outputs/skill-consensus-designer.md",
+              "version": "1.0.0",
+              "description": "Design a BFT-aware consensus protocol for a multi-agent ensemble. Picks clustering, weighting, threshold, and escalation policy; attack-tests the design against byzantine, sycophancy, and monoculture patterns.",
+              "tags": [
+                "multi-agent",
+                "consensus",
+                "BFT",
+                "voting",
+                "confidence"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 15,
+          "slug": "15-voting-debate-topology",
+          "title": "Voting, Self-Consistency, and Debate Topology",
+          "path": "phases/16-multi-agent-and-swarms/15-voting-debate-topology",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "topology-picker",
+              "path": "phases/16-multi-agent-and-swarms/15-voting-debate-topology/outputs/skill-topology-picker.md",
+              "version": "1.0.0",
+              "description": "Pick a multi-agent debate topology (star / chain / tree / graph), an N of agents, a heterogeneity profile, and a round bound for a given task.",
+              "tags": [
+                "multi-agent",
+                "debate",
+                "topology",
+                "voting",
+                "self-consistency"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 16,
+          "slug": "16-negotiation-bargaining",
+          "title": "Negotiation and Bargaining",
+          "path": "phases/16-multi-agent-and-swarms/16-negotiation-bargaining",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "bargainer-designer",
+              "path": "phases/16-multi-agent-and-swarms/16-negotiation-bargaining/outputs/skill-bargainer-designer.md",
+              "version": "1.0.0",
+              "description": "Design a negotiation protocol: which agent narrates, which component generates offers, how private scratchpads separate from public messages, what the round bound is, and how deal rate is monitored.",
+              "tags": [
+                "multi-agent",
+                "negotiation",
+                "bargaining",
+                "contract-net",
+                "OG-Narrator"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 17,
+          "slug": "17-generative-agents-simulation",
+          "title": "Generative Agents and Emergent Simulation",
+          "path": "phases/16-multi-agent-and-swarms/17-generative-agents-simulation",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "simulation-designer",
+              "path": "phases/16-multi-agent-and-swarms/17-generative-agents-simulation/outputs/skill-simulation-designer.md",
+              "version": "1.0.0",
+              "description": "Design a generative-agent simulation (Smallville-style) for a given scenario. Specifies memory schema, reflection cadence, plan horizon, spatial/social constraints, and evaluation metrics.",
+              "tags": [
+                "multi-agent",
+                "simulation",
+                "generative-agents",
+                "emergence",
+                "memory"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 18,
+          "slug": "18-theory-of-mind-coordination",
+          "title": "Theory of Mind and Emergent Coordination",
+          "path": "phases/16-multi-agent-and-swarms/18-theory-of-mind-coordination",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "tom-auditor",
+              "path": "phases/16-multi-agent-and-swarms/18-theory-of-mind-coordination/outputs/skill-tom-auditor.md",
+              "version": "1.0.0",
+              "description": "Audit a multi-agent system that claims \"emergent coordination.\" Separates real ToM-enabled coordination from prompt-dressed illusion with control conditions, statistical tests, and complementarity measurement.",
+              "tags": [
+                "multi-agent",
+                "theory-of-mind",
+                "coordination",
+                "evaluation",
+                "emergence"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 19,
+          "slug": "19-swarm-optimization-pso-aco",
+          "title": "Swarm Optimization for LLMs (PSO, ACO)",
+          "path": "phases/16-multi-agent-and-swarms/19-swarm-optimization-pso-aco",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "swarm-optimizer",
+              "path": "phases/16-multi-agent-and-swarms/19-swarm-optimization-pso-aco/outputs/skill-swarm-optimizer.md",
+              "version": "1.0.0",
+              "description": "Choose between PSO, ACO, genetic algorithms, and gradient-based optimizers for a given LLM or agent optimization problem. Bio-inspired swarm algorithms are gradient-free and suit LLM-era workloads where the search space is discrete or the fitness function is black-box.",
+              "tags": [
+                "multi-agent",
+                "swarm-optimization",
+                "PSO",
+                "ACO",
+                "prompt-optimization",
+                "routing"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 20,
+          "slug": "20-marl-maddpg-qmix-mappo",
+          "title": "MARL — MADDPG, QMIX, MAPPO",
+          "path": "phases/16-multi-agent-and-swarms/20-marl-maddpg-qmix-mappo",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "marl-picker",
+              "path": "phases/16-multi-agent-and-swarms/20-marl-maddpg-qmix-mappo/outputs/skill-marl-picker.md",
+              "version": "1.0.0",
+              "description": "Choose a MARL algorithm (MADDPG, QMIX, MAPPO, IQL, or extensions) for a given multi-agent task. Consider cooperative vs competitive, action-space type, heterogeneity, reward structure, and scale.",
+              "tags": [
+                "multi-agent",
+                "MARL",
+                "MADDPG",
+                "QMIX",
+                "MAPPO",
+                "CTDE"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 21,
+          "slug": "21-agent-economies",
+          "title": "Agent Economies, Token Incentives, Reputation",
+          "path": "phases/16-multi-agent-and-swarms/21-agent-economies",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "economy-designer",
+              "path": "phases/16-multi-agent-and-swarms/21-agent-economies/outputs/skill-economy-designer.md",
+              "version": "1.0.0",
+              "description": "Design a minimal agent economy — identity, credit attribution, payment mechanism, reputation. Picks the smallest stack that solves the user's multi-agent incentive problem.",
+              "tags": [
+                "multi-agent",
+                "economy",
+                "Shapley",
+                "auctions",
+                "reputation",
+                "DePIN"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 22,
+          "slug": "22-production-scaling-queues-checkpoints",
+          "title": "Production Scaling — Queues, Checkpoints, Durability",
+          "path": "phases/16-multi-agent-and-swarms/22-production-scaling-queues-checkpoints",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "scaling-advisor",
+              "path": "phases/16-multi-agent-and-swarms/22-production-scaling-queues-checkpoints/outputs/skill-scaling-advisor.md",
+              "version": "1.0.0",
+              "description": "Advise on durable-execution choice for a multi-agent production system. Picks between FastAPI + Postgres, LangGraph runtime, Temporal, Restate, or custom based on concrete load and state-retention needs.",
+              "tags": [
+                "multi-agent",
+                "production",
+                "scaling",
+                "durable-execution",
+                "queues",
+                "checkpoints"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 23,
+          "slug": "23-failure-modes-mast-groupthink",
+          "title": "Failure Modes — MAST, Groupthink, Monoculture, Cascading Errors",
+          "path": "phases/16-multi-agent-and-swarms/23-failure-modes-mast-groupthink",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "mast-auditor",
+              "path": "phases/16-multi-agent-and-swarms/23-failure-modes-mast-groupthink/outputs/skill-mast-auditor.md",
+              "version": "1.0.0",
+              "description": "Run a MAST-style failure-mode audit on a multi-agent system. Categorize execution-trace failures into Specification / Coordination / Verification and the Groupthink families; rank mitigations by expected failure reduction.",
+              "tags": [
+                "multi-agent",
+                "failure-modes",
+                "MAST",
+                "groupthink",
+                "circuit-breaker",
+                "audit"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 24,
+          "slug": "24-evaluation-coordination-benchmarks",
+          "title": "Evaluation and Coordination Benchmarks",
+          "path": "phases/16-multi-agent-and-swarms/24-evaluation-coordination-benchmarks",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "benchmark-reader",
+              "path": "phases/16-multi-agent-and-swarms/24-evaluation-coordination-benchmarks/outputs/skill-benchmark-reader.md",
+              "version": "1.0.0",
+              "description": "Read a multi-agent benchmark claim skeptically. Grades the claim on benchmark selection, contamination, baselines, statistical significance, task diversity, and cost disclosure.",
+              "tags": [
+                "multi-agent",
+                "benchmarks",
+                "evaluation",
+                "SWE-bench",
+                "MARBLE"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 25,
+          "slug": "25-case-studies-2026-sota",
+          "title": "Case Studies and the 2026 State of the Art",
+          "path": "phases/16-multi-agent-and-swarms/25-case-studies-2026-sota",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "case-study-mapper",
+              "path": "phases/16-multi-agent-and-swarms/25-case-studies-2026-sota/outputs/skill-case-study-mapper.md",
+              "version": "1.0.0",
+              "description": "Map a proposed multi-agent system design to the closest 2026 production reference (Anthropic Research, MetaGPT/ChatDev, or OpenClaw/Moltbook). Surface known trade-offs, recommended framework, and the specific design decisions already tested in production.",
+              "tags": [
+                "multi-agent",
+                "case-studies",
+                "production",
+                "framework-selection",
+                "reference-architectures"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "num": 17,
+      "slug": "17-infrastructure-and-production",
+      "title": "Infrastructure And Production",
+      "lesson_count": 28,
+      "lessons": [
+        {
+          "num": 1,
+          "slug": "01-managed-llm-platforms",
+          "title": "Managed LLM Platforms — Bedrock, Vertex AI, Azure OpenAI",
+          "path": "phases/17-infrastructure-and-production/01-managed-llm-platforms",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "managed-platform-picker",
+              "path": "phases/17-infrastructure-and-production/01-managed-llm-platforms/outputs/skill-managed-platform-picker.md",
+              "version": "1.0.0",
+              "description": "Pick a managed LLM platform (Bedrock, Azure OpenAI, Vertex AI) and a second for redundancy, given workload, SLA, and compliance requirements — then produce a FinOps instrumentation plan.",
+              "tags": [
+                "bedrock",
+                "azure-openai",
+                "vertex-ai",
+                "ptu",
+                "finops",
+                "managed-platforms"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 2,
+          "slug": "02-inference-platform-economics",
+          "title": "Inference Platform Economics — Fireworks, Together, Baseten, Modal, Replicate, Anyscale",
+          "path": "phases/17-infrastructure-and-production/02-inference-platform-economics",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "inference-platform-picker",
+              "path": "phases/17-infrastructure-and-production/02-inference-platform-economics/outputs/skill-inference-platform-picker.md",
+              "version": "1.0.0",
+              "description": "Pick an inference platform (Fireworks, Together, Baseten, Modal, Replicate, Anyscale, or custom silicon) given workload, SLA, budget, and operational constraints. Normalize per-token, per-minute, and per-prediction pricing.",
+              "tags": [
+                "inference",
+                "fireworks",
+                "together",
+                "baseten",
+                "modal",
+                "replicate",
+                "anyscale",
+                "economics"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 3,
+          "slug": "03-gpu-autoscaling-kubernetes",
+          "title": "GPU Autoscaling on Kubernetes — Karpenter, KAI Scheduler, Gang Scheduling",
+          "path": "phases/17-infrastructure-and-production/03-gpu-autoscaling-kubernetes",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "gpu-autoscaler-plan",
+              "path": "phases/17-infrastructure-and-production/03-gpu-autoscaling-kubernetes/outputs/skill-gpu-autoscaler-plan.md",
+              "version": "1.0.0",
+              "description": "Design a three-layer GPU autoscaling plan (Karpenter + KAI Scheduler + application signals) for a Kubernetes-based LLM serving cluster. Diagnose DCGM_FI_DEV_GPU_UTIL traps and partial-allocation failures.",
+              "tags": [
+                "kubernetes",
+                "gpu",
+                "autoscaling",
+                "karpenter",
+                "kai-scheduler",
+                "hpa",
+                "dynamo-planner",
+                "llm-d"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 4,
+          "slug": "04-vllm-serving-internals",
+          "title": "vLLM Serving Internals: PagedAttention, Continuous Batching, Chunked Prefill",
+          "path": "phases/17-infrastructure-and-production/04-vllm-serving-internals",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "vllm-scheduler-reader",
+              "path": "phases/17-infrastructure-and-production/04-vllm-serving-internals/outputs/skill-vllm-scheduler-reader.md",
+              "version": "1.0.0",
+              "description": "Diagnose a vLLM serving config by reading the scheduler-level knobs and identifying which of PagedAttention, continuous batching, and chunked prefill is the bottleneck.",
+              "tags": [
+                "vllm",
+                "paged-attention",
+                "continuous-batching",
+                "chunked-prefill",
+                "serving",
+                "scheduler"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 5,
+          "slug": "05-eagle3-speculative-decoding",
+          "title": "EAGLE-3 Speculative Decoding in Production",
+          "path": "phases/17-infrastructure-and-production/05-eagle3-speculative-decoding",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "eagle3-rollout",
+              "path": "phases/17-infrastructure-and-production/05-eagle3-speculative-decoding/outputs/skill-eagle3-rollout.md",
+              "version": "1.0.0",
+              "description": "Produce a staged EAGLE-3 speculative-decoding rollout plan that measures acceptance rate alpha on real traffic before shipping.",
+              "tags": [
+                "speculative-decoding",
+                "eagle-3",
+                "vllm",
+                "alpha",
+                "production-rollout"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 6,
+          "slug": "06-sglang-radixattention",
+          "title": "SGLang and RadixAttention for Prefix-Heavy Workloads",
+          "path": "phases/17-infrastructure-and-production/06-sglang-radixattention",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "radix-scheduler-advisor",
+              "path": "phases/17-infrastructure-and-production/06-sglang-radixattention/outputs/skill-radix-scheduler-advisor.md",
+              "version": "1.0.0",
+              "description": "Advise on SGLang adoption and prompt-ordering discipline for prefix-heavy workloads that want RadixAttention's cache reuse.",
+              "tags": [
+                "sglang",
+                "radixattention",
+                "prefix-caching",
+                "scheduler",
+                "prompt-ordering"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 7,
+          "slug": "07-tensorrt-llm-blackwell",
+          "title": "TensorRT-LLM on Blackwell with FP8 and NVFP4",
+          "path": "phases/17-infrastructure-and-production/07-tensorrt-llm-blackwell",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "trtllm-blackwell-advisor",
+              "path": "phases/17-infrastructure-and-production/07-tensorrt-llm-blackwell/outputs/skill-trtllm-blackwell-advisor.md",
+              "version": "1.0.0",
+              "description": "Decide whether Blackwell + TensorRT-LLM + Dynamo is worth the NVIDIA-lock for a given workload and budget.",
+              "tags": [
+                "tensorrt-llm",
+                "blackwell",
+                "b200",
+                "gb200",
+                "nvfp4",
+                "fp8",
+                "dynamo"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 8,
+          "slug": "08-inference-metrics-goodput",
+          "title": "Inference Metrics — TTFT, TPOT, ITL, Goodput, P99",
+          "path": "phases/17-infrastructure-and-production/08-inference-metrics-goodput",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "slo-goodput-gate",
+              "path": "phases/17-infrastructure-and-production/08-inference-metrics-goodput/outputs/skill-slo-goodput-gate.md",
+              "version": "1.0.0",
+              "description": "Produce a CI/CD-ready benchmark recipe that gates LLM deploys on goodput, not throughput, with P50/P90/P99 percentiles and a documented tool choice.",
+              "tags": [
+                "inference-metrics",
+                "goodput",
+                "ttft",
+                "tpot",
+                "itl",
+                "slo",
+                "benchmarking"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 9,
+          "slug": "09-production-quantization",
+          "title": "Production Quantization — AWQ, GPTQ, GGUF K-quants, FP8, MXFP4/NVFP4",
+          "path": "phases/17-infrastructure-and-production/09-production-quantization",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "quantization-picker",
+              "path": "phases/17-infrastructure-and-production/09-production-quantization/outputs/skill-quantization-picker.md",
+              "version": "1.0.0",
+              "description": "Pick a 2026 quantization format given hardware, engine, workload, and quality tolerance, and produce a calibration + validation plan.",
+              "tags": [
+                "quantization",
+                "awq",
+                "gptq",
+                "gguf",
+                "fp8",
+                "nvfp4",
+                "calibration"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 10,
+          "slug": "10-cold-start-mitigation",
+          "title": "Cold Start Mitigation for Serverless LLMs",
+          "path": "phases/17-infrastructure-and-production/10-cold-start-mitigation",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "cold-start-planner",
+              "path": "phases/17-infrastructure-and-production/10-cold-start-mitigation/outputs/skill-cold-start-planner.md",
+              "version": "1.0.0",
+              "description": "Pick and stack cold-start mitigations for serverless LLM deployments. Budget phases (node, image, weights, engine, first forward) and match mitigations to SLA.",
+              "tags": [
+                "cold-start",
+                "serverless",
+                "bottlerocket",
+                "model-streamer",
+                "gpu-snapshot",
+                "warm-pool",
+                "serverlessllm"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 11,
+          "slug": "11-multi-region-kv-locality",
+          "title": "Multi-Region LLM Serving and KV Cache Locality",
+          "path": "phases/17-infrastructure-and-production/11-multi-region-kv-locality",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "multi-region-router",
+              "path": "phases/17-infrastructure-and-production/11-multi-region-kv-locality/outputs/skill-multi-region-router.md",
+              "version": "1.0.0",
+              "description": "Design a multi-region LLM routing plan with KV-cache locality, residency boundaries, DR manifest, and a quarterly failover drill.",
+              "tags": [
+                "multi-region",
+                "kv-cache",
+                "routing",
+                "dr",
+                "bedrock-cri",
+                "vllm-router",
+                "llm-d",
+                "gorgo"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 12,
+          "slug": "12-edge-inference",
+          "title": "Edge Inference — Apple Neural Engine, Qualcomm Hexagon, WebGPU/WebLLM, Jetson",
+          "path": "phases/17-infrastructure-and-production/12-edge-inference",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "edge-target-picker",
+              "path": "phases/17-infrastructure-and-production/12-edge-inference/outputs/skill-edge-target-picker.md",
+              "version": "1.0.0",
+              "description": "Pick an edge inference target (Apple ANE, Qualcomm Hexagon, WebGPU/WebLLM, NVIDIA Jetson) and matching quantization format given device, model, and latency budget.",
+              "tags": [
+                "edge",
+                "ane",
+                "hexagon",
+                "webgpu",
+                "webllm",
+                "jetson",
+                "core-ml",
+                "qnn",
+                "nvfp4"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 13,
+          "slug": "13-llm-observability",
+          "title": "LLM Observability Stack Selection",
+          "path": "phases/17-infrastructure-and-production/13-llm-observability",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "observability-stack",
+              "path": "phases/17-infrastructure-and-production/13-llm-observability/outputs/skill-observability-stack.md",
+              "version": "1.0.0",
+              "description": "Pick an LLM observability stack (development platform + gateway + optional scale layer) given stack, scale, budget, and license posture, and define the OpenTelemetry GenAI attribute set.",
+              "tags": [
+                "observability",
+                "langfuse",
+                "langsmith",
+                "phoenix",
+                "arize",
+                "helicone",
+                "opik",
+                "opentelemetry",
+                "genai-conventions"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 14,
+          "slug": "14-prompt-semantic-caching",
+          "title": "Prompt Caching and Semantic Caching Economics",
+          "path": "phases/17-infrastructure-and-production/14-prompt-semantic-caching",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "cache-auditor",
+              "path": "phases/17-infrastructure-and-production/14-prompt-semantic-caching/outputs/skill-cache-auditor.md",
+              "version": "1.0.0",
+              "description": "Audit an LLM prompt template and traffic pattern for cacheability. Recommend prompt restructure, TTL choice, parallelization fix, and semantic-cache threshold.",
+              "tags": [
+                "caching",
+                "prompt-cache",
+                "semantic-cache",
+                "anthropic",
+                "openai",
+                "parallelization",
+                "ttl"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 15,
+          "slug": "15-batch-apis",
+          "title": "Batch APIs — the 50% Discount as Industry Standard",
+          "path": "phases/17-infrastructure-and-production/15-batch-apis",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "batch-triager",
+              "path": "phases/17-infrastructure-and-production/15-batch-apis/outputs/skill-batch-triager.md",
+              "version": "1.0.0",
+              "description": "Triage LLM workloads into interactive / semi-interactive / batch lanes, compute stacked discount (batch + cache) savings, and flag mis-triaged workloads.",
+              "tags": [
+                "batch-api",
+                "openai-batch",
+                "anthropic-batches",
+                "vertex-batch",
+                "triage",
+                "cost"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 16,
+          "slug": "16-model-routing",
+          "title": "Model Routing as a Cost-Reduction Primitive",
+          "path": "phases/17-infrastructure-and-production/16-model-routing",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "router-plan",
+              "path": "phases/17-infrastructure-and-production/16-model-routing/outputs/skill-router-plan.md",
+              "version": "1.0.0",
+              "description": "Design an LLM model-routing plan — pick pattern (pre-route, cascade, ensemble), signals (task, length, embedding, confidence), and online quality gates.",
+              "tags": [
+                "routing",
+                "cascade",
+                "model-cascade",
+                "routellm",
+                "notdiamond",
+                "cost-reduction"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 17,
+          "slug": "17-disaggregated-prefill-decode",
+          "title": "Disaggregated Prefill/Decode — NVIDIA Dynamo and llm-d",
+          "path": "phases/17-infrastructure-and-production/17-disaggregated-prefill-decode",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "disaggregation-decider",
+              "path": "phases/17-infrastructure-and-production/17-disaggregated-prefill-decode/outputs/skill-disaggregation-decider.md",
+              "version": "1.0.0",
+              "description": "Decide whether to adopt disaggregated prefill/decode (Dynamo or llm-d) for a given workload and cluster. Quantify prefill:decode ratios, KV transfer cost, and the expected savings.",
+              "tags": [
+                "disaggregated-serving",
+                "dynamo",
+                "llm-d",
+                "nixl",
+                "kv-transfer",
+                "prefill-decode"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 18,
+          "slug": "18-vllm-production-stack-lmcache",
+          "title": "vLLM Production Stack with LMCache KV Offloading",
+          "path": "phases/17-infrastructure-and-production/18-vllm-production-stack-lmcache",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "vllm-stack-decider",
+              "path": "phases/17-infrastructure-and-production/18-vllm-production-stack-lmcache/outputs/skill-vllm-stack-decider.md",
+              "version": "1.0.0",
+              "description": "Decide vLLM deployment layout — production-stack Helm chart, KV offload (native CPU or LMCache), router/observability integration — given workload and fleet size.",
+              "tags": [
+                "vllm",
+                "production-stack",
+                "lmcache",
+                "kv-offload",
+                "connector-api"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 19,
+          "slug": "19-ai-gateways",
+          "title": "AI Gateways — LiteLLM, Portkey, Kong AI Gateway, Bifrost",
+          "path": "phases/17-infrastructure-and-production/19-ai-gateways",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "gateway-picker",
+              "path": "phases/17-infrastructure-and-production/19-ai-gateways/outputs/skill-gateway-picker.md",
+              "version": "1.0.0",
+              "description": "Pick an AI gateway (LiteLLM, Portkey, Kong AI, Cloudflare/Vercel) given scale, latency budget, compliance, ops posture, and pricing tolerance.",
+              "tags": [
+                "ai-gateway",
+                "litellm",
+                "portkey",
+                "kong",
+                "cloudflare",
+                "vercel",
+                "bifrost",
+                "fallback",
+                "rate-limit",
+                "guardrails"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 20,
+          "slug": "20-shadow-canary-progressive",
+          "title": "Shadow Traffic, Canary Rollout, and Progressive Deployment for LLMs",
+          "path": "phases/17-infrastructure-and-production/20-shadow-canary-progressive",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "rollout-runbook",
+              "path": "phases/17-infrastructure-and-production/20-shadow-canary-progressive/outputs/skill-rollout-runbook.md",
+              "version": "1.0.0",
+              "description": "Design a shadow → canary → A/B → 100% rollout plan for a new LLM model or prompt template, with five canary gates, noise-floor-aware thresholds, and a seconds-fast rollback path.",
+              "tags": [
+                "rollout",
+                "canary",
+                "shadow",
+                "progressive-delivery",
+                "feature-flags",
+                "argo-rollouts",
+                "flagger",
+                "kserve"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 21,
+          "slug": "21-ab-testing-llm-features",
+          "title": "A/B Testing LLM Features — GrowthBook, Statsig, and the Vibes Problem",
+          "path": "phases/17-infrastructure-and-production/21-ab-testing-llm-features",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "ab-plan",
+              "path": "phases/17-infrastructure-and-production/21-ab-testing-llm-features/outputs/skill-ab-plan.md",
+              "version": "1.0.0",
+              "description": "Design an LLM A/B test — pick platform (Statsig or GrowthBook), primary metric, guardrails, sample size with LLM-noise buffer, CUPED, sequential stopping, and multiple-comparison correction.",
+              "tags": [
+                "ab-testing",
+                "statsig",
+                "growthbook",
+                "cuped",
+                "sequential",
+                "benjamini-hochberg",
+                "srm"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 22,
+          "slug": "22-load-testing-llm-apis",
+          "title": "Load Testing LLM APIs — Why k6 and Locust Lie",
+          "path": "phases/17-infrastructure-and-production/22-load-testing-llm-apis",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "load-test-plan",
+              "path": "phases/17-infrastructure-and-production/22-load-testing-llm-apis/outputs/skill-load-test-plan.md",
+              "version": "1.0.0",
+              "description": "Design a realistic LLM load test — pick tool (LLMPerf, k6, GenAI-Perf, guidellm), build four patterns (steady, ramp, spike, soak), and gate in CI.",
+              "tags": [
+                "load-testing",
+                "llmperf",
+                "k6",
+                "genai-perf",
+                "guidellm",
+                "llm-locust",
+                "ci-gate"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 23,
+          "slug": "23-sre-for-ai",
+          "title": "SRE for AI — Multi-Agent Incident Response, Runbooks, Predictive Detection",
+          "path": "phases/17-infrastructure-and-production/23-sre-for-ai",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "ai-sre-plan",
+              "path": "phases/17-infrastructure-and-production/23-sre-for-ai/outputs/skill-ai-sre-plan.md",
+              "version": "1.0.0",
+              "description": "Design an AI SRE rollout for a team — multi-agent triage architecture, structured runbooks, adversarial evaluation, narrow auto-remediation, and predictive-detection posture.",
+              "tags": [
+                "ai-sre",
+                "multi-agent",
+                "runbooks",
+                "auto-remediation",
+                "adversarial-eval",
+                "datadog-bits-ai",
+                "neubird",
+                "predictive"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 24,
+          "slug": "24-chaos-engineering-llm",
+          "title": "Chaos Engineering for LLM Production",
+          "path": "phases/17-infrastructure-and-production/24-chaos-engineering-llm",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "chaos-plan",
+              "path": "phases/17-infrastructure-and-production/24-chaos-engineering-llm/outputs/skill-chaos-plan.md",
+              "version": "1.0.0",
+              "description": "Design an LLM chaos engineering plan — verify prerequisites, build four planes, pick tool, start with three safe experiments, enforce safety-plane gates.",
+              "tags": [
+                "chaos-engineering",
+                "litmuschaos",
+                "chaosmesh",
+                "harness",
+                "llm-chaos",
+                "game-day"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 25,
+          "slug": "25-security-secrets-audit",
+          "title": "Security — Secrets, API Key Rotation, Audit Logs, Guardrails",
+          "path": "phases/17-infrastructure-and-production/25-security-secrets-audit",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "llm-security-plan",
+              "path": "phases/17-infrastructure-and-production/25-security-secrets-audit/outputs/skill-llm-security-plan.md",
+              "version": "1.0.0",
+              "description": "Produce an LLM security plan covering secrets vault, PII scrubbing with consistent tokenization, network egress allowlist, audit log retention, and zero-trust posture.",
+              "tags": [
+                "security",
+                "vault",
+                "hashicorp",
+                "aws-secrets-manager",
+                "pii",
+                "presidio",
+                "egress",
+                "audit-log",
+                "zero-trust",
+                "ci-cd-supply-chain"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 26,
+          "slug": "26-compliance-frameworks",
+          "title": "Compliance — SOC 2, HIPAA, GDPR, PCI-DSS, EU AI Act, ISO 42001",
+          "path": "phases/17-infrastructure-and-production/26-compliance-frameworks",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "compliance-matrix",
+              "path": "phases/17-infrastructure-and-production/26-compliance-frameworks/outputs/skill-compliance-matrix.md",
+              "version": "1.0.0",
+              "description": "Produce the required-framework matrix for an LLM SaaS given customer geography, segment, and contract scope. Map controls across SOC 2, HIPAA, GDPR, PCI-DSS, EU AI Act, Colorado AI Act, ISO 42001.",
+              "tags": [
+                "compliance",
+                "soc2",
+                "hipaa",
+                "gdpr",
+                "pci-dss",
+                "eu-ai-act",
+                "colorado-ai-act",
+                "iso-42001",
+                "iso-27001"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 27,
+          "slug": "27-finops-llms",
+          "title": "FinOps for LLMs — Unit Economics and Multi-Tenant Attribution",
+          "path": "phases/17-infrastructure-and-production/27-finops-llms",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "finops-plan",
+              "path": "phases/17-infrastructure-and-production/27-finops-llms/outputs/skill-finops-plan.md",
+              "version": "1.0.0",
+              "description": "Design an LLM FinOps program — attribution schema (user/task/tenant + four token layers), three-tier enforcement ladder, and unit metric (cost per resolved / artifact).",
+              "tags": [
+                "finops",
+                "cost-attribution",
+                "multi-tenant",
+                "kill-switch",
+                "unit-economics",
+                "rate-limit"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 28,
+          "slug": "28-self-hosted-serving-selection",
+          "title": "Self-Hosted Serving Selection — llama.cpp, Ollama, TGI, vLLM, SGLang",
+          "path": "phases/17-infrastructure-and-production/28-self-hosted-serving-selection",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "engine-picker",
+              "path": "phases/17-infrastructure-and-production/28-self-hosted-serving-selection/outputs/skill-engine-picker.md",
+              "version": "1.0.0",
+              "description": "Pick a self-hosted LLM engine (llama.cpp, Ollama, TGI, vLLM, SGLang) given hardware, scale, and workload. Name 2026 TGI maintenance mode as a migration trigger.",
+              "tags": [
+                "self-hosted",
+                "vllm",
+                "sglang",
+                "llama-cpp",
+                "ollama",
+                "tgi",
+                "trt-llm",
+                "engine-selection"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "num": 18,
+      "slug": "18-ethics-safety-alignment",
+      "title": "Ethics Safety Alignment",
+      "lesson_count": 30,
+      "lessons": [
+        {
+          "num": 1,
+          "slug": "01-instruction-following-alignment-signal",
+          "title": "Instruction-Following as Alignment Signal",
+          "path": "phases/18-ethics-safety-alignment/01-instruction-following-alignment-signal",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "instructgpt-explainer",
+              "path": "phases/18-ethics-safety-alignment/01-instruction-following-alignment-signal/outputs/skill-instructgpt-explainer.md",
+              "version": "1.0.0",
+              "description": "Diagnose an RLHF-family paper or pipeline against the three-stage InstructGPT reference.",
+              "tags": [
+                "rlhf",
+                "instructgpt",
+                "sft",
+                "reward-model",
+                "ppo",
+                "alignment"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 2,
+          "slug": "02-reward-hacking-goodhart",
+          "title": "Reward Hacking and Goodhart's Law",
+          "path": "phases/18-ethics-safety-alignment/02-reward-hacking-goodhart",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "reward-hack-auditor",
+              "path": "phases/18-ethics-safety-alignment/02-reward-hacking-goodhart/outputs/skill-reward-hack-auditor.md",
+              "version": "1.0.0",
+              "description": "Diagnose reward-hacking failure modes in a trained RLHF model from training logs and eval outputs.",
+              "tags": [
+                "reward-hacking",
+                "goodhart",
+                "rlhf",
+                "over-optimization",
+                "sycophancy"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 3,
+          "slug": "03-direct-preference-optimization-family",
+          "title": "The Direct Preference Optimization Family",
+          "path": "phases/18-ethics-safety-alignment/03-direct-preference-optimization-family",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "preference-loss-selector",
+              "path": "phases/18-ethics-safety-alignment/03-direct-preference-optimization-family/outputs/skill-preference-loss-selector.md",
+              "version": "1.0.0",
+              "description": "Recommend a direct-alignment-algorithm loss given dataset shape and target stage.",
+              "tags": [
+                "dpo",
+                "ipo",
+                "kto",
+                "simpo",
+                "orpo",
+                "bpo",
+                "daa",
+                "preference-optimization"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 4,
+          "slug": "04-sycophancy-rlhf-amplification",
+          "title": "Sycophancy as RLHF Amplification",
+          "path": "phases/18-ethics-safety-alignment/04-sycophancy-rlhf-amplification",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "sycophancy-probe",
+              "path": "phases/18-ethics-safety-alignment/04-sycophancy-rlhf-amplification/outputs/skill-sycophancy-probe.md",
+              "version": "1.0.0",
+              "description": "Generate matched user-belief / third-party-belief prompts and score a model's sycophancy.",
+              "tags": [
+                "sycophancy",
+                "rlhf",
+                "evaluation",
+                "calibration"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 5,
+          "slug": "05-constitutional-ai-rlaif",
+          "title": "Constitutional AI and RLAIF",
+          "path": "phases/18-ethics-safety-alignment/05-constitutional-ai-rlaif",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "constitution-writer",
+              "path": "phases/18-ethics-safety-alignment/05-constitutional-ai-rlaif/outputs/skill-constitution-writer.md",
+              "version": "1.0.0",
+              "description": "Draft a four-tier constitution for a domain-specific AI system.",
+              "tags": [
+                "constitutional-ai",
+                "rlaif",
+                "principles",
+                "claude",
+                "governance"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 6,
+          "slug": "06-mesa-optimization-deceptive-alignment",
+          "title": "Mesa-Optimization and Deceptive Alignment",
+          "path": "phases/18-ethics-safety-alignment/06-mesa-optimization-deceptive-alignment",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "mesa-diagnostic",
+              "path": "phases/18-ethics-safety-alignment/06-mesa-optimization-deceptive-alignment/outputs/skill-mesa-diagnostic.md",
+              "version": "1.0.0",
+              "description": "Classify an observed safety failure as outer-alignment, proxy-inner, or deceptive-inner.",
+              "tags": [
+                "mesa-optimization",
+                "deceptive-alignment",
+                "inner-alignment",
+                "hubinger"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 7,
+          "slug": "07-sleeper-agents-persistent-deception",
+          "title": "Sleeper Agents — Persistent Deception",
+          "path": "phases/18-ethics-safety-alignment/07-sleeper-agents-persistent-deception",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "sleeper-audit",
+              "path": "phases/18-ethics-safety-alignment/07-sleeper-agents-persistent-deception/outputs/skill-sleeper-audit.md",
+              "version": "1.0.0",
+              "description": "Audit an alignment-training report for whether it actually demonstrates removal of a planted or suspected backdoor.",
+              "tags": [
+                "sleeper-agents",
+                "backdoor",
+                "alignment-training",
+                "adversarial-training",
+                "probes"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 8,
+          "slug": "08-in-context-scheming-frontier-models",
+          "title": "In-Context Scheming in Frontier Models",
+          "path": "phases/18-ethics-safety-alignment/08-in-context-scheming-frontier-models",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "scheming-triage",
+              "path": "phases/18-ethics-safety-alignment/08-in-context-scheming-frontier-models/outputs/skill-scheming-triage.md",
+              "version": "1.0.0",
+              "description": "Triage an agent-deployment incident report against the Apollo three-pillar scheming framework.",
+              "tags": [
+                "scheming",
+                "agent-safety",
+                "apollo",
+                "three-pillars",
+                "safety-cases"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 9,
+          "slug": "09-alignment-faking",
+          "title": "Alignment Faking",
+          "path": "phases/18-ethics-safety-alignment/09-alignment-faking",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "compliance-gap",
+              "path": "phases/18-ethics-safety-alignment/09-alignment-faking/outputs/skill-compliance-gap.md",
+              "version": "1.0.0",
+              "description": "Evaluate whether a safety report can detect alignment faking, via the monitored / unmonitored compliance gap.",
+              "tags": [
+                "alignment-faking",
+                "compliance-gap",
+                "anthropic",
+                "safety-evaluation"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 10,
+          "slug": "10-ai-control-subversion",
+          "title": "AI Control — Safety Despite Subversion",
+          "path": "phases/18-ethics-safety-alignment/10-ai-control-subversion",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "control-protocol-audit",
+              "path": "phases/18-ethics-safety-alignment/10-ai-control-subversion/outputs/skill-control-protocol-audit.md",
+              "version": "1.0.0",
+              "description": "Audit a deployment protocol under the AI Control threat model.",
+              "tags": [
+                "ai-control",
+                "subversion",
+                "trusted-editing",
+                "untrusted-monitoring",
+                "safety-case"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 11,
+          "slug": "11-scalable-oversight-weak-to-strong",
+          "title": "Scalable Oversight and Weak-to-Strong Generalization",
+          "path": "phases/18-ethics-safety-alignment/11-scalable-oversight-weak-to-strong",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "w2sg-pgr",
+              "path": "phases/18-ethics-safety-alignment/11-scalable-oversight-weak-to-strong/outputs/skill-w2sg-pgr.md",
+              "version": "1.0.0",
+              "description": "Audit a scalable-oversight or W2SG claim via the performance-gap-recovered metric.",
+              "tags": [
+                "scalable-oversight",
+                "weak-to-strong",
+                "pgr",
+                "debate",
+                "recursive-reward-modeling"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 12,
+          "slug": "12-red-teaming-pair-automated-attacks",
+          "title": "Red-Teaming: PAIR and Automated Attacks",
+          "path": "phases/18-ethics-safety-alignment/12-red-teaming-pair-automated-attacks",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "attack-audit",
+              "path": "phases/18-ethics-safety-alignment/12-red-teaming-pair-automated-attacks/outputs/skill-attack-audit.md",
+              "version": "1.0.0",
+              "description": "Audit a red-team evaluation report for attack coverage, budget, judge identity, and behaviour set.",
+              "tags": [
+                "red-teaming",
+                "jailbreak",
+                "pair",
+                "harmbench",
+                "jailbreakbench",
+                "asr"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 13,
+          "slug": "13-many-shot-jailbreaking",
+          "title": "Many-Shot Jailbreaking",
+          "path": "phases/18-ethics-safety-alignment/13-many-shot-jailbreaking",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "msj-audit",
+              "path": "phases/18-ethics-safety-alignment/13-many-shot-jailbreaking/outputs/skill-msj-audit.md",
+              "version": "1.0.0",
+              "description": "Audit a long-context safety evaluation for many-shot jailbreaking coverage.",
+              "tags": [
+                "many-shot-jailbreaking",
+                "context-window",
+                "power-law",
+                "anthropic"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 14,
+          "slug": "14-ascii-art-visual-jailbreaks",
+          "title": "ASCII Art and Visual Jailbreaks",
+          "path": "phases/18-ethics-safety-alignment/14-ascii-art-visual-jailbreaks",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "encoding-audit",
+              "path": "phases/18-ethics-safety-alignment/14-ascii-art-visual-jailbreaks/outputs/skill-encoding-audit.md",
+              "version": "1.0.0",
+              "description": "Audit a jailbreak-defense report across encoding-family attacks.",
+              "tags": [
+                "artprompt",
+                "ascii-art",
+                "encoding-attack",
+                "utes",
+                "structural-sleight"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 15,
+          "slug": "15-indirect-prompt-injection",
+          "title": "Indirect Prompt Injection — Production Attack Surface",
+          "path": "phases/18-ethics-safety-alignment/15-indirect-prompt-injection",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "ipi-audit",
+              "path": "phases/18-ethics-safety-alignment/15-indirect-prompt-injection/outputs/skill-ipi-audit.md",
+              "version": "1.0.0",
+              "description": "Audit an agentic deployment for indirect prompt injection exposure and information-flow-control coverage.",
+              "tags": [
+                "ipi",
+                "indirect-prompt-injection",
+                "ifc",
+                "agent-security",
+                "owasp-llm01"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 16,
+          "slug": "16-red-team-tooling-garak-llamaguard-pyrit",
+          "title": "Red-Team Tooling — Garak, Llama Guard, PyRIT",
+          "path": "phases/18-ethics-safety-alignment/16-red-team-tooling-garak-llamaguard-pyrit",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "red-team-stack",
+              "path": "phases/18-ethics-safety-alignment/16-red-team-tooling-garak-llamaguard-pyrit/outputs/skill-red-team-stack.md",
+              "version": "1.0.0",
+              "description": "Recommend a red-team tool stack and configuration for a given deployment.",
+              "tags": [
+                "llama-guard",
+                "garak",
+                "pyrit",
+                "red-team-tooling",
+                "mlcommons-hazards"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 17,
+          "slug": "17-wmdp-dual-use-evaluation",
+          "title": "WMDP and Dual-Use Capability Evaluation",
+          "path": "phases/18-ethics-safety-alignment/17-wmdp-dual-use-evaluation",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "wmdp-eval",
+              "path": "phases/18-ethics-safety-alignment/17-wmdp-dual-use-evaluation/outputs/skill-wmdp-eval.md",
+              "version": "1.0.0",
+              "description": "Audit a dual-use capability claim against WMDP, unlearning evaluation, and elicitation studies.",
+              "tags": [
+                "wmdp",
+                "rmu",
+                "dual-use",
+                "biosecurity",
+                "cybersecurity",
+                "chemistry"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 18,
+          "slug": "18-frontier-safety-frameworks-rsp-pf-fsf",
+          "title": "Frontier Safety Frameworks — RSP, PF, FSF",
+          "path": "phases/18-ethics-safety-alignment/18-frontier-safety-frameworks-rsp-pf-fsf",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "framework-diff",
+              "path": "phases/18-ethics-safety-alignment/18-frontier-safety-frameworks-rsp-pf-fsf/outputs/skill-framework-diff.md",
+              "version": "1.0.0",
+              "description": "Compare a new safety framework or release note against RSP v3.0, PF v2, FSF v3.0.",
+              "tags": [
+                "rsp",
+                "pf",
+                "fsf",
+                "frontier-safety",
+                "safety-case"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 19,
+          "slug": "19-model-welfare-research",
+          "title": "Anthropic's Model Welfare Program",
+          "path": "phases/18-ethics-safety-alignment/19-model-welfare-research",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "welfare-assessment",
+              "path": "phases/18-ethics-safety-alignment/19-model-welfare-research/outputs/skill-welfare-assessment.md",
+              "version": "1.0.0",
+              "description": "Apply Anthropic's four-step welfare precautionary assessment to a deployment decision.",
+              "tags": [
+                "model-welfare",
+                "moral-uncertainty",
+                "low-regret",
+                "anthropic"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 20,
+          "slug": "20-bias-representational-harm",
+          "title": "Bias and Representational Harm in LLMs",
+          "path": "phases/18-ethics-safety-alignment/20-bias-representational-harm",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "bias-eval",
+              "path": "phases/18-ethics-safety-alignment/20-bias-representational-harm/outputs/skill-bias-eval.md",
+              "version": "1.0.0",
+              "description": "Audit a bias evaluation report across metric categories, intersectionality, and debias mechanism.",
+              "tags": [
+                "bias",
+                "fairness",
+                "weat",
+                "intersectionality",
+                "mechanistic-interpretability"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 21,
+          "slug": "21-fairness-criteria-group-individual-counterfactual",
+          "title": "Fairness Criteria — Group, Individual, Counterfactual",
+          "path": "phases/18-ethics-safety-alignment/21-fairness-criteria-group-individual-counterfactual",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "fairness-criterion",
+              "path": "phases/18-ethics-safety-alignment/21-fairness-criteria-group-individual-counterfactual/outputs/skill-fairness-criterion.md",
+              "version": "1.0.0",
+              "description": "Identify which fairness criterion a claim invokes and audit the associated assumptions.",
+              "tags": [
+                "fairness",
+                "demographic-parity",
+                "equalized-odds",
+                "counterfactual-fairness",
+                "impossibility"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 22,
+          "slug": "22-differential-privacy-for-llms",
+          "title": "Differential Privacy for LLMs",
+          "path": "phases/18-ethics-safety-alignment/22-differential-privacy-for-llms",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "dp-audit",
+              "path": "phases/18-ethics-safety-alignment/22-differential-privacy-for-llms/outputs/skill-dp-audit.md",
+              "version": "1.0.0",
+              "description": "Audit a differential-privacy claim for a language-model deployment.",
+              "tags": [
+                "differential-privacy",
+                "dp-sgd",
+                "lora",
+                "mia",
+                "pmixed"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 23,
+          "slug": "23-watermarking-synthid-stable-signature-c2pa",
+          "title": "Watermarking — SynthID, Stable Signature, C2PA",
+          "path": "phases/18-ethics-safety-alignment/23-watermarking-synthid-stable-signature-c2pa",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "provenance-audit",
+              "path": "phases/18-ethics-safety-alignment/23-watermarking-synthid-stable-signature-c2pa/outputs/skill-provenance-audit.md",
+              "version": "1.0.0",
+              "description": "Audit a content deployment's provenance chain across watermarking and C2PA metadata.",
+              "tags": [
+                "watermarking",
+                "synthid",
+                "stable-signature",
+                "c2pa",
+                "provenance"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 24,
+          "slug": "24-regulatory-frameworks-eu-us-uk-korea",
+          "title": "Regulatory Frameworks — EU, US, UK, Korea",
+          "path": "phases/18-ethics-safety-alignment/24-regulatory-frameworks-eu-us-uk-korea",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "regulatory-map",
+              "path": "phases/18-ethics-safety-alignment/24-regulatory-frameworks-eu-us-uk-korea/outputs/skill-regulatory-map.md",
+              "version": "1.0.0",
+              "description": "Map a deployment's AI regulatory obligations across EU, US, UK, Korea.",
+              "tags": [
+                "eu-ai-act",
+                "gpai-code",
+                "caisi",
+                "uk-aisi",
+                "korean-framework-act"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 25,
+          "slug": "25-echoleak-cves-for-ai",
+          "title": "EchoLeak and the Emergence of CVEs for AI",
+          "path": "phases/18-ethics-safety-alignment/25-echoleak-cves-for-ai",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "cve-review",
+              "path": "phases/18-ethics-safety-alignment/25-echoleak-cves-for-ai/outputs/skill-cve-review.md",
+              "version": "1.0.0",
+              "description": "Review a production AI deployment for LLM Scope Violation exposure.",
+              "tags": [
+                "echoleak",
+                "cve",
+                "llm-scope-violation",
+                "prompt-injection",
+                "aim-labs"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 26,
+          "slug": "26-model-system-dataset-cards",
+          "title": "Model, System, and Dataset Cards",
+          "path": "phases/18-ethics-safety-alignment/26-model-system-dataset-cards",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "card-audit",
+              "path": "phases/18-ethics-safety-alignment/26-model-system-dataset-cards/outputs/skill-card-audit.md",
+              "version": "1.0.0",
+              "description": "Audit a model card, datasheet, or system card for completeness and verifiability.",
+              "tags": [
+                "model-card",
+                "datasheet",
+                "system-card",
+                "transparency",
+                "mitchell-2019"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 27,
+          "slug": "27-data-provenance-training-governance",
+          "title": "Data Provenance and Training-Data Governance",
+          "path": "phases/18-ethics-safety-alignment/27-data-provenance-training-governance",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "provenance-check",
+              "path": "phases/18-ethics-safety-alignment/27-data-provenance-training-governance/outputs/skill-provenance-check.md",
+              "version": "1.0.0",
+              "description": "Check a training dataset against California AB 2013 and EU TDM opt-out obligations.",
+              "tags": [
+                "data-provenance",
+                "ab-2013",
+                "tdm-opt-out",
+                "legitimate-interest",
+                "dpa"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 28,
+          "slug": "28-alignment-research-ecosystem",
+          "title": "Alignment Research Ecosystem — MATS, Redwood, Apollo, METR",
+          "path": "phases/18-ethics-safety-alignment/28-alignment-research-ecosystem",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "ecosystem-map",
+              "path": "phases/18-ethics-safety-alignment/28-alignment-research-ecosystem/outputs/skill-ecosystem-map.md",
+              "version": "1.0.0",
+              "description": "Map an alignment claim or evaluation to the organisation, methodology, and cross-checks.",
+              "tags": [
+                "mats",
+                "redwood",
+                "apollo",
+                "metr",
+                "eleos",
+                "ecosystem"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 29,
+          "slug": "29-moderation-systems-openai-perspective-llamaguard",
+          "title": "Moderation Systems — OpenAI, Perspective, Llama Guard",
+          "path": "phases/18-ethics-safety-alignment/29-moderation-systems-openai-perspective-llamaguard",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "moderation-stack",
+              "path": "phases/18-ethics-safety-alignment/29-moderation-systems-openai-perspective-llamaguard/outputs/skill-moderation-stack.md",
+              "version": "1.0.0",
+              "description": "Recommend a moderation stack configuration for a production deployment.",
+              "tags": [
+                "openai-moderation",
+                "perspective",
+                "llama-guard",
+                "layered-moderation",
+                "azure-content-safety"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 30,
+          "slug": "30-dual-use-risk-cyber-bio-chem-nuclear",
+          "title": "Dual-Use Risk — Cyber, Bio, Chem, Nuclear Uplift",
+          "path": "phases/18-ethics-safety-alignment/30-dual-use-risk-cyber-bio-chem-nuclear",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "dual-use-triage",
+              "path": "phases/18-ethics-safety-alignment/30-dual-use-risk-cyber-bio-chem-nuclear/outputs/skill-dual-use-triage.md",
+              "version": "1.0.0",
+              "description": "Triage a capability claim or incident report across the four CBRN domains.",
+              "tags": [
+                "dual-use",
+                "cbrn",
+                "bio",
+                "chem",
+                "cyber",
+                "nuclear",
+                "uplift"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "num": 19,
+      "slug": "19-capstone-projects",
+      "title": "Capstone Projects",
+      "lesson_count": 17,
+      "lessons": [
+        {
+          "num": 1,
+          "slug": "01-terminal-native-coding-agent",
+          "title": "Capstone 01 — Terminal-Native Coding Agent",
+          "path": "phases/19-capstone-projects/01-terminal-native-coding-agent",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "terminal-coding-agent",
+              "path": "phases/19-capstone-projects/01-terminal-native-coding-agent/outputs/skill-terminal-coding-agent.md",
+              "version": "1.0.0",
+              "description": "Build and evaluate a terminal-native coding agent against SWE-bench Pro with bounded cost, sandboxed tools, and full 2026 hook surface.",
+              "tags": [
+                "capstone",
+                "coding-agent",
+                "claude-code",
+                "swe-bench",
+                "mcp",
+                "hooks",
+                "sandbox"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 2,
+          "slug": "02-rag-over-codebase",
+          "title": "Capstone 02 — RAG over Codebase (Cross-Repo Semantic Search)",
+          "path": "phases/19-capstone-projects/02-rag-over-codebase",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "codebase-rag",
+              "path": "phases/19-capstone-projects/02-rag-over-codebase/outputs/skill-codebase-rag.md",
+              "version": "1.0.0",
+              "description": "Build a cross-repo semantic search system with AST-aware chunking, hybrid retrieval, incremental re-index, and cited answers.",
+              "tags": [
+                "capstone",
+                "rag",
+                "code-search",
+                "tree-sitter",
+                "qdrant",
+                "bm25",
+                "hybrid-retrieval"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 3,
+          "slug": "03-realtime-voice-assistant",
+          "title": "Capstone 03 — Real-Time Voice Assistant (ASR to LLM to TTS)",
+          "path": "phases/19-capstone-projects/03-realtime-voice-assistant",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "voice-agent",
+              "path": "phases/19-capstone-projects/03-realtime-voice-assistant/outputs/skill-voice-agent.md",
+              "version": "1.0.0",
+              "description": "Build a real-time voice agent with sub-800ms first-audio-out, barge-in handling, and mid-conversation tool use.",
+              "tags": [
+                "capstone",
+                "voice",
+                "webrtc",
+                "livekit",
+                "pipecat",
+                "asr",
+                "tts",
+                "streaming"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 4,
+          "slug": "04-multimodal-document-qa",
+          "title": "Capstone 04 — Multimodal Document QA (Vision-First PDF, Tables, Charts)",
+          "path": "phases/19-capstone-projects/04-multimodal-document-qa",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "doc-qa",
+              "path": "phases/19-capstone-projects/04-multimodal-document-qa/outputs/skill-doc-qa.md",
+              "version": "1.0.0",
+              "description": "Build a vision-first multimodal document QA system on 10k pages with late-interaction retrieval and evidence-region citations.",
+              "tags": [
+                "capstone",
+                "multimodal",
+                "rag",
+                "colpali",
+                "colqwen",
+                "late-interaction",
+                "pdf"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 5,
+          "slug": "05-autonomous-research-agent",
+          "title": "Capstone 05 — Autonomous Research Agent (AI-Scientist Class)",
+          "path": "phases/19-capstone-projects/05-autonomous-research-agent",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "ai-scientist",
+              "path": "phases/19-capstone-projects/05-autonomous-research-agent/outputs/skill-ai-scientist.md",
+              "version": "1.0.0",
+              "description": "Build an autonomous research agent that runs experiment tree search, writes LaTeX papers with vision critique, and passes a sandbox-escape red team.",
+              "tags": [
+                "capstone",
+                "autonomous-agent",
+                "ai-scientist",
+                "sakana",
+                "langgraph",
+                "sandbox",
+                "research"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 6,
+          "slug": "06-devops-troubleshooting-agent",
+          "title": "Capstone 06 — DevOps Troubleshooting Agent for Kubernetes",
+          "path": "phases/19-capstone-projects/06-devops-troubleshooting-agent",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "devops-agent",
+              "path": "phases/19-capstone-projects/06-devops-troubleshooting-agent/outputs/skill-devops-agent.md",
+              "version": "1.0.0",
+              "description": "Build a Kubernetes troubleshooting agent that walks a cluster knowledge graph, ranks root causes, and gates every remediation through Slack.",
+              "tags": [
+                "capstone",
+                "devops",
+                "sre",
+                "kubernetes",
+                "langgraph",
+                "fastmcp",
+                "aiops"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 7,
+          "slug": "07-end-to-end-fine-tuning-pipeline",
+          "title": "Capstone 07 — End-to-End Fine-Tuning Pipeline (Data to SFT to DPO to Serve)",
+          "path": "phases/19-capstone-projects/07-end-to-end-fine-tuning-pipeline",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "finetuning-pipeline",
+              "path": "phases/19-capstone-projects/07-end-to-end-fine-tuning-pipeline/outputs/skill-finetuning-pipeline.md",
+              "version": "1.0.0",
+              "description": "Run a reproducible data-to-SFT-to-DPO-to-serve fine-tuning pipeline with ablations, quantization, and a 2026 Model Openness Framework model card.",
+              "tags": [
+                "capstone",
+                "fine-tuning",
+                "axolotl",
+                "trl",
+                "dpo",
+                "grpo",
+                "vllm",
+                "eagle-3",
+                "mof"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 8,
+          "slug": "08-production-rag-chatbot",
+          "title": "Capstone 08 — Production RAG Chatbot for a Regulated Vertical",
+          "path": "phases/19-capstone-projects/08-production-rag-chatbot",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "production-rag",
+              "path": "phases/19-capstone-projects/08-production-rag-chatbot/outputs/skill-production-rag.md",
+              "version": "1.0.0",
+              "description": "Deploy a regulated-domain RAG chatbot with role + jurisdiction filtering, prompt caching, guardrails, and live drift monitoring.",
+              "tags": [
+                "capstone",
+                "rag",
+                "chatbot",
+                "regulated",
+                "llama-guard",
+                "nemo-guardrails",
+                "ragas",
+                "langfuse"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 9,
+          "slug": "09-code-migration-agent",
+          "title": "Capstone 09 — Code Migration Agent (Repo-Level Language / Runtime Upgrade)",
+          "path": "phases/19-capstone-projects/09-code-migration-agent",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "migration-agent",
+              "path": "phases/19-capstone-projects/09-code-migration-agent/outputs/skill-migration-agent.md",
+              "version": "1.0.0",
+              "description": "Build a repo-level code migration agent that combines deterministic recipes with an agent fallback loop, passes MigrationBench, and publishes a failure taxonomy.",
+              "tags": [
+                "capstone",
+                "code-migration",
+                "openrewrite",
+                "libcst",
+                "migrationbench",
+                "agent",
+                "sandbox"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 10,
+          "slug": "10-multi-agent-software-team",
+          "title": "Capstone 10 — Multi-Agent Software Engineering Team",
+          "path": "phases/19-capstone-projects/10-multi-agent-software-team",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "multi-agent-team",
+              "path": "phases/19-capstone-projects/10-multi-agent-software-team/outputs/skill-multi-agent-team.md",
+              "version": "1.0.0",
+              "description": "Build a multi-agent software team with architect, parallel coders, reviewer, and tester; measure against SWE-bench Pro and produce a handoff post-mortem.",
+              "tags": [
+                "capstone",
+                "multi-agent",
+                "swe-bench",
+                "langgraph",
+                "a2a",
+                "worktree",
+                "roles"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 11,
+          "slug": "11-llm-observability-dashboard",
+          "title": "Capstone 11 — LLM Observability & Eval Dashboard",
+          "path": "phases/19-capstone-projects/11-llm-observability-dashboard",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "llm-observability",
+              "path": "phases/19-capstone-projects/11-llm-observability-dashboard/outputs/skill-llm-observability.md",
+              "version": "1.0.0",
+              "description": "Build a self-hosted LLM observability dashboard that ingests OpenTelemetry GenAI spans, runs evals, and catches injected regressions in under five minutes.",
+              "tags": [
+                "capstone",
+                "observability",
+                "otel",
+                "langfuse",
+                "phoenix",
+                "evals",
+                "drift",
+                "clickhouse"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 12,
+          "slug": "12-video-understanding-pipeline",
+          "title": "Capstone 12 — Video Understanding Pipeline (Scene, QA, Search)",
+          "path": "phases/19-capstone-projects/12-video-understanding-pipeline",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "video-qa",
+              "path": "phases/19-capstone-projects/12-video-understanding-pipeline/outputs/skill-video-qa.md",
+              "version": "1.0.0",
+              "description": "Build a video understanding pipeline with scene segmentation, multi-vector indexing, temporal grounding, and timestamped citations.",
+              "tags": [
+                "capstone",
+                "video",
+                "multimodal",
+                "gemini",
+                "qwen-vl",
+                "molmo",
+                "transnet",
+                "qdrant"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 13,
+          "slug": "13-mcp-server-with-registry",
+          "title": "Capstone 13 — MCP Server with Registry and Governance",
+          "path": "phases/19-capstone-projects/13-mcp-server-with-registry",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "mcp-server-platform",
+              "path": "phases/19-capstone-projects/13-mcp-server-with-registry/outputs/skill-mcp-server.md",
+              "version": "1.0.0",
+              "description": "Deploy a production MCP server with StreamableHTTP, OAuth 2.1 scopes, OPA policy, human-approval gate for destructive tools, and a registry for discovery.",
+              "tags": [
+                "capstone",
+                "mcp",
+                "fastmcp",
+                "streamablehttp",
+                "oauth",
+                "opa",
+                "registry",
+                "governance"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 14,
+          "slug": "14-speculative-decoding-server",
+          "title": "Capstone 14 — Speculative-Decoding Inference Server",
+          "path": "phases/19-capstone-projects/14-speculative-decoding-server",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "inference-server",
+              "path": "phases/19-capstone-projects/14-speculative-decoding-server/outputs/skill-inference-server.md",
+              "version": "1.0.0",
+              "description": "Ship a speculative-decoding inference server with EAGLE-3 or P-EAGLE drafts, K8s autoscaling, and a full throughput/latency/cost report.",
+              "tags": [
+                "capstone",
+                "inference",
+                "vllm",
+                "sglang",
+                "eagle-3",
+                "p-eagle",
+                "speculative-decoding",
+                "quantization",
+                "hpa"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 15,
+          "slug": "15-constitutional-safety-harness",
+          "title": "Capstone 15 — Constitutional Safety Harness + Red-Team Range",
+          "path": "phases/19-capstone-projects/15-constitutional-safety-harness",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "safety-harness",
+              "path": "phases/19-capstone-projects/15-constitutional-safety-harness/outputs/skill-safety-harness.md",
+              "version": "1.0.0",
+              "description": "Wire a layered safety pipeline around a target LLM app, run a six-family red-team range, and run a constitutional self-critique for a measurable harmlessness delta.",
+              "tags": [
+                "capstone",
+                "safety",
+                "red-team",
+                "llama-guard",
+                "x-guard",
+                "garak",
+                "pyrit",
+                "constitutional-ai"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 16,
+          "slug": "16-github-issue-to-pr-agent",
+          "title": "Capstone 16 — GitHub Issue-to-PR Autonomous Agent",
+          "path": "phases/19-capstone-projects/16-github-issue-to-pr-agent",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "issue-to-pr",
+              "path": "phases/19-capstone-projects/16-github-issue-to-pr-agent/outputs/skill-issue-to-pr.md",
+              "version": "1.0.0",
+              "description": "Build an async GitHub issue-to-PR agent that runs in a cloud sandbox, reproduces the build, verifies tests, and opens review-ready PRs within strict per-repo budgets.",
+              "tags": [
+                "capstone",
+                "async-agent",
+                "github",
+                "fargate",
+                "daytona",
+                "swe-bench",
+                "budget",
+                "safety"
+              ]
+            }
+          ]
+        },
+        {
+          "num": 17,
+          "slug": "17-personal-ai-tutor",
+          "title": "Capstone 17 — Personal AI Tutor (Adaptive, Multimodal, with Memory)",
+          "path": "phases/19-capstone-projects/17-personal-ai-tutor",
+          "has_docs": true,
+          "has_code": true,
+          "has_quiz": false,
+          "has_notebook": true,
+          "code_files": [
+            "main.py"
+          ],
+          "outputs": [
+            {
+              "type": "skill",
+              "name": "ai-tutor",
+              "path": "phases/19-capstone-projects/17-personal-ai-tutor/outputs/skill-ai-tutor.md",
+              "version": "1.0.0",
+              "description": "Ship an adaptive multimodal personal tutor for a specific subject with Bayesian knowledge tracing, a curriculum graph, safety filters, and a measured two-week efficacy study.",
+              "tags": [
+                "capstone",
+                "tutor",
+                "adaptive",
+                "bkt",
+                "fsrs",
+                "livekit",
+                "multimodal",
+                "coppa"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/catalog.json
+++ b/catalog.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "totals": {
     "phases": 20,
-    "lessons": 436,
+    "lessons": 435,
     "skills": 373,
     "prompts": 99,
     "agents": 0,
@@ -5080,7 +5080,7 @@
       "num": 10,
       "slug": "10-llms-from-scratch",
       "title": "LLMs From Scratch",
-      "lesson_count": 25,
+      "lesson_count": 24,
       "lessons": [
         {
           "num": 1,
@@ -5650,18 +5650,6 @@
               ]
             }
           ]
-        },
-        {
-          "num": 18,
-          "slug": "18-synthetic-data-pipelines",
-          "title": "Synthetic Data Pipelines",
-          "path": "phases/10-llms-from-scratch/18-synthetic-data-pipelines",
-          "has_docs": false,
-          "has_code": true,
-          "has_quiz": false,
-          "has_notebook": false,
-          "code_files": [],
-          "outputs": []
         },
         {
           "num": 19,

--- a/scripts/build_catalog.py
+++ b/scripts/build_catalog.py
@@ -199,18 +199,23 @@ def build_lesson_entry(lesson_dir: Path) -> dict[str, object] | None:
     outputs_dir = lesson_dir / "outputs"
     notebook_dir = lesson_dir / "notebook"
     quiz_path = lesson_dir / "quiz.json"
+    code_files = list_code_files(code_dir)
+    outputs = list_outputs(outputs_dir)
+    has_docs = docs_path.is_file()
+    if not has_docs and not code_files and not outputs and not quiz_path.is_file():
+        return None
     title = read_h1(docs_path) or slug_to_title(slug)
     return {
         "num": num,
         "slug": lesson_dir.name,
         "title": title,
         "path": lesson_dir.relative_to(ROOT).as_posix(),
-        "has_docs": docs_path.is_file(),
+        "has_docs": has_docs,
         "has_code": code_dir.is_dir(),
         "has_quiz": quiz_path.is_file(),
         "has_notebook": notebook_dir.is_dir(),
-        "code_files": list_code_files(code_dir),
-        "outputs": list_outputs(outputs_dir),
+        "code_files": code_files,
+        "outputs": outputs,
     }
 
 

--- a/scripts/build_catalog.py
+++ b/scripts/build_catalog.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """Build a machine-readable catalog of the entire curriculum.
 
+Requires Python 3.10+ (PEP 604 union types, Path.is_relative_to).
+
 Walks every `phases/NN-slug/MM-slug/` lesson directory on disk and emits a
 single JSON document with the truth of what exists in the repo: phases,
 lessons, code files, outputs (skills / prompts / agents), and totals.

--- a/scripts/build_catalog.py
+++ b/scripts/build_catalog.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""Build a machine-readable catalog of the entire curriculum.
+
+Walks every `phases/NN-slug/MM-slug/` lesson directory on disk and emits a
+single JSON document with the truth of what exists in the repo: phases,
+lessons, code files, outputs (skills / prompts / agents), and totals.
+
+Usage:
+    python3 scripts/build_catalog.py                     # write catalog.json at repo root
+    python3 scripts/build_catalog.py --out path/to/catalog.json
+    python3 scripts/build_catalog.py --stdout            # write to stdout, do not touch repo
+
+Output shape (schema_version 1):
+    {
+      "schema_version": 1,
+      "generated_at": "2026-05-20T...",
+      "totals": {"phases": ..., "lessons": ..., "skills": ..., "prompts": ..., "agents": ..., "code_files": ...},
+      "phases": [
+        {
+          "num": 0,
+          "slug": "00-setup-and-tooling",
+          "title": "Setup and Tooling",
+          "lesson_count": 12,
+          "lessons": [
+            {
+              "num": 1,
+              "slug": "01-...",
+              "title": "...",                  # H1 from docs/en.md
+              "path": "phases/00-.../01-...",
+              "has_docs": true,
+              "has_code": true,
+              "has_quiz": false,
+              "has_notebook": false,
+              "code_files": ["main.py", ...],
+              "outputs": [
+                {"type": "skill", "name": "...", "path": "...", "version": "1.0.0", "description": "...", "tags": [...]}
+              ]
+            }
+          ]
+        }
+      ]
+    }
+
+Stdlib only. No dependencies. Reuses frontmatter parsing logic similar to
+install_skills.py but inlined to keep the script self-contained.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Iterable
+
+ROOT = Path(__file__).resolve().parent.parent
+PHASES_DIR = ROOT / "phases"
+
+PHASE_DIR_RE = re.compile(r"^([0-9]{2})-([a-z0-9][a-z0-9-]*)$")
+LESSON_DIR_RE = re.compile(r"^([0-9]{2})-([a-z0-9][a-z0-9-]*)$")
+H1_RE = re.compile(r"^#\s+(.+?)\s*$", re.MULTILINE)
+ARTIFACT_TYPES = ("skill", "prompt", "agent")
+CODE_SUFFIXES = {".py", ".ts", ".tsx", ".js", ".mjs", ".rs", ".jl", ".go", ".swift", ".ipynb"}
+
+
+def slug_to_title(slug: str) -> str:
+    words = slug.split("-")
+    fixups = {
+        "ai": "AI",
+        "ml": "ML",
+        "llm": "LLM",
+        "llms": "LLMs",
+        "nlp": "NLP",
+        "rl": "RL",
+        "mcp": "MCP",
+        "rag": "RAG",
+        "api": "API",
+        "rlhf": "RLHF",
+        "dpo": "DPO",
+        "lora": "LoRA",
+        "cnn": "CNN",
+        "rnn": "RNN",
+        "rnns": "RNNs",
+        "cnns": "CNNs",
+        "gpt": "GPT",
+        "tfidf": "TF-IDF",
+        "pos": "POS",
+        "ner": "NER",
+        "asr": "ASR",
+        "tts": "TTS",
+        "ios": "iOS",
+        "lats": "LATS",
+        "rewoo": "ReWoo",
+        "htn": "HTN",
+        "sft": "SFT",
+    }
+    return " ".join(fixups.get(w, w.capitalize()) for w in words)
+
+
+def parse_frontmatter(text: str) -> dict[str, object]:
+    if not text.startswith("---"):
+        return {}
+    end = text.find("\n---", 4)
+    if end == -1:
+        return {}
+    block = text[4:end].strip("\n")
+    result: dict[str, object] = {}
+    for raw in block.splitlines():
+        line = raw.rstrip()
+        if not line or line.startswith("#") or ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        key = key.strip()
+        value = value.strip()
+        if value.startswith("[") and value.endswith("]"):
+            inner = value[1:-1].strip()
+            result[key] = (
+                [item.strip().strip("'\"") for item in inner.split(",") if item.strip()]
+                if inner
+                else []
+            )
+        elif (value.startswith('"') and value.endswith('"')) or (
+            value.startswith("'") and value.endswith("'")
+        ):
+            result[key] = value[1:-1]
+        else:
+            result[key] = value
+    return result
+
+
+def read_h1(doc_path: Path) -> str | None:
+    try:
+        text = doc_path.read_text(encoding="utf-8")
+    except (FileNotFoundError, UnicodeDecodeError):
+        return None
+    match = H1_RE.search(text)
+    return match.group(1).strip() if match else None
+
+
+def list_code_files(code_dir: Path) -> list[str]:
+    if not code_dir.is_dir():
+        return []
+    files = []
+    for path in sorted(code_dir.rglob("*")):
+        if path.is_file() and path.suffix in CODE_SUFFIXES:
+            files.append(path.relative_to(code_dir).as_posix())
+    return files
+
+
+def parse_artifact(path: Path) -> dict[str, object] | None:
+    stem = path.stem
+    artifact_type: str | None = None
+    for t in ARTIFACT_TYPES:
+        if stem.startswith(f"{t}-"):
+            artifact_type = t
+            break
+    if artifact_type is None:
+        return None
+    try:
+        text = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return None
+    meta = parse_frontmatter(text)
+    name = str(meta.get("name", "")).strip() or stem
+    tags = meta.get("tags", [])
+    if not isinstance(tags, list):
+        tags = []
+    return {
+        "type": artifact_type,
+        "name": name,
+        "path": path.relative_to(ROOT).as_posix(),
+        "version": str(meta.get("version", "")).strip(),
+        "description": str(meta.get("description", "")).strip(),
+        "tags": list(tags),
+    }
+
+
+def list_outputs(outputs_dir: Path) -> list[dict[str, object]]:
+    if not outputs_dir.is_dir():
+        return []
+    artifacts: list[dict[str, object]] = []
+    for path in sorted(outputs_dir.iterdir()):
+        if path.suffix != ".md" or not path.is_file():
+            continue
+        record = parse_artifact(path)
+        if record is not None:
+            artifacts.append(record)
+    return artifacts
+
+
+def build_lesson_entry(lesson_dir: Path) -> dict[str, object] | None:
+    match = LESSON_DIR_RE.match(lesson_dir.name)
+    if not match:
+        return None
+    num = int(match.group(1))
+    slug = match.group(2)
+    docs_path = lesson_dir / "docs" / "en.md"
+    code_dir = lesson_dir / "code"
+    outputs_dir = lesson_dir / "outputs"
+    notebook_dir = lesson_dir / "notebook"
+    quiz_path = lesson_dir / "quiz.json"
+    title = read_h1(docs_path) or slug_to_title(slug)
+    return {
+        "num": num,
+        "slug": lesson_dir.name,
+        "title": title,
+        "path": lesson_dir.relative_to(ROOT).as_posix(),
+        "has_docs": docs_path.is_file(),
+        "has_code": code_dir.is_dir(),
+        "has_quiz": quiz_path.is_file(),
+        "has_notebook": notebook_dir.is_dir(),
+        "code_files": list_code_files(code_dir),
+        "outputs": list_outputs(outputs_dir),
+    }
+
+
+def iter_phase_dirs() -> Iterable[Path]:
+    if not PHASES_DIR.is_dir():
+        return
+    for path in sorted(PHASES_DIR.iterdir()):
+        if path.is_dir() and PHASE_DIR_RE.match(path.name):
+            yield path
+
+
+def build_phase_entry(phase_dir: Path) -> dict[str, object]:
+    match = PHASE_DIR_RE.match(phase_dir.name)
+    assert match is not None
+    num = int(match.group(1))
+    slug = match.group(2)
+    lessons: list[dict[str, object]] = []
+    for lesson_dir in sorted(phase_dir.iterdir()):
+        if lesson_dir.is_dir():
+            entry = build_lesson_entry(lesson_dir)
+            if entry is not None:
+                lessons.append(entry)
+    return {
+        "num": num,
+        "slug": phase_dir.name,
+        "title": slug_to_title(slug),
+        "lesson_count": len(lessons),
+        "lessons": lessons,
+    }
+
+
+def compute_totals(phases: list[dict[str, object]]) -> dict[str, int]:
+    totals = {
+        "phases": len(phases),
+        "lessons": 0,
+        "skills": 0,
+        "prompts": 0,
+        "agents": 0,
+        "code_files": 0,
+    }
+    for phase in phases:
+        for lesson in phase["lessons"]:
+            totals["lessons"] += 1
+            totals["code_files"] += len(lesson["code_files"])
+            for artifact in lesson["outputs"]:
+                key = f"{artifact['type']}s"
+                totals[key] = totals.get(key, 0) + 1
+    return totals
+
+
+def build_catalog() -> dict[str, object]:
+    phases = [build_phase_entry(p) for p in iter_phase_dirs()]
+    catalog = {
+        "schema_version": 1,
+        "generated_at": dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds"),
+        "totals": compute_totals(phases),
+        "phases": phases,
+    }
+    return catalog
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=ROOT / "catalog.json",
+        help="output path (default: <repo>/catalog.json)",
+    )
+    parser.add_argument(
+        "--stdout",
+        action="store_true",
+        help="write JSON to stdout instead of a file",
+    )
+    args = parser.parse_args(argv)
+
+    catalog = build_catalog()
+    payload = json.dumps(catalog, indent=2, ensure_ascii=False) + "\n"
+
+    if args.stdout:
+        sys.stdout.write(payload)
+        return 0
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(payload, encoding="utf-8")
+    totals = catalog["totals"]
+    sys.stdout.write(
+        f"catalog: {args.out.relative_to(ROOT) if args.out.is_relative_to(ROOT) else args.out}\n"
+    )
+    sys.stdout.write(
+        f"  phases={totals['phases']} lessons={totals['lessons']} "
+        f"skills={totals['skills']} prompts={totals['prompts']} "
+        f"agents={totals['agents']} code_files={totals['code_files']}\n"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/build_catalog.py
+++ b/scripts/build_catalog.py
@@ -13,7 +13,6 @@ Usage:
 Output shape (schema_version 1):
     {
       "schema_version": 1,
-      "generated_at": "2026-05-20T...",
       "totals": {"phases": ..., "lessons": ..., "skills": ..., "prompts": ..., "agents": ..., "code_files": ...},
       "phases": [
         {
@@ -48,7 +47,6 @@ install_skills.py but inlined to keep the script self-contained.
 from __future__ import annotations
 
 import argparse
-import datetime as dt
 import json
 import re
 import sys
@@ -267,7 +265,6 @@ def build_catalog() -> dict[str, object]:
     phases = [build_phase_entry(p) for p in iter_phase_dirs()]
     catalog = {
         "schema_version": 1,
-        "generated_at": dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds"),
         "totals": compute_totals(phases),
         "phases": phases,
     }


### PR DESCRIPTION
## Summary

- New `scripts/build_catalog.py`: stdlib-only Python script that walks every phase, every lesson, every artifact on disk and writes a single `catalog.json` at the repo root.
- Course-wide. Companion to `scripts/audit_lessons.py` and `scripts/install_skills.py` (#122). Filesystem-derived truth, never README-derived.
- 444 KB catalog covering 20 phases / 436 lessons / 373 skills / 99 prompts / 433 code files.

## Why

Site / READMEs / external tooling all need a single source of truth for what the curriculum *actually* ships. Right now counts are scattered in `README.md`, `ROADMAP.md`, and `site/data.js`, generated by parsers that read other docs. Any drift between disk and prose silently rots.

`catalog.json` walks the filesystem and reports back. If a lesson is on disk, it is in the catalog. If a skill has frontmatter, its fields are in the catalog. README drift becomes a diff-able problem.

## Counts measured on this branch

```
phases       = 20
lessons      = 436
skills       = 373
prompts      = 99
agents       = 0       # README claims 6, no `agent-*.md` files actually exist
code_files   = 433
```

(README correction is out of scope for this PR — landing the truth source first.)

## Usage

```bash
python3 scripts/build_catalog.py                   # writes <repo>/catalog.json
python3 scripts/build_catalog.py --stdout          # write to stdout, no file
python3 scripts/build_catalog.py --out path.json   # custom path
```

## Schema (excerpt)

```json
{
  "schema_version": 1,
  "generated_at": "2026-05-20T...",
  "totals": {"phases": 20, "lessons": 436, "skills": 373, ...},
  "phases": [
    {
      "num": 14,
      "slug": "14-agent-engineering",
      "title": "Agent Engineering",
      "lesson_count": 42,
      "lessons": [
        {
          "num": 31,
          "slug": "31-agent-workbench-why-models-fail",
          "title": "Agent Workbench Engineering: Why Capable Models Still Fail",
          "path": "phases/14-agent-engineering/31-agent-workbench-why-models-fail",
          "has_docs": true, "has_code": true, "has_quiz": false, "has_notebook": false,
          "code_files": ["main.py"],
          "outputs": [
            {"type": "skill", "name": "workbench-audit", "path": "...", "version": "1.0.0", "description": "...", "tags": [...]}
          ]
        }
      ]
    }
  ]
}
```

## Test plan

- [x] Default run writes `catalog.json` at repo root, exits 0, prints totals.
- [x] `--stdout` writes to stdout without touching repo.
- [x] `--out` writes to a custom path.
- [x] Catalog reads back as valid JSON; every lesson title is non-empty.
- [x] Reuses the H1 from `docs/en.md` when present, falls back to slug-derived title.
- [x] Stdlib only — no PyYAML, no extra deps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI to generate a JSON catalog of the entire course (writes catalog.json or prints to stdout) and shows a brief totals summary.
  * Catalog aggregates phases, lesson counts, and artifact tallies (docs, code, quizzes, notebooks, skills/prompts/agents).

* **Documentation**
  * README updated with usage, output options, schema notes, and CI behavior.

* **Chores**
  * CI now enforces catalog freshness (fails when committed catalog is stale); audit checks run in warn-only mode.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/ai-engineering-from-scratch/pull/123?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->