### PR TITLE
fix(site): split on /\r?\n/ to stop table separators leaking into lesson data

### DIFF
--- a/site/build.js
+++ b/site/build.js
@@ -25,7 +25,7 @@ function parseRoadmap(content) {
   let currentPhase = null;
   let currentPhaseStatus = null;
 
-  for (const line of content.split('\n')) {
+  for (const line of content.split(/\r?\n/)) {
     // Match phase headers like: ## Phase 0: Setup & Tooling — ✅
     const phaseMatch = line.match(/^##\s+Phase\s+(\d+).*?—\s*(✅|🚧|⬚)/);
     if (phaseMatch) {
@@ -60,7 +60,7 @@ function parseReadme(content, roadmapStatuses) {
   // Phase 0 is in a <table> block, phases 1-19 are in <details> blocks
   // We'll parse line by line to extract phase headers and lesson tables
 
-  const lines = content.split('\n');
+  const lines = content.split(/\r?\n/);
   let currentPhase = null;
   let inLessonTable = false;
   let isCapstoneTable = false;
@@ -240,7 +240,7 @@ function extractLessonMeta(relPath) {
   const docPath = path.join(REPO_ROOT, relPath, 'docs', 'en.md');
   const result = { summary: '', keywords: '' };
   try {
-    const lines = fs.readFileSync(docPath, 'utf8').split('\n');
+    const lines = fs.readFileSync(docPath, 'utf8').split(/\r?\n/);
     const h3s = [];
     for (const raw of lines) {
       const line = raw.trim();
@@ -265,7 +265,7 @@ function parseGlossary(content) {
   const terms = [];
   let currentTerm = null;
 
-  for (const line of content.split('\n')) {
+  for (const line of content.split(/\r?\n/)) {
     // Match term headers: ### Agent or ### Adam (Optimizer)
     const termMatch = line.match(/^###\s+(.+)/);
     if (termMatch) {


### PR DESCRIPTION
## What

Fixes #108.

On Windows (or any CRLF checkout), `content.split('\n')` leaves a trailing `\r` on each line. This makes the table separator regex `/^\|[\s:|-]+\|$/` miss — the `$` anchor can't match with `\r` still sitting after the final `|`.

The separator lines then fall through to lesson-row parsing, producing 20 ghost entries in `data.js` with:
- name: `--------`
- type: `:----:`
- lang: `------`

## Fix

Replaced all four `split('\n')` calls with `split(/\r?\n/)` in:
- `parseRoadmap`
- `parseReadme`
- `extractLessonMeta`
- `parseGlossary`

This handles both LF and CRLF without touching the separator regex itself.

## Verification

Before: 448 lessons (20 ghost separators parsed as lessons)
After: 428 lessons (all legitimate, zero ghost entries)

Tested locally on Windows with `node site/build.js` — confirmed no `"name": "--------"` entries remain in `site/data.js`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved build process compatibility with Windows systems for proper markdown file handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/ai-engineering-from-scratch/pull/131?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->