### PR TITLE
Add instructions to redirect git remote to user's own fork before pushing

### DIFF
--- a/phases/00-setup-and-tooling/02-git-and-collaboration/docs/en.md
+++ b/phases/00-setup-and-tooling/02-git-and-collaboration/docs/en.md
@@ -78,6 +78,7 @@ cd ai-engineering-from-scratch
 git checkout -b my-progress
 # By default, `origin` points to this repo. Run the command below to redirect pushes to your own fork:
 git remote set-url origin <your_repository_url>.git
+git remote -v # Check if the repository points to your fork
 
 # work through lessons, commit your code
 

--- a/phases/00-setup-and-tooling/02-git-and-collaboration/docs/en.md
+++ b/phases/00-setup-and-tooling/02-git-and-collaboration/docs/en.md
@@ -77,7 +77,8 @@ cd ai-engineering-from-scratch
 
 git checkout -b my-progress
 # By default, `origin` points to this repo. Run the command below to redirect pushes to your own fork:
-git remote set-url origin <your_repository_url>.git 
+git remote set-url origin <your_repository_url>.git
+
 # work through lessons, commit your code
 
 git push origin my-progress

--- a/phases/00-setup-and-tooling/02-git-and-collaboration/docs/en.md
+++ b/phases/00-setup-and-tooling/02-git-and-collaboration/docs/en.md
@@ -76,7 +76,10 @@ git clone https://github.com/rohitg00/ai-engineering-from-scratch.git
 cd ai-engineering-from-scratch
 
 git checkout -b my-progress
+# By default, `origin` points to this repo. Run the command below to redirect pushes to your own fork:
+git remote set-url origin <your_repository_url>.git 
 # work through lessons, commit your code
+
 git push origin my-progress
 ```
 


### PR DESCRIPTION
## What this PR does
Added a `git remote set-url` step to redirect pushes to the user's own forked repository instead of the original `rohitg00/ai-engineering-from-scratch` repository.

## Kind of change
- [ ] New lesson
- [ ] Fix to an existing lesson
- [ ] Translation
- [ ] New output (prompt, skill, agent, MCP server)
- [x] Docs / website / tooling

## Checklist
- [x] Code runs without errors with the listed dependencies
- [ ] No comments in code files (docs explain, code is self-explanatory)
- [ ] Built from scratch first, then shown with a framework (for new lessons)
- [ ] Lesson folder matches `LESSON_TEMPLATE.md` structure
- [ ] ROADMAP.md row for the lesson is a markdown link (`[Name](phases/...)`), not bare text
- [x] One lesson per commit (atomic per-lesson rule)
- [x] Tested locally / code output matches what `docs/en.md` claims

## Phase / lesson
Phase 0 · 02-git-and-collaboration

## Notes for reviewer
Users cloning the repo directly will have `origin` pointing to the original repository, causing push attempts to fail or target the wrong remote. This adds a `git remote set-url` step in the setup instructions to prevent that. No lesson content or code was modified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified course setup guidance: note that the default remote may point to the course repository, instruct learners to reset the remote URL to their own fork before pushing, and remind them to work through lessons and commit changes as they learn.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/ai-engineering-from-scratch/pull/136?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->