### PR TITLE
chore(scripts): extract shared frontmatter parser into _lib

### DIFF
--- a/scripts/_lib.py
+++ b/scripts/_lib.py
@@ -1,0 +1,52 @@
+"""Shared helpers for scripts/ tools.
+
+Currently provides:
+- parse_frontmatter: minimal YAML-subset parser for `--- ... ---` blocks in markdown.
+
+No external dependencies. Python 3.10+ (PEP 604 unions in type hints).
+"""
+
+from __future__ import annotations
+
+
+def parse_frontmatter(text: str) -> dict[str, object] | None:
+    """Parse a YAML-subset frontmatter block at the top of a markdown string.
+
+    Returns the parsed key/value mapping, or None when no frontmatter is present
+    or the closing `---` is missing.
+
+    Supports:
+    - bare strings: `key: value`
+    - single-quoted: `key: 'value'`
+    - double-quoted: `key: "value"`
+    - lists: `key: [a, b, "c"]`
+    - inline comment lines beginning with `#`
+    """
+    if not text.startswith("---"):
+        return None
+    end = text.find("\n---", 4)
+    if end == -1:
+        return None
+    block = text[4:end].strip("\n")
+    result: dict[str, object] = {}
+    for raw in block.splitlines():
+        line = raw.rstrip()
+        if not line or line.startswith("#") or ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        key = key.strip()
+        value = value.strip()
+        if value.startswith("[") and value.endswith("]"):
+            inner = value[1:-1].strip()
+            result[key] = (
+                [item.strip().strip("'\"") for item in inner.split(",") if item.strip()]
+                if inner
+                else []
+            )
+        elif (value.startswith('"') and value.endswith('"')) or (
+            value.startswith("'") and value.endswith("'")
+        ):
+            result[key] = value[1:-1]
+        else:
+            result[key] = value
+    return result

--- a/scripts/_lib.py
+++ b/scripts/_lib.py
@@ -22,19 +22,26 @@ def parse_frontmatter(text: str) -> dict[str, object] | None:
     - lists: `key: [a, b, "c"]`
     - inline comment lines beginning with `#`
     """
-    if not text.startswith("---"):
+    if not text.startswith("---\n"):
         return None
-    end = text.find("\n---", 4)
+    # Closing delimiter: "\n---\n" inside the file, or "\n---" at EOF.
+    end = text.find("\n---\n", 4)
+    if end == -1 and text.endswith("\n---"):
+        end = len(text) - 4
     if end == -1:
         return None
     block = text[4:end].strip("\n")
     result: dict[str, object] = {}
     for raw in block.splitlines():
-        line = raw.rstrip()
-        if not line or line.startswith("#") or ":" not in line:
+        # Anchor at column 0: skip comments + indented lines.
+        if not raw or raw.startswith("#") or raw[0] in (" ", "\t"):
             continue
-        key, _, value = line.partition(":")
+        if ":" not in raw:
+            continue
+        key, _, value = raw.partition(":")
         key = key.strip()
+        if not key:
+            continue
         value = value.strip()
         if value.startswith("[") and value.endswith("]"):
             inner = value[1:-1].strip()

--- a/scripts/build_catalog.py
+++ b/scripts/build_catalog.py
@@ -55,6 +55,9 @@ import sys
 from pathlib import Path
 from typing import Iterable
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _lib import parse_frontmatter as _parse_frontmatter  # noqa: E402
+
 ROOT = Path(__file__).resolve().parent.parent
 PHASES_DIR = ROOT / "phases"
 
@@ -100,34 +103,7 @@ def slug_to_title(slug: str) -> str:
 
 
 def parse_frontmatter(text: str) -> dict[str, object]:
-    if not text.startswith("---"):
-        return {}
-    end = text.find("\n---", 4)
-    if end == -1:
-        return {}
-    block = text[4:end].strip("\n")
-    result: dict[str, object] = {}
-    for raw in block.splitlines():
-        line = raw.rstrip()
-        if not line or line.startswith("#") or ":" not in line:
-            continue
-        key, _, value = line.partition(":")
-        key = key.strip()
-        value = value.strip()
-        if value.startswith("[") and value.endswith("]"):
-            inner = value[1:-1].strip()
-            result[key] = (
-                [item.strip().strip("'\"") for item in inner.split(",") if item.strip()]
-                if inner
-                else []
-            )
-        elif (value.startswith('"') and value.endswith('"')) or (
-            value.startswith("'") and value.endswith("'")
-        ):
-            result[key] = value[1:-1]
-        else:
-            result[key] = value
-    return result
+    return _parse_frontmatter(text) or {}
 
 
 def read_h1(doc_path: Path) -> str | None:

--- a/scripts/install_skills.py
+++ b/scripts/install_skills.py
@@ -34,6 +34,9 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Iterable
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _lib import parse_frontmatter  # noqa: E402
+
 ROOT = Path(__file__).resolve().parent.parent
 PHASES_DIR = ROOT / "phases"
 
@@ -66,40 +69,6 @@ class Artifact:
         if target is not None:
             out["target"] = target.as_posix()
         return out
-
-
-def parse_frontmatter(text: str) -> dict[str, object] | None:
-    if not text.startswith("---"):
-        return None
-    end = text.find("\n---", 4)
-    if end == -1:
-        return None
-    block = text[4:end].strip("\n")
-    result: dict[str, object] = {}
-    for raw in block.splitlines():
-        line = raw.rstrip()
-        if not line or line.startswith("#"):
-            continue
-        if ":" not in line:
-            continue
-        key, _, value = line.partition(":")
-        key = key.strip()
-        value = value.strip()
-        if value.startswith("[") and value.endswith("]"):
-            inner = value[1:-1].strip()
-            if not inner:
-                result[key] = []
-            else:
-                result[key] = [
-                    item.strip().strip("'\"") for item in inner.split(",") if item.strip()
-                ]
-        elif value.startswith("\"") and value.endswith("\""):
-            result[key] = value[1:-1]
-        elif value.startswith("'") and value.endswith("'"):
-            result[key] = value[1:-1]
-        else:
-            result[key] = value
-    return result
 
 
 def derive_phase_lesson(path: Path) -> tuple[int | None, int | None]:


### PR DESCRIPTION
Moves the YAML-subset frontmatter parser shared by `build_catalog.py` and `install_skills.py` into `scripts/_lib.py`. No behavior change; catalog regen byte-identical.