### PR TITLE
docs(readme): add skillkit and pro-workflow to From the same author

### DIFF
--- a/README.md
+++ b/README.md
@@ -1037,14 +1037,17 @@ Sign up via [GitHub Sponsors](https://github.com/sponsors/rohitg00).
 
 ## From the same author
 
-The curriculum teaches the primitives. These three repositories ship them in production —
-memory, reasoning, and a knowledge-base protocol — and compose into a full agent stack.
+The curriculum teaches the primitives. These repositories ship them in production:
+memory, reasoning, knowledge protocol, agent-skill toolchain, and an agent-workflow
+patterns library.
 
 | Repo | Stars | What it is |
 |---|---|---|
 | [agentmemory](https://github.com/rohitg00/agentmemory) | ![stars](https://img.shields.io/github/stars/rohitg00/agentmemory?style=flat-square&label=%E2%98%85&color=3553ff&labelColor=fafaf5) | Persistent memory for AI coding agents. The state surface from Phase 14, productionized. |
 | [agentbrain](https://github.com/rohitg00/agentbrain) | ![stars](https://img.shields.io/github/stars/rohitg00/agentbrain?style=flat-square&label=%E2%98%85&color=3553ff&labelColor=fafaf5) | Evidence-first operating system for agents. Reasoning + verification surfaces, end-to-end. |
 | [akbp](https://github.com/rohitg00/akbp) | ![stars](https://img.shields.io/github/stars/rohitg00/akbp?style=flat-square&label=%E2%98%85&color=3553ff&labelColor=fafaf5) | Agent Knowledge Base Protocol. Handoff + knowledge layer between sessions and across agents. |
+| [skillkit](https://github.com/rohitg00/skillkit) | ![stars](https://img.shields.io/github/stars/rohitg00/skillkit?style=flat-square&label=%E2%98%85&color=3553ff&labelColor=fafaf5) | Universal CLI to install skills across 32 AI coding agents (Claude, Cursor, Codex, OpenClaw, Hermes, ...). |
+| [pro-workflow](https://github.com/rohitg00/pro-workflow) | ![stars](https://img.shields.io/github/stars/rohitg00/pro-workflow?style=flat-square&label=%E2%98%85&color=3553ff&labelColor=fafaf5) | Battle-tested Claude Code workflows. 8 patterns from power users: self-correction, parallel worktrees, split memory, learning logs. |
 
 ```
 ░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒


### PR DESCRIPTION
## Summary

- Add `skillkit` and `pro-workflow` rows to the README "## From the same author" table.
- skillkit: universal CLI for installing skills across 32 AI coding agents.
- pro-workflow: battle-tested Claude Code workflow patterns (self-correction, parallel worktrees, split memory, learning logs).

## Diff

Table grew from 3 rows (agentmemory, agentbrain, akbp) to 5 rows. Lede sentence reworded to reflect the broader scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the related projects section to showcase a broader collection of resources available to users. Added two new repository references and enhanced descriptions to highlight additional development primitives and agent-workflow pattern libraries from the same author.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/ai-engineering-from-scratch/pull/124?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->