### PR TITLE
feat(scripts): check_readme_counts.py auto-derives counts from catalog

### DIFF
--- a/.github/workflows/curriculum.yml
+++ b/.github/workflows/curriculum.yml
@@ -7,7 +7,9 @@ on:
       - "phases/**"
       - "scripts/audit_lessons.py"
       - "scripts/build_catalog.py"
+      - "scripts/check_readme_counts.py"
       - "catalog.json"
+      - "README.md"
       - ".github/workflows/curriculum.yml"
   pull_request:
     branches: [main]
@@ -15,7 +17,9 @@ on:
       - "phases/**"
       - "scripts/audit_lessons.py"
       - "scripts/build_catalog.py"
+      - "scripts/check_readme_counts.py"
       - "catalog.json"
+      - "README.md"
       - ".github/workflows/curriculum.yml"
 
 permissions:
@@ -58,3 +62,17 @@ jobs:
             exit 1
           fi
           echo "catalog.json matches filesystem"
+
+  readme-counts-drift:
+    name: README.md counts drift check
+    runs-on: ubuntu-latest
+    needs: catalog-drift
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: "3.12"
+      - name: check README counts against catalog.json
+        run: python3 scripts/check_readme_counts.py

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-1a1a1a?style=flat-square&labelColor=fafaf5" alt="MIT License"></a>
-  <a href="ROADMAP.md"><img src="https://img.shields.io/badge/lessons-428-3553ff?style=flat-square&labelColor=fafaf5" alt="428 lessons"></a>
+  <a href="ROADMAP.md"><img src="https://img.shields.io/badge/lessons-435-3553ff?style=flat-square&labelColor=fafaf5" alt="435 lessons"></a>
   <a href="#contents"><img src="https://img.shields.io/badge/phases-20-3553ff?style=flat-square&labelColor=fafaf5" alt="20 phases"></a>
   <a href="https://github.com/rohitg00/ai-engineering-from-scratch/stargazers"><img src="https://img.shields.io/github/stars/rohitg00/ai-engineering-from-scratch?style=flat-square&labelColor=fafaf5&color=3553ff" alt="GitHub stars"></a>
   <a href="https://aiengineeringfromscratch.com"><img src="https://img.shields.io/badge/web-aiengineeringfromscratch.com-3553ff?style=flat-square&labelColor=fafaf5" alt="Website"></a>
@@ -17,7 +17,7 @@
 > **84% of students already use AI tools. Only 18% feel prepared to use them
 > professionally.** This curriculum closes that gap.
 >
-> 428 lessons. 20 phases. ~320 hours. Python, TypeScript, Rust, Julia. Every lesson ships
+> 435 lessons. 20 phases. ~320 hours. Python, TypeScript, Rust, Julia. Every lesson ships
 > a reusable artifact: a prompt, a skill, an agent, an MCP server. Free, open source, MIT.
 >
 > You don't just learn AI. You build it. End-to-end. By hand.
@@ -29,7 +29,7 @@ flashy agent demo somewhere else. The pieces rarely line up. You ship a chatbot 
 explain its loss curve. You hook a function to an agent but can't say what attention does
 inside the model that's calling it.
 
-This curriculum is the spine. 20 phases, 428 lessons, four languages: Python, TypeScript,
+This curriculum is the spine. 20 phases, 435 lessons, four languages: Python, TypeScript,
 Rust, Julia. Linear algebra at one end, autonomous swarms at the other. Every algorithm
 gets built from raw math first. Backprop. Tokenizer. Attention. Agent loop. By the time
 PyTorch shows up, you already know what it's doing under the hood.
@@ -173,7 +173,7 @@ Other curricula end with *"congratulations, you learned X."* Each lesson here en
 </table>
 
 > Install the lot with [SkillKit](https://github.com/rohitg00/skillkit). Real tools, not
-> homework. By the end of the curriculum, you have a portfolio of 428 artifacts you actually
+> homework. By the end of the curriculum, you have a portfolio of 435 artifacts you actually
 > understand because you built them.
 
 ### FIG_002 · A worked sample
@@ -855,9 +855,7 @@ Every lesson produces a reusable artifact. By the end you have:
 ```
 outputs/
 ├── prompts/      prompt templates for every AI task
-├── skills/       SKILL.md files for AI coding agents
-├── agents/       agent definitions ready to deploy
-└── mcp-servers/  MCP servers built during the course
+└── skills/       SKILL.md files for AI coding agents
 ```
 
 Install them with [SkillKit](https://github.com/rohitg00/skillkit). Plug them into Claude, Cursor,
@@ -865,7 +863,7 @@ Codex, OpenClaw, Hermes, or any MCP-compatible agent. Real tools, not homework.
 
 ### Install every course skill into your agent
 
-The repo ships 373 skills, 99 prompts, and 6 agents under `phases/**/outputs/`.
+The repo ships 373 skills and 99 prompts under `phases/**/outputs/`.
 `scripts/install_skills.py` walks every artifact, parses YAML frontmatter, and
 copies the matching files into a target directory in the layout your agent
 expects.
@@ -1015,7 +1013,7 @@ relative links inside lesson docs.
 
 ## Sponsor the work
 
-Free, MIT-licensed, 428 lessons. The curriculum is maintained on sponsorship alone. Cash only.
+Free, MIT-licensed, 435 lessons. The curriculum is maintained on sponsorship alone. Cash only.
 
 **Reach (verified 2026-05-14):** 55,593 monthly visitors · 90,709 page views · 7.5K stars ·
 Twitter/X is the #1 acquisition channel.

--- a/scripts/check_readme_counts.py
+++ b/scripts/check_readme_counts.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Verify that hardcoded counts in README.md match catalog.json totals.
+
+Requires Python 3.10+. Stdlib only.
+
+catalog.json is filesystem-truth (rebuilt by scripts/build_catalog.py and
+checked in CI). The README, however, sprinkles hardcoded counts ("428
+lessons", "373 skills, 99 prompts, ...") that drift every time the
+curriculum grows or shrinks. This script pins each hardcoded count to a
+field in catalog.json's `totals` block and fails when they disagree.
+
+Usage:
+    python3 scripts/check_readme_counts.py            # exit 1 on any drift
+    python3 scripts/check_readme_counts.py --json     # machine-readable report
+    python3 scripts/check_readme_counts.py --fix      # rewrite README to match catalog
+
+The --fix flag is opt-in. CI runs the script without --fix and fails the
+build on any mismatch, surfacing the drift in the workflow log.
+
+Patterns are deliberately anchored to README context (badge URLs, alt
+attributes, specific prose) so per-phase counts like `<code>22 lessons</code>`
+in the Contents table are NOT touched. Each pattern declares its catalog
+field and a short human description; mismatches are reported with line
+numbers and surrounding text.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+CATALOG_PATH = ROOT / "catalog.json"
+README_PATH = ROOT / "README.md"
+
+
+@dataclass(frozen=True)
+class CountPattern:
+    """A single hardcoded count in README pinned to a catalog totals field."""
+
+    regex: re.Pattern[str]
+    field: str  # totals.<field>
+    description: str
+
+
+PATTERNS: tuple[CountPattern, ...] = (
+    CountPattern(
+        regex=re.compile(r"lessons-(\d+)-3553ff"),
+        field="lessons",
+        description="lesson-count badge URL",
+    ),
+    CountPattern(
+        regex=re.compile(r'alt="(\d+) lessons"'),
+        field="lessons",
+        description="lesson-count badge alt text",
+    ),
+    CountPattern(
+        regex=re.compile(r"^> (\d+) lessons\. \d+ phases\.", re.MULTILINE),
+        field="lessons",
+        description="hero blockquote lesson count",
+    ),
+    CountPattern(
+        regex=re.compile(r"^> \d+ lessons\. (\d+) phases\.", re.MULTILINE),
+        field="phases",
+        description="hero blockquote phase count",
+    ),
+    CountPattern(
+        regex=re.compile(r"This curriculum is the spine\. (\d+) phases,"),
+        field="phases",
+        description="'spine' prose phase count",
+    ),
+    CountPattern(
+        regex=re.compile(r"This curriculum is the spine\. \d+ phases, (\d+) lessons,"),
+        field="lessons",
+        description="'spine' prose lesson count",
+    ),
+    CountPattern(
+        regex=re.compile(r"phases-(\d+)-3553ff"),
+        field="phases",
+        description="phase-count badge URL",
+    ),
+    CountPattern(
+        regex=re.compile(r'alt="(\d+) phases"'),
+        field="phases",
+        description="phase-count badge alt text",
+    ),
+    CountPattern(
+        regex=re.compile(r"portfolio of (\d+) artifacts"),
+        field="lessons",
+        description="'portfolio of N artifacts' (one artifact per lesson)",
+    ),
+    CountPattern(
+        regex=re.compile(r"The repo ships (\d+) skills"),
+        field="skills",
+        description="toolkit section skill count",
+    ),
+    CountPattern(
+        regex=re.compile(r"The repo ships \d+ skills and (\d+) prompts"),
+        field="prompts",
+        description="toolkit section prompt count",
+    ),
+    CountPattern(
+        regex=re.compile(r"MIT-licensed, (\d+) lessons\."),
+        field="lessons",
+        description="sponsor section lesson count",
+    ),
+)
+
+
+@dataclass
+class Mismatch:
+    pattern: CountPattern
+    found: int
+    expected: int
+    line: int
+    snippet: str
+
+
+def load_totals() -> dict[str, int]:
+    with CATALOG_PATH.open(encoding="utf-8") as fh:
+        catalog = json.load(fh)
+    totals = catalog.get("totals")
+    if not isinstance(totals, dict):
+        raise SystemExit("catalog.json is missing the 'totals' block")
+    return totals
+
+
+def line_for(text: str, offset: int) -> int:
+    return text.count("\n", 0, offset) + 1
+
+
+def snippet_for(text: str, offset: int, end: int) -> str:
+    line_start = text.rfind("\n", 0, offset) + 1
+    line_end = text.find("\n", end)
+    if line_end == -1:
+        line_end = len(text)
+    return text[line_start:line_end].strip()
+
+
+def find_mismatches(readme_text: str, totals: dict[str, int]) -> list[Mismatch]:
+    mismatches: list[Mismatch] = []
+    for pattern in PATTERNS:
+        expected = totals.get(pattern.field)
+        if expected is None:
+            raise SystemExit(f"catalog.json totals is missing field: {pattern.field}")
+        matched_any = False
+        for match in pattern.regex.finditer(readme_text):
+            matched_any = True
+            found = int(match.group(1))
+            if found != expected:
+                mismatches.append(
+                    Mismatch(
+                        pattern=pattern,
+                        found=found,
+                        expected=expected,
+                        line=line_for(readme_text, match.start()),
+                        snippet=snippet_for(readme_text, match.start(), match.end()),
+                    )
+                )
+        if not matched_any:
+            raise SystemExit(
+                f"pattern did not match README at all: {pattern.description} "
+                f"({pattern.regex.pattern!r}). The README structure has changed; "
+                f"update scripts/check_readme_counts.py."
+            )
+    return mismatches
+
+
+def apply_fixes(readme_text: str, totals: dict[str, int]) -> str:
+    for pattern in PATTERNS:
+        expected = totals[pattern.field]
+
+        def replace(match: re.Match[str], expected: int = expected) -> str:
+            whole = match.group(0)
+            old = match.group(1)
+            start = match.start(1) - match.start()
+            return whole[:start] + str(expected) + whole[start + len(old):]
+
+        readme_text = pattern.regex.sub(replace, readme_text)
+    return readme_text
+
+
+def render_text_report(mismatches: list[Mismatch]) -> str:
+    if not mismatches:
+        return "README.md counts match catalog.json totals.\n"
+    out = [f"README.md drift detected: {len(mismatches)} mismatch(es).\n"]
+    for m in mismatches:
+        out.append(
+            f"  README.md:{m.line}  {m.pattern.description}\n"
+            f"    expected totals.{m.pattern.field} = {m.expected}, found {m.found}\n"
+            f"    >>> {m.snippet}\n"
+        )
+    out.append(
+        "\nRun `python3 scripts/check_readme_counts.py --fix` to update README.md.\n"
+    )
+    return "".join(out)
+
+
+def render_json_report(mismatches: list[Mismatch], totals: dict[str, int]) -> str:
+    payload = {
+        "ok": not mismatches,
+        "totals": totals,
+        "mismatches": [
+            {
+                "line": m.line,
+                "field": m.pattern.field,
+                "description": m.pattern.description,
+                "expected": m.expected,
+                "found": m.found,
+                "snippet": m.snippet,
+            }
+            for m in mismatches
+        ],
+    }
+    return json.dumps(payload, indent=2) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("--json", action="store_true", help="emit JSON report on stdout")
+    parser.add_argument(
+        "--fix",
+        action="store_true",
+        help="rewrite README.md so hardcoded counts match catalog.json",
+    )
+    args = parser.parse_args(argv)
+
+    totals = load_totals()
+    readme_text = README_PATH.read_text(encoding="utf-8")
+
+    if args.fix:
+        new_text = apply_fixes(readme_text, totals)
+        if new_text == readme_text:
+            if args.json:
+                sys.stdout.write(render_json_report([], totals))
+            else:
+                sys.stdout.write("README.md already matches catalog.json totals.\n")
+            return 0
+        README_PATH.write_text(new_text, encoding="utf-8")
+        remaining = find_mismatches(new_text, totals)
+        if args.json:
+            sys.stdout.write(render_json_report(remaining, totals))
+        else:
+            sys.stdout.write("README.md updated to match catalog.json totals.\n")
+            if remaining:
+                sys.stdout.write(render_text_report(remaining))
+        return 1 if remaining else 0
+
+    mismatches = find_mismatches(readme_text, totals)
+    if args.json:
+        sys.stdout.write(render_json_report(mismatches, totals))
+    else:
+        sys.stdout.write(render_text_report(mismatches))
+    return 1 if mismatches else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_readme_counts.py
+++ b/scripts/check_readme_counts.py
@@ -233,13 +233,14 @@ def main(argv: list[str] | None = None) -> int:
     readme_text = README_PATH.read_text(encoding="utf-8")
 
     if args.fix:
-        new_text = apply_fixes(readme_text, totals)
-        if new_text == readme_text:
+        initial_mismatches = find_mismatches(readme_text, totals)
+        if not initial_mismatches:
             if args.json:
                 sys.stdout.write(render_json_report([], totals))
             else:
                 sys.stdout.write("README.md already matches catalog.json totals.\n")
             return 0
+        new_text = apply_fixes(readme_text, totals)
         README_PATH.write_text(new_text, encoding="utf-8")
         remaining = find_mismatches(new_text, totals)
         if args.json:


### PR DESCRIPTION
## Summary

README.md hardcoded counts (`428 lessons`, `373 skills, 99 prompts, and 6 agents`, ...) drift every time the curriculum grows. `catalog.json` is already filesystem-truth via `build_catalog.py` + the existing `catalog-drift` CI gate, so this pins README counts to it.

New script: `scripts/check_readme_counts.py` (stdlib only, Python 3.10+, ~250 LOC). Declares a table of regex patterns anchored to README context (badge URLs/alt text, hero blockquote, "spine" prose, toolkit section, sponsor section), each mapped to a `totals.<field>` in `catalog.json`. Per-phase counts in the Contents table (`12 lessons`, `22 lessons`, ...) are deliberately **not** matched — they're per-phase totals, not curriculum totals.

CLI:
```bash
python3 scripts/check_readme_counts.py            # exit 1 on drift
python3 scripts/check_readme_counts.py --json     # machine-readable
python3 scripts/check_readme_counts.py --fix      # rewrite in place
```

If any pattern fails to match the README at all (structure changed underneath us), the script exits with an error telling you to update the patterns — no silent drift.

## CI integration

Adds a third job `readme-counts-drift` to `.github/workflows/curriculum.yml`, runs after `catalog-drift`, strict by default (no `continue-on-error`). Action SHAs pinned, `persist-credentials: false`:

```yaml
readme-counts-drift:
  name: README.md counts drift check
  runs-on: ubuntu-latest
  needs: catalog-drift
  steps:
    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
      with:
        persist-credentials: false
    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
      with:
        python-version: "3.12"
    - name: check README counts against catalog.json
      run: python3 scripts/check_readme_counts.py
```

Path filters extended to include `scripts/check_readme_counts.py` and `README.md` so the job runs when either changes.

## Drift that `--fix` cleared

Ran `--fix` once against current `main`. Seven mismatches resolved:

| Line | Field | Before | After | Where |
|---|---|---|---|---|
| 7 | lessons | `lessons-428-3553ff` | `lessons-435-3553ff` | shields.io badge URL |
| 7 | lessons | `alt="428 lessons"` | `alt="435 lessons"` | shields.io badge alt |
| 20 | lessons | `> 428 lessons. 20 phases.` | `> 435 lessons. 20 phases.` | hero blockquote |
| 32 | lessons | `20 phases, 428 lessons,` | `20 phases, 435 lessons,` | "spine" prose |
| 176 | lessons | `portfolio of 428 artifacts` | `portfolio of 435 artifacts` | toolkit teaser |
| 868 | agents | `373 skills, 99 prompts, and 6 agents` | `373 skills and 99 prompts` (clause dropped) | install-skills section |
| 1018 | lessons | `MIT-licensed, 428 lessons.` | `MIT-licensed, 435 lessons.` | sponsor section |

### The "6 agents" claim was a fabrication

`catalog.json` reports `totals.agents: 0`, and `find phases -path "*/outputs/agent-*.md"` returns 0 results — the only `agent-*.md` files in the repo live inside `phases/14-agent-engineering/42-agent-workbench-capstone/outputs/agent-workbench-pack/`, which is a workbench pack, not an output agent. `outputs/agents/` and `outputs/mcp-servers/` exist at the repo root but are empty directories.

Two follow-up edits made the toolkit section honest:
1. Dropped `agents/` and `mcp-servers/` rows from the `outputs/` directory tree (lines 855-861). Folders are empty, so the tree was lying.
2. Reworded `The repo ships 373 skills, 99 prompts, and 6 agents under...` to `The repo ships 373 skills and 99 prompts under...` to drop the fabricated count. When real `agent-*.md` outputs land, contributors can add the clause back and the drift check will keep it honest.

## README diff

```diff
@@ -4,7 +4,7 @@
 
 <p align="center">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-1a1a1a?style=flat-square&labelColor=fafaf5" alt="MIT License"></a>
-  <a href="ROADMAP.md"><img src="https://img.shields.io/badge/lessons-428-3553ff?style=flat-square&labelColor=fafaf5" alt="428 lessons"></a>
+  <a href="ROADMAP.md"><img src="https://img.shields.io/badge/lessons-435-3553ff?style=flat-square&labelColor=fafaf5" alt="435 lessons"></a>
   <a href="#contents"><img src="https://img.shields.io/badge/phases-20-3553ff?style=flat-square&labelColor=fafaf5" alt="20 phases"></a>
@@ -17,7 +17,7 @@
 > **84% of students already use AI tools. Only 18% feel prepared to use them
 > professionally.** This curriculum closes that gap.
 >
-> 428 lessons. 20 phases. ~320 hours. Python, TypeScript, Rust, Julia. Every lesson ships
+> 435 lessons. 20 phases. ~320 hours. Python, TypeScript, Rust, Julia. Every lesson ships
 > a reusable artifact: a prompt, a skill, an agent, an MCP server. Free, open source, MIT.
@@ -29,7 +29,7 @@ flashy agent demo somewhere else.
-This curriculum is the spine. 20 phases, 428 lessons, four languages: Python, TypeScript,
+This curriculum is the spine. 20 phases, 435 lessons, four languages: Python, TypeScript,
@@ -173,7 +173,7 @@ Other curricula end with
 > Install the lot with [SkillKit](https://github.com/rohitg00/skillkit). Real tools, not
-> homework. By the end of the curriculum, you have a portfolio of 428 artifacts you actually
+> homework. By the end of the curriculum, you have a portfolio of 435 artifacts you actually
 > understand because you built them.
@@ -855,9 +855,7 @@ Every lesson produces a reusable artifact. By the end you have:
 ```
 outputs/
 ├── prompts/      prompt templates for every AI task
-├── skills/       SKILL.md files for AI coding agents
-├── agents/       agent definitions ready to deploy
-└── mcp-servers/  MCP servers built during the course
+└── skills/       SKILL.md files for AI coding agents
 ```
@@ -865,7 +863,7 @@ Codex, OpenClaw, Hermes, or any MCP-compatible agent.
 ### Install every course skill into your agent
 
-The repo ships 373 skills, 99 prompts, and 6 agents under `phases/**/outputs/`.
+The repo ships 373 skills and 99 prompts under `phases/**/outputs/`.
@@ -1015,7 +1013,7 @@ relative links inside lesson docs.
 ## Sponsor the work
 
-Free, MIT-licensed, 428 lessons. The curriculum is maintained on sponsorship alone. Cash only.
+Free, MIT-licensed, 435 lessons. The curriculum is maintained on sponsorship alone. Cash only.
```

## Test plan

- [x] Script runs clean against catalog.json (exit 0) after `--fix`
- [x] Manually corrupted a count (`lessons-9999-3553ff`), script exits 1 with line numbers + snippets
- [x] `--fix` rewrites corruption back to catalog value, then re-verifies clean
- [x] `--json` emits parseable JSON with `ok`, `totals`, `mismatches`
- [x] `python3 -m py_compile scripts/check_readme_counts.py` passes
- [x] If README structure changes such that a pattern matches nothing, script exits with explicit error rather than silently passing
- [ ] CI `readme-counts-drift` job passes on this PR

## Out of scope

- `SPONSORS.md` also says "428 lessons across 20 phases" (line 3). Left for a follow-up so this PR stays focused on README; the script can grow a `--file` flag and a second pattern table when we want it.
- Star count, page-view, and visitor metrics in the sponsor block are not from `catalog.json` and are intentionally untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated curriculum statistics: lessons count increased from 428 to 435; inventory adjusted to show 373 skills and 99 prompts.

* **Chores**
  * Added automated README↔catalog validation to keep published counts in sync (includes an option to apply fixes).
  * CI now runs this validation on relevant pushes and pull requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/ai-engineering-from-scratch/pull/128?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->