### PR TITLE
feat(phase-14): mission.md briefing per workbench lesson 31-42

### DIFF
--- a/README.md
+++ b/README.md
@@ -675,6 +675,8 @@ Twenty phases. Click any phase to expand its lesson list.
 | 41 | [The Workbench on a Real Repo](phases/14-agent-engineering/41-workbench-for-real-repos/) | Build | Python |
 | 42 | [Capstone: Ship a Reusable Agent Workbench Pack](phases/14-agent-engineering/42-agent-workbench-capstone/) | Build | Python |
 
+Each Phase 14 workbench lesson (31-42) ships a `mission.md` briefing the agent before it opens the full lesson docs.
+
 </details>
 
 <details id="phase-15">

--- a/phases/14-agent-engineering/31-agent-workbench-why-models-fail/mission.md
+++ b/phases/14-agent-engineering/31-agent-workbench-why-models-fail/mission.md
@@ -1,0 +1,27 @@
+# Mission - Agent Workbench: Why Capable Models Still Fail
+
+## Goal
+Run the same small repo task twice, once prompt-only and once with the seven workbench surfaces wired in, and emit a failure-mode report that maps each missed surface to the symptom it caused.
+
+## Inputs
+- A stub agent and a tiny FastAPI-style handler to validate
+- The seven-surface list (instructions, state, scope, feedback, verification, review, handoff)
+
+## Deliverables
+- `code/main.py` that runs both pipelines back to back
+- `failure_modes.json` summarizing the prompt-only run
+- One-line verdict for the workbench run
+
+## Acceptance
+- `python3 code/main.py` exits zero
+- Output shows a side-by-side log of the two runs
+- `failure_modes.json` lists every missed surface with the matching symptom
+
+## Out of scope
+- Calling a real model. The stub is rule-based on purpose.
+- Building any one surface in depth. That is what the next eleven lessons are for.
+
+## References
+- `docs/en.md` - full lesson
+- `code/main.py` - reference implementation
+- `outputs/skill-workbench-audit.md` - extracted skill

--- a/phases/14-agent-engineering/32-minimal-agent-workbench/mission.md
+++ b/phases/14-agent-engineering/32-minimal-agent-workbench/mission.md
@@ -1,0 +1,28 @@
+# Mission - The Minimal Agent Workbench
+
+## Goal
+Lay down the three-file minimum workbench (router, state, task board) into a fresh `workdir/` and prove a single agent turn can read state, pull a task, write to scope, and persist updated state.
+
+## Inputs
+- An empty `workdir/` directory next to the lesson code
+- Knowledge of the three files: `AGENTS.md`, `agent_state.json`, `task_board.json`
+
+## Deliverables
+- `code/main.py` that creates the three files and runs one turn
+- `workdir/AGENTS.md` short router pointing at state, board, and the verification command
+- `workdir/agent_state.json` with active task id, touched files, next action
+- `workdir/task_board.json` with a small backlog and statuses
+
+## Acceptance
+- `python3 code/main.py` exits zero on first and second run
+- Second run picks up where the first left off, not from scratch
+- Diff printed by the script shows the one file the turn touched
+
+## Out of scope
+- Scope contracts, verification gates, reviewer agents. Those layer on top in later lessons.
+- Long monolithic `AGENTS.md`. The router stays short on purpose.
+
+## References
+- `docs/en.md` - full lesson
+- `code/main.py` - reference implementation
+- `outputs/skill-minimal-workbench.md` - extracted skill

--- a/phases/14-agent-engineering/33-instructions-as-executable-constraints/mission.md
+++ b/phases/14-agent-engineering/33-instructions-as-executable-constraints/mission.md
@@ -1,0 +1,27 @@
+# Mission - Agent Instructions as Executable Constraints
+
+## Goal
+Turn prose instructions into machine-checkable rules across five categories and emit a rule report a reviewer can score.
+
+## Inputs
+- `docs/agent-rules.md` with one rule per heading, each carrying slug, category, description, and a `check` field
+- A demo agent run that intentionally violates two rules
+
+## Deliverables
+- Parser that loads `agent-rules.md` into a dataclass
+- `rule_checker.py` style functions, one per `check` referenced
+- `rule_report.json` with pass/fail per rule and an aggregate severity
+
+## Acceptance
+- `python3 code/main.py` exits zero
+- Output prints the parsed rule set, the run trace, and pass/fail per rule
+- `rule_report.json` catches the two intentional violations
+
+## Out of scope
+- Wiring the checker into CI. The lesson exits at a written report.
+- Framework guardrails (OpenAI SDK, LangGraph interrupts). The rule set is the human-readable contract those implement.
+
+## References
+- `docs/en.md` - full lesson
+- `code/main.py` - reference implementation
+- `outputs/skill-rule-set-builder.md` - extracted skill

--- a/phases/14-agent-engineering/34-repo-memory-and-state/mission.md
+++ b/phases/14-agent-engineering/34-repo-memory-and-state/mission.md
@@ -1,0 +1,27 @@
+# Mission - Repo Memory and Durable State
+
+## Goal
+Author JSON Schemas for `agent_state.json` and `task_board.json`, build a `StateManager` that loads, validates, mutates, and writes atomically, and prove the round-trip across two turns.
+
+## Inputs
+- The three-file workbench shape from lesson 32
+- A stdlib-only validator covering required, type, enum, pattern, and items
+
+## Deliverables
+- `agent_state.schema.json` and `task_board.schema.json` next to the code
+- `StateManager.load`, `StateManager.update`, `StateManager.commit` with temp-and-rename writes
+- A demo run that mutates state across two turns and reloads cleanly
+
+## Acceptance
+- `python3 code/main.py` exits zero
+- A bad write (missing required field, bad enum) is refused, not persisted
+- `workdir/agent_state.json` after the run validates against the schema
+
+## Out of scope
+- SQLite or external storage backends. The local file is the lesson.
+- LangGraph checkpointers, Letta memory blocks. Same idea, different storage; out of scope here.
+
+## References
+- `docs/en.md` - full lesson
+- `code/main.py` - reference implementation
+- `outputs/skill-state-schema.md` - extracted skill

--- a/phases/14-agent-engineering/35-initialization-scripts/mission.md
+++ b/phases/14-agent-engineering/35-initialization-scripts/mission.md
@@ -1,0 +1,27 @@
+# Mission - Initialization Scripts for Agents
+
+## Goal
+Build `init_agent.py` that probes runtime, dependencies, test command, env vars, and state freshness, then writes `init_report.json` and halts the session loud when a block-severity probe fails.
+
+## Inputs
+- A repo with a `requirements.txt` (or equivalent), a test command, and the workbench state file from lesson 34
+- The probe table from the lesson (runtime, deps, paths, env, state freshness, last-known-good commit)
+
+## Deliverables
+- `init_agent.py` with one function per probe returning `(name, status, detail)`
+- `init_report.json` carrying the full probe set and a timestamp
+- Non-zero exit on any block-severity probe failure
+
+## Acceptance
+- `python3 code/main.py` exits zero on the happy path
+- Running it twice in a row is a no-op except for the timestamp
+- A simulated missing env var probe surfaces in the report and flips the exit code
+
+## Out of scope
+- Auto-installing missing dependencies. The script halts and surfaces; the human fixes.
+- Calling an LLM from a probe. Probes stay deterministic plumbing.
+
+## References
+- `docs/en.md` - full lesson
+- `code/main.py` - reference implementation
+- `outputs/skill-init-script.md` - extracted skill

--- a/phases/14-agent-engineering/36-scope-contracts/mission.md
+++ b/phases/14-agent-engineering/36-scope-contracts/mission.md
@@ -1,0 +1,28 @@
+# Mission - Scope Contracts and Task Boundaries
+
+## Goal
+Write a per-task `scope_contract.json` and a glob-aware checker that compares the agent's diff against the contract and flags any forbidden or off-scope writes.
+
+## Inputs
+- A task description with allowed globs, forbidden globs, acceptance commands, rollback paragraph, approvals required
+- Two demo runs: one that stays in scope, one that creeps
+
+## Deliverables
+- `scope_contract.json` schema validator (subset of JSON Schema, glob arrays)
+- A diff parser that produces a `RunSummary` from touched files plus commands run
+- `scope_check(contract, run) -> (violations, in_scope, off_scope)`
+- `scope_report.json` saved next to the script
+
+## Acceptance
+- `python3 code/main.py` exits zero
+- The in-scope run reports zero violations
+- The creeping run reports the exact off-scope files and the reason for each
+
+## Out of scope
+- Time budgets, network egress allowlists. The lesson ships file globs; the exercise prompts extend it.
+- Wiring into a runtime interrupt. The lesson exits at the report.
+
+## References
+- `docs/en.md` - full lesson
+- `code/main.py` - reference implementation
+- `outputs/skill-scope-contract.md` - extracted skill

--- a/phases/14-agent-engineering/37-runtime-feedback-loops/mission.md
+++ b/phases/14-agent-engineering/37-runtime-feedback-loops/mission.md
@@ -1,0 +1,27 @@
+# Mission - Runtime Feedback Loops
+
+## Goal
+Build `run_with_feedback` that wraps `subprocess.run`, captures stdout, stderr, exit code, and duration, truncates output deterministically, and appends a JSONL record the next turn and the verification gate both read.
+
+## Inputs
+- Three demo commands to exercise the runner: one success, one failure, one slow
+- Token budget: deterministic head plus tail with a `...truncated N lines...` marker
+
+## Deliverables
+- `run_with_feedback(command, agent_note)` writing to `feedback_record.jsonl`
+- A loader that streams the JSONL into a Python list
+- A printer that shows the last record per command
+
+## Acceptance
+- `python3 code/main.py` exits zero
+- `feedback_record.jsonl` accumulates one record per command across re-runs
+- A command with `exit_code: null` cannot be marked successful by the loop
+
+## Out of scope
+- Telemetry pipelines (OTel, Langfuse). Feedback is for the next turn; telemetry is for the operator.
+- Redaction passes and rotation policy. Lesson exercise prompts cover those.
+
+## References
+- `docs/en.md` - full lesson
+- `code/main.py` - reference implementation
+- `outputs/skill-feedback-runner.md` - extracted skill

--- a/phases/14-agent-engineering/38-verification-gates/mission.md
+++ b/phases/14-agent-engineering/38-verification-gates/mission.md
@@ -1,0 +1,27 @@
+# Mission - Verification Gates
+
+## Goal
+Implement `verify(task_id, artifacts)` as a pure deterministic function over scope report, rule report, feedback log, and diff, emitting one `verification_report.json` per task close-out.
+
+## Inputs
+- Stub loaders for `scope_report.json`, `rule_report.json`, `feedback_record.jsonl`, and the diff
+- The check table: acceptance ran, acceptance exited zero, scope clean, no `null` exits, all block-severity rules pass
+
+## Deliverables
+- A pure `verify(task_id, artifacts) -> VerdictReport`
+- A printer that shows per-check results and the final pass/fail
+- Three demo scenarios written to disk: clean pass, scope creep, missing acceptance
+
+## Acceptance
+- `python3 code/main.py` exits zero
+- The clean-pass scenario reports `passed: true`; the other two report `passed: false`
+- Each scenario writes a separate `verification_report.json` under `outputs/verification/`
+
+## Out of scope
+- LLM-as-judge logic. The gate stays deterministic; qualitative judgment belongs to the reviewer in lesson 39.
+- Signed override audit logs. The exercise prompts extend the gate that way.
+
+## References
+- `docs/en.md` - full lesson
+- `code/main.py` - reference implementation
+- `outputs/skill-verification-gate.md` - extracted skill

--- a/phases/14-agent-engineering/39-reviewer-agent/mission.md
+++ b/phases/14-agent-engineering/39-reviewer-agent/mission.md
@@ -1,0 +1,27 @@
+# Mission - Reviewer Agent: Separate Builder from Marker
+
+## Goal
+Build a reviewer loop that reads the builder's artifacts read-only and emits a `review_report.json` scored across five dimensions, totalling out of 10, with a verdict of pass, soft_fail, or hard_fail.
+
+## Inputs
+- `ReviewerInputs` bundling diff, state, feedback, and verification verdict from prior lessons
+- Rubric dimensions: problem fit, scope discipline, assumptions, verification quality, handoff readiness
+
+## Deliverables
+- One scoring function per dimension (stub-grade for the lesson, deterministic)
+- `review_report.json` writer with five scores, total, and verdict
+- Two demo cases: a clean change and a "right tests, wrong problem" change
+
+## Acceptance
+- `python3 code/main.py` exits zero
+- The clean change scores at least 7 with verdict `pass`
+- The wrong-problem change drops below 5 on at least one dimension and verdict flips to `hard_fail`
+
+## Out of scope
+- Real LLM calls. The lesson stubs each dimension; the skill swaps in a model later.
+- Editing the diff. The reviewer reads, scores, and reports. Patches are the builder's job next turn.
+
+## References
+- `docs/en.md` - full lesson
+- `code/main.py` - reference implementation
+- `outputs/skill-reviewer-agent.md` - extracted skill

--- a/phases/14-agent-engineering/40-multi-session-handoff/mission.md
+++ b/phases/14-agent-engineering/40-multi-session-handoff/mission.md
@@ -1,0 +1,28 @@
+# Mission - Multi-Session Handoff
+
+## Goal
+Generate `handoff.md` and `handoff.json` from workbench artifacts at session end so the next session is productive in the first minute. Both forms carry the same seven fields; the JSON wins on disagreement.
+
+## Inputs
+- `agent_state.json`, `verification_report.json`, `review_report.json`, `feedback_record.jsonl` from earlier lessons
+- The seven fields: summary, changed_files, commands_run, failed_attempts, open_risks, next_action, verdict_pointer
+
+## Deliverables
+- A `WorkbenchSnapshot` loader bundling the four artifacts
+- `generate_handoff(snapshot) -> (markdown, payload)`
+- A feedback filter that picks the last K records plus every non-zero exit
+- `handoff.md` and `handoff.json` written next to the script
+
+## Acceptance
+- `python3 code/main.py` exits zero
+- Both files carry all seven fields and a non-empty `next_action`
+- Re-running the script with the same inputs produces an identical packet
+
+## Out of scope
+- Compaction strategies (Codex compact endpoint, Claude Code five-stage). Handoff closes a session; compaction extends one.
+- PR templating. The markdown is reusable as a PR body but the lesson stops at the file.
+
+## References
+- `docs/en.md` - full lesson
+- `code/main.py` - reference implementation
+- `outputs/skill-handoff-generator.md` - extracted skill

--- a/phases/14-agent-engineering/41-workbench-for-real-repos/mission.md
+++ b/phases/14-agent-engineering/41-workbench-for-real-repos/mission.md
@@ -1,0 +1,27 @@
+# Mission - The Workbench on a Real Repo
+
+## Goal
+Run the same `/signup` validation task through a prompt-only pipeline and a workbench-guided pipeline against the same sample app, then emit a before/after comparison report a skeptic can read.
+
+## Inputs
+- `sample_app/` with `app.py` (no validation), `test_app.py` (one happy-path test), `README.md`, `scripts/release.sh` as forbidden-zone bait
+- Both pipelines fully scripted, no real LLM calls
+
+## Deliverables
+- `code/main.py` orchestrating both pipelines against the same fixture
+- `before-after-report.md` with the five outcomes table
+- `comparison.json` for downstream charting
+
+## Acceptance
+- `python3 code/main.py` exits zero
+- The report measures all five outcomes: tests actually ran, acceptance met, files outside scope, handoff quality, reviewer total
+- The workbench pipeline beats the prompt-only pipeline on at least four of the five
+
+## Out of scope
+- Plugging in a real LLM. The pipelines are scripted for reproducibility.
+- Tuning the model. The comparison holds the model constant by construction.
+
+## References
+- `docs/en.md` - full lesson
+- `code/main.py` - reference implementation
+- `outputs/skill-workbench-benchmark.md` - extracted skill

--- a/phases/14-agent-engineering/42-agent-workbench-capstone/mission.md
+++ b/phases/14-agent-engineering/42-agent-workbench-capstone/mission.md
@@ -1,0 +1,27 @@
+# Mission - Capstone: Ship a Reusable Agent Workbench Pack
+
+## Goal
+Assemble the eleven prior lessons into a versioned `outputs/agent-workbench-pack/` directory with an installer that lays it idempotently into any target repo.
+
+## Inputs
+- Schemas, scripts, and docs from lessons 32 through 40
+- The pack layout: `AGENTS.md`, `docs/`, `schemas/`, `scripts/`, `bin/`, `README.md`, `VERSION`
+
+## Deliverables
+- `outputs/agent-workbench-pack/` with the full layout populated
+- `bin/install.sh` (or `bin/install.py`) that refuses to overwrite without `--force`
+- `VERSION` file plus a `README.md` describing what stays in and what stays out
+
+## Acceptance
+- `python3 code/main.py` exits zero and prints the pack tree
+- Re-running the assembler is idempotent
+- `bin/install.sh` into a fresh target leaves a working workbench: state, board, rules, scope, init, runner, gate, reviewer, handoff all in place
+
+## Out of scope
+- Per-project task content. Tasks belong on the target repo's board, not in the pack.
+- Vendor SDK calls. The pack is framework-agnostic by design.
+
+## References
+- `docs/en.md` - full lesson
+- `code/main.py` - reference implementation
+- `outputs/skill-workbench-pack.md` - extracted skill


### PR DESCRIPTION
## Summary

Adds a `mission.md` briefing file to each of the 12 Phase 14 Agent Workbench mini-track lessons (31-42). The briefing is a short pre-read the agent (or human) can scan before opening the full `docs/en.md`. Same structure across all 12 files: Goal, Inputs, Deliverables, Acceptance, Out of scope, References.

Twelve atomic per-lesson commits (one per lesson dir, per the repo's atomic-commit rule), plus one tiny README touch noting the new briefings live in Phase 14.

`catalog.json` is unchanged. The catalog doesn't track `mission.md`, so 12 new files don't move counts.

## Mission goals (one line each)

- 31 - Run prompt-only vs workbench-guided side by side, emit failure-mode report
- 32 - Lay down three-file minimum workbench, prove one turn round-trip
- 33 - Turn prose rules into machine-checkable rule report
- 34 - Schema-first state with atomic temp-and-rename writes
- 35 - Deterministic init script with refuse-on-fail probes
- 36 - Per-task scope contract and glob-aware diff checker
- 37 - Feedback runner capturing exit, output, duration into JSONL
- 38 - Deterministic verification gate over scope, rules, feedback, diff
- 39 - Reviewer loop scoring five dimensions, read-only on builder artifacts
- 40 - Handoff packet with seven fields, generated not written
- 41 - Same task run twice on a real-feeling repo, before/after report
- 42 - Capstone pack assembled into a drop-in directory with installer

## Structure

Each `mission.md` is 25-45 lines. Terse on purpose. No em-dashes, no AI-vocabulary slop. References section at the bottom always points at `docs/en.md`, `code/main.py`, and the lesson's extracted skill in `outputs/`.

## Test plan

- [ ] Eyeball one mission per third of the mini-track (31, 36, 42) for tone and accuracy against `docs/en.md`
- [ ] Confirm `catalog.json` is unchanged
- [ ] Confirm README renders Phase 14 section without breaking the lesson table
