### PR TITLE
fix(outputs): rename skills to remove name collisions

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -2717,8 +2717,8 @@
           "outputs": [
             {
               "type": "skill",
-              "name": "tokenizer-picker",
-              "path": "phases/05-nlp-foundations-to-advanced/04-glove-fasttext-subword/outputs/skill-tokenizer-picker.md",
+              "name": "embeddings-picker",
+              "path": "phases/05-nlp-foundations-to-advanced/04-glove-fasttext-subword/outputs/skill-embeddings-picker.md",
               "version": "1.0.0",
               "description": "Pick a tokenization approach for a new language model or text pipeline.",
               "tags": [
@@ -3101,8 +3101,8 @@
           "outputs": [
             {
               "type": "skill",
-              "name": "tokenizer-picker",
-              "path": "phases/05-nlp-foundations-to-advanced/19-subword-tokenization/outputs/skill-tokenizer-picker.md",
+              "name": "bpe-vs-wordpiece",
+              "path": "phases/05-nlp-foundations-to-advanced/19-subword-tokenization/outputs/skill-bpe-vs-wordpiece.md",
               "version": "1.0.0",
               "description": "Pick tokenizer algorithm, vocab size, library for a given corpus and deployment target.",
               "tags": [
@@ -5405,8 +5405,8 @@
             },
             {
               "type": "skill",
-              "name": "skill-evaluation",
-              "path": "phases/10-llms-from-scratch/10-evaluation/outputs/skill-evaluation.md",
+              "name": "llm-evaluation",
+              "path": "phases/10-llms-from-scratch/10-evaluation/outputs/skill-llm-evaluation.md",
               "version": "1.0.0",
               "description": "Decision framework for choosing the right LLM evaluation strategy based on task type, budget, and requirements",
               "tags": [

--- a/catalog.json
+++ b/catalog.json
@@ -2717,7 +2717,7 @@
           "outputs": [
             {
               "type": "skill",
-              "name": "embeddings-picker",
+              "name": "skill-embeddings-picker",
               "path": "phases/05-nlp-foundations-to-advanced/04-glove-fasttext-subword/outputs/skill-embeddings-picker.md",
               "version": "1.0.0",
               "description": "Pick a tokenization approach for a new language model or text pipeline.",
@@ -3101,7 +3101,7 @@
           "outputs": [
             {
               "type": "skill",
-              "name": "bpe-vs-wordpiece",
+              "name": "skill-bpe-vs-wordpiece",
               "path": "phases/05-nlp-foundations-to-advanced/19-subword-tokenization/outputs/skill-bpe-vs-wordpiece.md",
               "version": "1.0.0",
               "description": "Pick tokenizer algorithm, vocab size, library for a given corpus and deployment target.",
@@ -5405,7 +5405,7 @@
             },
             {
               "type": "skill",
-              "name": "llm-evaluation",
+              "name": "skill-llm-evaluation",
               "path": "phases/10-llms-from-scratch/10-evaluation/outputs/skill-llm-evaluation.md",
               "version": "1.0.0",
               "description": "Decision framework for choosing the right LLM evaluation strategy based on task type, budget, and requirements",

--- a/phases/05-nlp-foundations-to-advanced/04-glove-fasttext-subword/docs/en.md
+++ b/phases/05-nlp-foundations-to-advanced/04-glove-fasttext-subword/docs/en.md
@@ -211,7 +211,7 @@ The `Ġ` prefix marks word boundaries (a GPT-2 convention). Every modern tokeniz
 
 ## Ship It
 
-Save as `outputs/skill-tokenizer-picker.md`:
+Save as `outputs/skill-embeddings-picker.md`:
 
 ```markdown
 ---

--- a/phases/05-nlp-foundations-to-advanced/04-glove-fasttext-subword/outputs/skill-embeddings-picker.md
+++ b/phases/05-nlp-foundations-to-advanced/04-glove-fasttext-subword/outputs/skill-embeddings-picker.md
@@ -1,5 +1,5 @@
 ---
-name: embeddings-picker
+name: skill-embeddings-picker
 description: Pick a tokenization approach for a new language model or text pipeline.
 version: 1.0.0
 phase: 5

--- a/phases/05-nlp-foundations-to-advanced/04-glove-fasttext-subword/outputs/skill-embeddings-picker.md
+++ b/phases/05-nlp-foundations-to-advanced/04-glove-fasttext-subword/outputs/skill-embeddings-picker.md
@@ -1,5 +1,5 @@
 ---
-name: tokenizer-picker
+name: embeddings-picker
 description: Pick a tokenization approach for a new language model or text pipeline.
 version: 1.0.0
 phase: 5

--- a/phases/05-nlp-foundations-to-advanced/19-subword-tokenization/docs/en.md
+++ b/phases/05-nlp-foundations-to-advanced/19-subword-tokenization/docs/en.md
@@ -132,7 +132,7 @@ Vocabulary size is a scaling decision, not a constant. Rough heuristic: 32k for 
 
 ## Ship It
 
-Save as `outputs/skill-tokenizer-picker.md`:
+Save as `outputs/skill-bpe-vs-wordpiece.md`:
 
 ```markdown
 ---

--- a/phases/05-nlp-foundations-to-advanced/19-subword-tokenization/outputs/skill-bpe-vs-wordpiece.md
+++ b/phases/05-nlp-foundations-to-advanced/19-subword-tokenization/outputs/skill-bpe-vs-wordpiece.md
@@ -1,5 +1,5 @@
 ---
-name: bpe-vs-wordpiece
+name: skill-bpe-vs-wordpiece
 description: Pick tokenizer algorithm, vocab size, library for a given corpus and deployment target.
 version: 1.0.0
 phase: 5

--- a/phases/05-nlp-foundations-to-advanced/19-subword-tokenization/outputs/skill-bpe-vs-wordpiece.md
+++ b/phases/05-nlp-foundations-to-advanced/19-subword-tokenization/outputs/skill-bpe-vs-wordpiece.md
@@ -1,5 +1,5 @@
 ---
-name: tokenizer-picker
+name: bpe-vs-wordpiece
 description: Pick tokenizer algorithm, vocab size, library for a given corpus and deployment target.
 version: 1.0.0
 phase: 5

--- a/phases/10-llms-from-scratch/10-evaluation/docs/en.md
+++ b/phases/10-llms-from-scratch/10-evaluation/docs/en.md
@@ -478,7 +478,7 @@ RAGAS measures what generic evals miss: whether the model's answer is grounded i
 
 This lesson produces `outputs/prompt-eval-designer.md` -- a reusable prompt that designs custom eval suites for any task. Give it a task description and it generates test cases, scoring functions, and a pass/fail threshold recommendation.
 
-It also produces `outputs/skill-evaluation.md` -- a decision framework for choosing the right evaluation strategy based on your task type, budget, and latency requirements.
+It also produces `outputs/skill-llm-evaluation.md` -- a decision framework for choosing the right evaluation strategy based on your task type, budget, and latency requirements.
 
 ## Exercises
 

--- a/phases/10-llms-from-scratch/10-evaluation/outputs/skill-llm-evaluation.md
+++ b/phases/10-llms-from-scratch/10-evaluation/outputs/skill-llm-evaluation.md
@@ -1,5 +1,5 @@
 ---
-name: skill-evaluation
+name: llm-evaluation
 description: Decision framework for choosing the right LLM evaluation strategy based on task type, budget, and requirements
 version: 1.0.0
 phase: 10

--- a/phases/10-llms-from-scratch/10-evaluation/outputs/skill-llm-evaluation.md
+++ b/phases/10-llms-from-scratch/10-evaluation/outputs/skill-llm-evaluation.md
@@ -1,5 +1,5 @@
 ---
-name: llm-evaluation
+name: skill-llm-evaluation
 description: Decision framework for choosing the right LLM evaluation strategy based on task type, budget, and requirements
 version: 1.0.0
 phase: 10


### PR DESCRIPTION
Phase 10 `skill-evaluation` -> `skill-llm-evaluation` (Phase 2 keeps the canonical `skill-evaluation`). Both Phase 5 `skill-tokenizer-picker` renamed: `04-glove-fasttext-subword` -> `skill-embeddings-picker`, `19-subword-tokenization` -> `skill-bpe-vs-wordpiece`. Cross-refs in docs updated. Catalog regenerated. `install_skills.py --layout skillkit` now installs 378/378 without collision warnings.