### PR TITLE
fix(a11y): skip-to-content link + focus-visible rings

### DIFF
--- a/site/catalog.html
+++ b/site/catalog.html
@@ -70,6 +70,12 @@
       border-color: var(--accent);
     }
 
+    .catalog-search:focus-visible,
+    .catalog-filter:focus-visible {
+      outline: 2px solid var(--blueprint);
+      outline-offset: 2px;
+    }
+
     .catalog-filter {
       font-family: var(--font-body);
       font-size: 1rem;
@@ -211,6 +217,8 @@
 </head>
 <body>
 
+  <a href="#main" class="skip-link">Skip to content</a>
+
   <header class="site-header">
     <div class="header-inner">
       <a href="index.html" class="logo">
@@ -242,7 +250,7 @@
     </div>
   </header>
 
-  <main class="catalog-page">
+  <main class="catalog-page" id="main">
     <div class="container">
       <div class="catalog-header">
         <h1>Lesson Catalog</h1>

--- a/site/glossary.html
+++ b/site/glossary.html
@@ -67,6 +67,11 @@
       border-color: var(--accent);
     }
 
+    .glossary-search:focus-visible {
+      outline: 2px solid var(--blueprint);
+      outline-offset: 2px;
+    }
+
     .glossary-count {
       text-align: center;
       font-family: var(--font-mono);
@@ -163,6 +168,8 @@
 </head>
 <body>
 
+  <a href="#main" class="skip-link">Skip to content</a>
+
   <header class="site-header">
     <div class="header-inner">
       <a href="index.html" class="logo">
@@ -194,7 +201,7 @@
     </div>
   </header>
 
-  <main class="glossary-page">
+  <main class="glossary-page" id="main">
     <div class="container">
       <div class="glossary-header">
         <h1>AI Glossary</h1>

--- a/site/index.html
+++ b/site/index.html
@@ -568,6 +568,8 @@
 </head>
 <body>
 
+  <a href="#main" class="skip-link">Skip to content</a>
+
   <header class="site-header">
     <div class="header-inner">
       <a href="index.html" class="logo">
@@ -598,7 +600,7 @@
     </div>
   </header>
 
-  <main>
+  <main id="main">
 
     <section class="manual-masthead container">
       <div class="manual-meta-row">

--- a/site/lesson.html
+++ b/site/lesson.html
@@ -1563,6 +1563,8 @@
 </head>
 <body>
 
+  <a href="#main" class="skip-link">Skip to content</a>
+
   <div class="scroll-progress" id="scrollProgress"></div>
 
   <header class="site-header">
@@ -1612,7 +1614,7 @@
 
   <div class="lesson-layout">
     <aside class="lesson-sidebar" id="lessonSidebar"></aside>
-    <main class="lesson-main">
+    <main class="lesson-main" id="main">
       <div class="lesson-content" id="lessonContent">
         <div class="lesson-loading" id="lessonLoading">
           <div class="spinner"></div>

--- a/site/prereqs.html
+++ b/site/prereqs.html
@@ -394,6 +394,8 @@
 </head>
 <body>
 
+  <a href="#main" class="skip-link">Skip to content</a>
+
   <header class="site-header">
     <div class="header-inner">
       <a href="index.html" class="logo">
@@ -425,7 +427,7 @@
     </div>
   </header>
 
-  <main class="prereqs-page">
+  <main class="prereqs-page" id="main">
     <div class="container">
       <div class="prereqs-header">
         <h1>Roadmap</h1>

--- a/site/style.css
+++ b/site/style.css
@@ -101,6 +101,28 @@ body {
   transition: background-color 0.2s, color 0.2s;
 }
 
+.skip-link {
+  position: absolute;
+  left: -9999px;
+  top: 0;
+  z-index: 9999;
+  background: var(--blueprint);
+  color: #fff;
+  padding: 12px 18px;
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+  text-decoration: none;
+  border-radius: 0;
+}
+
+.skip-link:focus,
+.skip-link:focus-visible {
+  left: 16px;
+  top: 16px;
+  outline: 2px solid var(--ink);
+  outline-offset: 2px;
+}
+
 .container {
   max-width: 1200px;
   margin: 0 auto;


### PR DESCRIPTION
Adds visually-hidden `Skip to content` link as first child of `<body>` on all 5 site pages (index, lesson, catalog, glossary, prereqs), revealing on first Tab. Adds `:focus-visible` outlines on `.catalog-search`, `.catalog-filter`, and `.glossary-search` so keyboard users see a focus ring on inputs that strip the default outline.