### PR TITLE
fix(site): mermaid labels readable in light mode (closes #110)

### DIFF
--- a/site/lesson.html
+++ b/site/lesson.html
@@ -917,10 +917,12 @@
       height: auto;
     }
 
-    .lesson-article .mermaid-render foreignObject p,
-    .lesson-article .mermaid-render foreignObject span,
-    .mermaid-modal-body foreignObject p,
-    .mermaid-modal-body foreignObject span {
+    :where(
+      .lesson-article .mermaid-render foreignObject p,
+      .lesson-article .mermaid-render foreignObject span,
+      .mermaid-modal-body foreignObject p,
+      .mermaid-modal-body foreignObject span
+    ) {
       font-family: var(--font-mono);
       font-size: 13px;
       line-height: 1.4;


### PR DESCRIPTION
Wraps mermaid label CSS override in `:where()` to drop selector specificity to 0. Mermaid-emitted node colors (e.g. `style A fill:#1a1a2e,color:#fff`) now win again, restoring readable labels on dark-filled nodes in light mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated styling implementation for diagram text rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/ai-engineering-from-scratch/pull/139?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->