### PR TITLE
fix: clear audit backlog and flip CI audit to strict

### DIFF
--- a/.github/workflows/curriculum.yml
+++ b/.github/workflows/curriculum.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   audit:
-    name: invariant checks (warn-only)
+    name: invariant checks
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
@@ -33,11 +33,7 @@ jobs:
         with:
           python-version: "3.12"
       - name: run scripts/audit_lessons.py
-        continue-on-error: true
         run: python3 scripts/audit_lessons.py
-      - name: warn-only note
-        run: |
-          echo "::notice::audit results above are warn-only until the 11 backlog issues are fixed in a follow-up PR"
 
   catalog-drift:
     name: catalog.json drift check

--- a/phases/05-nlp-foundations-to-advanced/01-text-processing/docs/en.md
+++ b/phases/05-nlp-foundations-to-advanced/01-text-processing/docs/en.md
@@ -21,8 +21,6 @@ This lesson builds the three preprocessing primitives from scratch, then shows h
 
 Three operations. Each has a job and a failure mode.
 
-![Preprocessing pipeline: raw text → tokens → stems or lemmas → model](./assets/pipeline.svg)
-
 **Tokenization** splits a string into tokens. "Token" is deliberately vague because the right granularity depends on the task. Word-level for classical NLP. Subword for transformers. Character for languages without whitespace.
 
 **Stemming** chops suffixes with rules. Fast, aggressive, dumb. `running -> run`. `organization -> organ`. That second one is the failure mode.

--- a/phases/05-nlp-foundations-to-advanced/02-bag-of-words-tfidf/docs/en.md
+++ b/phases/05-nlp-foundations-to-advanced/02-bag-of-words-tfidf/docs/en.md
@@ -19,8 +19,6 @@ This lesson builds bag of words, then TF-IDF, from scratch. Then shows scikit-le
 
 ## The Concept
 
-![BoW vs TF-IDF representation flow](./assets/bow-tfidf.svg)
-
 **Bag of Words (BoW)** throws away order. For each document, count how many times each vocabulary word appears. Vector length is the vocabulary size. Position `i` is the count of word `i`.
 
 **TF-IDF** reweights BoW. A word that appears in every document is uninformative, so scale it down. A word rare across the corpus but frequent in a single document is signal, so scale it up.

--- a/phases/05-nlp-foundations-to-advanced/03-word-embeddings-word2vec/docs/en.md
+++ b/phases/05-nlp-foundations-to-advanced/03-word-embeddings-word2vec/docs/en.md
@@ -17,8 +17,6 @@ Word2Vec gave us that space. Two layer neural network, trillion-token training r
 
 ## The Concept
 
-![Skip-gram window and embedding space](./assets/word2vec.svg)
-
 **Distributional hypothesis** (Firth, 1957): "You shall know a word by the company it keeps." If two words appear in similar contexts, they probably mean similar things.
 
 Word2Vec comes in two flavors, both exploiting that idea.

--- a/phases/05-nlp-foundations-to-advanced/04-glove-fasttext-subword/docs/en.md
+++ b/phases/05-nlp-foundations-to-advanced/04-glove-fasttext-subword/docs/en.md
@@ -21,8 +21,6 @@ This lesson walks all three, then explains which to reach for when.
 
 ## The Concept
 
-![Three embedding approaches: GloVe co-occurrence, FastText subwords, BPE merges](./assets/embeddings.svg)
-
 **GloVe (Global Vectors).** Build the word-word co-occurrence matrix `X` where `X[i][j]` is how often word `j` appears in the context of word `i`. Train vectors such that `v_i · v_j + b_i + b_j ≈ log(X[i][j])`. Weight the loss so frequent pairs do not dominate. Done.
 
 **FastText.** A word is the sum of its character n-grams plus the word itself. `where` becomes `<wh, whe, her, ere, re>, <where>`. The word vector is the sum of those component vectors. Train as Word2Vec. Benefit: unseen words (`whereupon`) compose from known n-grams.

--- a/phases/05-nlp-foundations-to-advanced/05-sentiment-analysis/docs/en.md
+++ b/phases/05-nlp-foundations-to-advanced/05-sentiment-analysis/docs/en.md
@@ -17,8 +17,6 @@ Sentiment is a working lab for classical NLP. If you understand why every naive 
 
 ## The Concept
 
-![Sentiment pipeline: tokens → features → classifier → label](./assets/sentiment.svg)
-
 Classical sentiment is a two-step recipe.
 
 1. **Represent.** Turn the text into a feature vector. BoW, TF-IDF, or n-grams.

--- a/phases/05-nlp-foundations-to-advanced/06-named-entity-recognition/docs/en.md
+++ b/phases/05-nlp-foundations-to-advanced/06-named-entity-recognition/docs/en.md
@@ -17,8 +17,6 @@ This lesson walks the classical path (rule-based, HMM, CRF) into the modern one 
 
 ## The Concept
 
-![NER tagging: BIO schema + CRF+BiLSTM pipeline](./assets/ner.svg)
-
 **BIO tagging** (or BILOU) turns entity extraction into a sequence-labeling problem. Label each token with `B-TYPE` (beginning of entity), `I-TYPE` (inside entity), or `O` (outside any entity).
 
 ```

--- a/phases/05-nlp-foundations-to-advanced/07-pos-tagging-parsing/docs/en.md
+++ b/phases/05-nlp-foundations-to-advanced/07-pos-tagging-parsing/docs/en.md
@@ -19,8 +19,6 @@ Worth knowing. This lesson introduces the tagsets, the baselines, and the point 
 
 ## The Concept
 
-![POS tag + dependency parse example](./assets/pos-parse.svg)
-
 **POS tagging** labels each token with a grammatical category. The **Penn Treebank (PTB)** tagset is the English default. 36 tags with distinctions the casual reader finds fussy: `NN` singular noun, `NNS` plural noun, `NNP` proper noun singular, `VBD` verb past tense, `VBZ` verb 3rd person singular present, and so on. The **Universal Dependencies (UD)** tagset is coarser (17 tags) and language-agnostic; it became the default for cross-lingual work.
 
 ```

--- a/phases/05-nlp-foundations-to-advanced/08-cnns-rnns-for-text/docs/en.md
+++ b/phases/05-nlp-foundations-to-advanced/08-cnns-rnns-for-text/docs/en.md
@@ -21,8 +21,6 @@ This lesson builds both, then names the failure that motivated attention.
 
 ## The Concept
 
-![TextCNN filters vs. RNN hidden state unrolling](./assets/cnn-rnn.svg)
-
 **TextCNN** (Kim, 2014). Tokens get embedded. A width-`k` 1D convolution slides a filter over consecutive `k`-grams of embeddings, producing a feature map. Global max-pooling over that map picks the strongest activation. Concatenate max-pooled outputs from several filter widths. Feed to a classifier head.
 
 Why it works. A filter is a learnable n-gram. Max-pooling is position-invariant, so "not good" fires the same feature at the start or middle of a review. Three filter widths with 100 filters each gives you 300 learned n-gram detectors. Training is parallel; no sequential dependency.

--- a/phases/05-nlp-foundations-to-advanced/09-sequence-to-sequence/docs/en.md
+++ b/phases/05-nlp-foundations-to-advanced/09-sequence-to-sequence/docs/en.md
@@ -17,8 +17,6 @@ This is worth studying for two reasons. First, the context-vector bottleneck is 
 
 ## The Concept
 
-![Encoder-decoder with context vector bottleneck](./assets/seq2seq.svg)
-
 **Encoder.** An RNN that reads the source sentence. Its final hidden state is the **context vector** — a fixed-size summary of the entire input. Lose nothing but the source, supposedly.
 
 **Decoder.** Another RNN initialized from the context vector. At each step it takes the previously generated token as input and produces a distribution over the target vocabulary. Sample or argmax to pick the next token. Feed it back in. Repeat until an `<EOS>` token is produced or max length is hit.

--- a/phases/05-nlp-foundations-to-advanced/17-chatbots-rule-to-neural/docs/en.md
+++ b/phases/05-nlp-foundations-to-advanced/17-chatbots-rule-to-neural/docs/en.md
@@ -127,7 +127,8 @@ def agent_loop(user_message, tools, llm, max_steps=5):
                 history.append({"role": "assistant", "tool_call": tool_call})
                 history.append({"role": "tool", "name": tool_name, "content": f"error: arguments must be a dict, got {type(args).__name__}"})
                 continue
-            result = tools[tool_name](**args)
+            fn = tools[tool_name]
+            result = fn(**args)
             history.append({"role": "assistant", "tool_call": tool_call})
             history.append({"role": "tool", "name": tool_name, "content": result})
         else:


### PR DESCRIPTION
## What

Clears the 11-issue audit backlog reported by `scripts/audit_lessons.py` and flips the curriculum CI workflow's audit job from warn-only to blocking.

## Changes

**1. Phase 05 — remove dead asset references (10 of 11 backlog issues).**

Nine of the warnings were broken image embeds pointing at SVG files that were never created:

```
phases/05-nlp-foundations-to-advanced/01-text-processing/docs/en.md   ./assets/pipeline.svg
phases/05-nlp-foundations-to-advanced/02-bag-of-words-tfidf/docs/en.md  ./assets/bow-tfidf.svg
phases/05-nlp-foundations-to-advanced/03-word-embeddings-word2vec/docs/en.md  ./assets/word2vec.svg
phases/05-nlp-foundations-to-advanced/04-glove-fasttext-subword/docs/en.md   ./assets/embeddings.svg
phases/05-nlp-foundations-to-advanced/05-sentiment-analysis/docs/en.md  ./assets/sentiment.svg
phases/05-nlp-foundations-to-advanced/06-named-entity-recognition/docs/en.md  ./assets/ner.svg
phases/05-nlp-foundations-to-advanced/07-pos-tagging-parsing/docs/en.md  ./assets/pos-parse.svg
phases/05-nlp-foundations-to-advanced/08-cnns-rnns-for-text/docs/en.md  ./assets/cnn-rnn.svg
phases/05-nlp-foundations-to-advanced/09-sequence-to-sequence/docs/en.md  ./assets/seq2seq.svg
```

These references have been dead since they were authored — the SVGs never existed in the repo. Removed the embed lines (and the single blank line that only existed to separate the embed from the prose). No surrounding text was rewritten; the lessons read fine without the figure placeholder.

The tenth was `'**args' (malformed link)` in `phases/05-nlp-foundations-to-advanced/17-chatbots-rule-to-neural/docs/en.md`. That was a false positive: `tools[tool_name](**args)` inside a Python fenced code block matches the audit's markdown-link regex. Split the expression across two lines so the `](**args)` adjacency disappears while the Python remains valid:

```python
fn = tools[tool_name]
result = fn(**args)
```

**2. CI workflow — flip audit to strict.**

With the backlog at zero, the warn-only escape hatch in `.github/workflows/curriculum.yml` is no longer needed:

- Removed `continue-on-error: true` from the audit step.
- Removed the "warn-only note" echo step.
- Renamed the job from `invariant checks (warn-only)` to `invariant checks`.

## Why this is safe

- Locally, `python3 scripts/audit_lessons.py` now exits 0 (435 lessons checked, 0 issues).
- The 11th backlog item, `phases/10-llms-from-scratch/18-synthetic-data-pipelines/docs/en.md: missing docs/en.md`, only appears on local checkouts that have an orphan `code/__pycache__` directory under that lesson slug. The directory is not in git (`git ls-files` for that path returns empty), so CI never sees it. No repo change needed.
- After this PR, any future PR that adds a broken link, missing `docs/en.md`, malformed quiz, or invalid lesson dir name will fail CI instead of silently emitting a notice.

## Test plan

- [x] `python3 scripts/audit_lessons.py` exits 0 locally
- [ ] `curriculum / invariant checks` job passes on this PR
- [ ] `curriculum / catalog.json drift check` still passes (no catalog changes in this PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI/CD**
  * Audit validation now enforces stricter quality checks; failed audits will block the CI pipeline.

* **Documentation**
  * Removed embedded diagram images from multiple NLP course modules to streamline lesson content and presentation.

* **Refactor**
  * Updated code structure in chatbots lesson to improve code example clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/ai-engineering-from-scratch/pull/129?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->