### PR TITLE
feat(phase-14/15): expand crewai-role-based-crews to phase median

### DIFF
--- a/phases/14-agent-engineering/15-crewai-role-based-crews/code/main.py
+++ b/phases/14-agent-engineering/15-crewai-role-based-crews/code/main.py
@@ -10,6 +10,7 @@ keyed off agent role and input prefix.
 
 from __future__ import annotations
 
+import hashlib
 from dataclasses import dataclass, field
 from typing import Any, Callable
 
@@ -166,7 +167,11 @@ class Memory:
         self.entity: dict[str, dict[str, str]] = {}
 
     def _embed(self, text: str) -> np.ndarray:
-        rng = np.random.default_rng(abs(hash(text)) % (2**32))
+        seed = int.from_bytes(
+            hashlib.sha256(text.encode("utf-8")).digest()[:8],
+            "little",
+        )
+        rng = np.random.default_rng(seed)
         v = rng.standard_normal(self.dim)
         n = np.linalg.norm(v)
         return v / n if n > 0 else v
@@ -194,7 +199,12 @@ class Memory:
 
 def _researcher(prior: Any, tools: list[Callable[..., str]], memory: Memory | None) -> str:
     topic = prior if isinstance(prior, str) else ""
-    sources = search(topic) if tools else "src1, src2, src3"
+    # Run whichever search-ish tool the agent was wired with, in order.
+    search_fn = next(
+        (t for t in tools if getattr(t, "is_tool", False) and "search" in getattr(t, "tool_name", "").lower()),
+        None,
+    )
+    sources = search_fn(topic) if search_fn else "src1, src2, src3"
     return f"3 sources on {topic}: {sources}"
 
 
@@ -283,15 +293,24 @@ def main() -> None:
 
     @flow.start
     def kickoff(topic: str) -> tuple[str, str]:
-        return "researched", _researcher(topic, [search], memory)
+        out = _researcher(topic, [search], memory)
+        memory.write_short_term("researcher", out)
+        memory.write_long_term("researcher", out)
+        return "researched", out
 
     @flow.listen("researched")
     def on_researched(prior: str) -> tuple[str, str]:
-        return "drafted", _writer(prior, [], memory)
+        out = _writer(prior, [], memory)
+        memory.write_short_term("writer", out)
+        memory.write_long_term("writer", out)
+        return "drafted", out
 
     @flow.listen("drafted")
     def on_drafted(prior: str) -> tuple[str, str]:
-        return "edited", _editor(prior, [], memory)
+        out = _editor(prior, [], memory)
+        memory.write_short_term("editor", out)
+        memory.write_long_term("editor", out)
+        return "edited", out
 
     @flow.listen("edited")
     def on_edited(prior: str) -> None:

--- a/phases/14-agent-engineering/15-crewai-role-based-crews/code/main.py
+++ b/phases/14-agent-engineering/15-crewai-role-based-crews/code/main.py
@@ -1,13 +1,44 @@
 """CrewAI-shaped Crew and Flow primitives in stdlib.
 
-Crew = role-based autonomous collaboration. Flow = event-driven deterministic.
-Same three-step task (research, outline, draft) implemented both ways.
+Three-agent crew (researcher, writer, editor) producing a brief on
+"agent engineering 2026". Same crew is run Sequential, Hierarchical, and
+through a Flow to show all three execution shapes.
+
+Stdlib + numpy. Mock LLM responses are deterministic hardcoded strings
+keyed off agent role and input prefix.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Any, Callable
+
+import numpy as np
+
+
+def tool(name: str) -> Callable[[Callable[..., str]], Callable[..., str]]:
+    """Mirror of CrewAI's @tool decorator. Marks a function as a tool the
+    Agent can call. Docstring is the description; signature is the schema."""
+
+    def decorator(fn: Callable[..., str]) -> Callable[..., str]:
+        fn.tool_name = name  # type: ignore[attr-defined]
+        fn.is_tool = True  # type: ignore[attr-defined]
+        return fn
+
+    return decorator
+
+
+@tool("Search the web")
+def search(query: str) -> str:
+    """Return top results for the query."""
+    fixtures = {
+        "agent engineering": "src1: agent loop, src2: tool use, src3: memory",
+        "crewai": "src1: docs intro, src2: flows guide, src3: tools ref",
+    }
+    for key, value in fixtures.items():
+        if key in query.lower():
+            return value
+    return "src1: generic, src2: generic, src3: generic"
 
 
 @dataclass
@@ -16,6 +47,7 @@ class Agent:
     goal: str
     backstory: str
     fn: Callable[..., str]
+    tools: list[Callable[..., str]] = field(default_factory=list)
 
 
 @dataclass
@@ -23,21 +55,25 @@ class Task:
     description: str
     expected_output: str
     agent: Agent
-    inputs: dict[str, Any] = field(default_factory=dict)
+    context: list["Task"] = field(default_factory=list)
 
 
 @dataclass
 class SequentialCrew:
     agents: list[Agent]
     tasks: list[Task]
+    memory: "Memory | None" = None
 
-    def kickoff(self, context: dict[str, Any]) -> list[str]:
+    def kickoff(self, inputs: dict[str, Any]) -> list[str]:
         outputs: list[str] = []
-        running = context.get("topic", "")
+        prior = inputs.get("topic", "")
         for task in self.tasks:
-            out = task.agent.fn(running)
+            out = task.agent.fn(prior, task.agent.tools, self.memory)
             outputs.append(f"[{task.agent.role}] {out}")
-            running = out
+            prior = out
+            if self.memory is not None:
+                self.memory.write_short_term(task.agent.role, out)
+                self.memory.write_long_term(task.agent.role, out)
         return outputs
 
 
@@ -46,13 +82,14 @@ class HierarchicalCrew:
     manager: Agent
     specialists: dict[str, Agent]
     max_steps: int = 5
+    memory: "Memory | None" = None
 
     def kickoff(self, topic: str) -> list[str]:
         outputs: list[str] = []
         current = topic
         done: set[str] = set()
         for _ in range(self.max_steps):
-            pick = self.manager.fn(done)
+            pick = self.manager.fn(done, [], None)
             if pick == "done":
                 outputs.append("[manager] done")
                 break
@@ -60,16 +97,18 @@ class HierarchicalCrew:
             if specialist is None:
                 outputs.append(f"[manager] unknown pick {pick!r}")
                 break
-            out = specialist.fn(current)
-            outputs.append(f"[{specialist.role}] {out}")
+            out = specialist.fn(current, specialist.tools, self.memory)
+            outputs.append(f"[manager -> {specialist.role}] {out}")
             current = out
             done.add(pick)
+            if self.memory is not None:
+                self.memory.write_short_term(specialist.role, out)
         return outputs
 
 
 class Flow:
-    """Deterministic event-driven workflow. start() fires on kickoff;
-    listen(topic) fires when another step emits that topic.
+    """Deterministic event-driven workflow. @start fires on kickoff;
+    @listen(topic) fires when another step emits that topic.
     """
 
     def __init__(self) -> None:
@@ -85,6 +124,7 @@ class Flow:
         def decorator(fn: Callable[[Any], tuple[str, Any] | None]) -> Callable[..., Any]:
             self.listeners[topic] = fn
             return fn
+
         return decorator
 
     def kickoff(self, payload: Any) -> list[tuple[str, str, Any]]:
@@ -103,91 +143,174 @@ class Flow:
         return self.trace
 
 
-def _researcher(topic: str) -> str:
-    return f"research: {topic} - 3 sources gathered"
+class Memory:
+    """Four-store memory matching CrewAI's short, long, entity, contextual.
+    Long-term retrieval uses numpy cosine similarity on hashed token vectors.
+    """
+
+    def __init__(self, dim: int = 16) -> None:
+        self.dim = dim
+        self.short_term: list[tuple[str, str]] = []
+        self.long_term: list[tuple[str, str, np.ndarray]] = []
+        self.entity: dict[str, dict[str, str]] = {}
+
+    def _embed(self, text: str) -> np.ndarray:
+        rng = np.random.default_rng(abs(hash(text)) % (2**32))
+        v = rng.standard_normal(self.dim)
+        n = np.linalg.norm(v)
+        return v / n if n > 0 else v
+
+    def write_short_term(self, role: str, value: str) -> None:
+        self.short_term.append((role, value))
+
+    def write_long_term(self, role: str, value: str) -> None:
+        self.long_term.append((role, value, self._embed(value)))
+
+    def write_entity(self, entity_id: str, key: str, value: str) -> None:
+        self.entity.setdefault(entity_id, {})[key] = value
+
+    def recall_long_term(self, query: str, k: int = 2) -> list[tuple[str, str, float]]:
+        if not self.long_term:
+            return []
+        q = self._embed(query)
+        scored = [(r, v, float(np.dot(q, e))) for r, v, e in self.long_term]
+        scored.sort(key=lambda row: row[2], reverse=True)
+        return scored[:k]
+
+    def reset_short_term(self) -> None:
+        self.short_term = []
 
 
-def _outliner(prior: str) -> str:
-    return f"outline: 3 sections from '{prior[:30]}...'"
+def _researcher(prior: Any, tools: list[Callable[..., str]], memory: Memory | None) -> str:
+    topic = prior if isinstance(prior, str) else ""
+    sources = search(topic) if tools else "src1, src2, src3"
+    return f"3 sources on {topic}: {sources}"
 
 
-def _drafter(prior: str) -> str:
-    return f"draft: 800 words based on '{prior[:30]}...'"
+def _writer(prior: Any, tools: list[Callable[..., str]], memory: Memory | None) -> str:
+    text = prior if isinstance(prior, str) else ""
+    return f"draft (3 paragraphs) from sources: {text[:60]}"
 
 
-def _manager(done: set[str]) -> str:
+def _editor(prior: Any, tools: list[Callable[..., str]], memory: Memory | None) -> str:
+    text = prior if isinstance(prior, str) else ""
+    return f"final brief (tightened, 800 words): {text[:60]}"
+
+
+def _manager(prior: Any, tools: list[Callable[..., str]], memory: Memory | None) -> str:
+    done = prior if isinstance(prior, set) else set()
     if "researcher" not in done:
         return "researcher"
-    if "outliner" not in done:
-        return "outliner"
-    if "drafter" not in done:
-        return "drafter"
+    if "writer" not in done:
+        return "writer"
+    if "editor" not in done:
+        return "editor"
     return "done"
+
+
+def build_agents() -> tuple[Agent, Agent, Agent]:
+    researcher = Agent(
+        role="researcher",
+        goal="find 3 credible sources",
+        backstory="former librarian. terse. cites primaries.",
+        fn=_researcher,
+        tools=[search],
+    )
+    writer = Agent(
+        role="writer",
+        goal="turn sources into a draft",
+        backstory="editorial voice. paragraphs of three.",
+        fn=_writer,
+    )
+    editor = Agent(
+        role="editor",
+        goal="tighten draft to final brief",
+        backstory="cuts adjectives. enforces house style.",
+        fn=_editor,
+    )
+    return researcher, writer, editor
 
 
 def main() -> None:
     print("=" * 70)
-    print("CREWAI CREW AND FLOW — Phase 14, Lesson 15")
+    print("CREWAI CREW AND FLOW - Phase 14, Lesson 15")
     print("=" * 70)
 
-    researcher = Agent(role="researcher", goal="find 3 sources",
-                       backstory="former librarian, terse", fn=_researcher)
-    outliner = Agent(role="outliner", goal="structure the piece",
-                     backstory="writes in threes", fn=_outliner)
-    drafter = Agent(role="drafter", goal="turn outline into prose",
-                    backstory="editorial voice", fn=_drafter)
+    researcher, writer, editor = build_agents()
+    memory = Memory()
 
-    print("\n1. SequentialCrew (autonomous role-based)")
-    crew = SequentialCrew(
-        agents=[researcher, outliner, drafter],
+    print("\n1. SequentialCrew (researcher -> writer -> editor)")
+    seq = SequentialCrew(
+        agents=[researcher, writer, editor],
         tasks=[
-            Task(description="research topic", expected_output="sources",
-                 agent=researcher),
-            Task(description="outline", expected_output="3 sections",
-                 agent=outliner),
-            Task(description="draft", expected_output="800 words",
-                 agent=drafter),
+            Task("research the topic", "3 sources", researcher),
+            Task("write a draft", "3 paragraphs", writer),
+            Task("edit to final brief", "800 words", editor),
         ],
+        memory=memory,
     )
-    for line in crew.kickoff({"topic": "agent engineering 2026"}):
+    for line in seq.kickoff({"topic": "agent engineering 2026"}):
         print(f"  {line}")
 
     print("\n2. HierarchicalCrew (manager routes)")
-    manager = Agent(role="manager", goal="pick next specialist",
-                    backstory="PM background", fn=_manager)
+    manager = Agent(
+        role="manager",
+        goal="pick next specialist",
+        backstory="PM background. routes by missing role.",
+        fn=_manager,
+    )
     hcrew = HierarchicalCrew(
         manager=manager,
-        specialists={"researcher": researcher, "outliner": outliner,
-                     "drafter": drafter},
+        specialists={"researcher": researcher, "writer": writer, "editor": editor},
+        memory=memory,
     )
     for line in hcrew.kickoff("agent engineering 2026"):
         print(f"  {line}")
 
-    print("\n3. Flow (event-driven deterministic)")
+    print("\n3. Flow (deterministic, event-driven)")
     flow = Flow()
 
     @flow.start
     def kickoff(topic: str) -> tuple[str, str]:
-        return "researched", _researcher(topic)
+        return "researched", _researcher(topic, [search], memory)
 
     @flow.listen("researched")
     def on_researched(prior: str) -> tuple[str, str]:
-        return "outlined", _outliner(prior)
-
-    @flow.listen("outlined")
-    def on_outlined(prior: str) -> tuple[str, str]:
-        return "drafted", _drafter(prior)
+        return "drafted", _writer(prior, [], memory)
 
     @flow.listen("drafted")
-    def on_drafted(prior: str) -> None:
+    def on_drafted(prior: str) -> tuple[str, str]:
+        return "edited", _editor(prior, [], memory)
+
+    @flow.listen("edited")
+    def on_edited(prior: str) -> None:
         return None
 
     for step_name, topic, output in flow.kickoff("agent engineering 2026"):
-        print(f"  [{step_name}] -> topic={topic!r} output={output}")
+        print(f"  [{step_name}] topic={topic!r} out={output[:60]}")
+
+    print("\n4. Memory: recall_long_term('brief')")
+    for role, value, score in memory.recall_long_term("brief"):
+        print(f"  [{role}] score={score:+.3f} value={value[:50]}")
+
+    print("\n5. Second kickoff (long-term memory survives)")
+    memory.reset_short_term()
+    seq2 = SequentialCrew(
+        agents=[researcher, writer, editor],
+        tasks=[
+            Task("research", "3 sources", researcher),
+            Task("draft", "3 paragraphs", writer),
+            Task("edit", "800 words", editor),
+        ],
+        memory=memory,
+    )
+    seq2.kickoff({"topic": "agent engineering 2026"})
+    print(f"  long_term entries: {len(memory.long_term)}")
+    print(f"  short_term entries (this run): {len(memory.short_term)}")
 
     print()
-    print("Crew: variable, LLM picks the shape. Flow: fixed, code owns the shape.")
-    print("CrewAI 2026 docs: start production with Flow; fold Crews in as sub-steps.")
+    print("Crew: LLM picks the shape. Flow: code owns the shape.")
+    print("Docs (2026): start production with a Flow; fold Crews in as sub-steps.")
 
 
 if __name__ == "__main__":

--- a/phases/14-agent-engineering/15-crewai-role-based-crews/code/main.py
+++ b/phases/14-agent-engineering/15-crewai-role-based-crews/code/main.py
@@ -67,9 +67,20 @@ class SequentialCrew:
     def kickoff(self, inputs: dict[str, Any]) -> list[str]:
         outputs: list[str] = []
         prior = inputs.get("topic", "")
+        by_task: dict[int, str] = {}
         for task in self.tasks:
-            out = task.agent.fn(prior, task.agent.tools, self.memory)
+            if task.context:
+                # CrewAI behavior: feed outputs of every declared upstream task
+                # into the current one. Falls back to prior when none declared.
+                joined = "\n\n".join(
+                    by_task[id(t)] for t in task.context if id(t) in by_task
+                )
+                agent_input = joined or prior
+            else:
+                agent_input = prior
+            out = task.agent.fn(agent_input, task.agent.tools, self.memory)
             outputs.append(f"[{task.agent.role}] {out}")
+            by_task[id(task)] = out
             prior = out
             if self.memory is not None:
                 self.memory.write_short_term(task.agent.role, out)

--- a/phases/14-agent-engineering/15-crewai-role-based-crews/docs/en.md
+++ b/phases/14-agent-engineering/15-crewai-role-based-crews/docs/en.md
@@ -1,64 +1,149 @@
 # CrewAI: Role-Based Crews and Flows
 
-> CrewAI is the 2026 role-based multi-agent framework — Agents, Tasks, Crews, Processes as the four primitives. Production guidance from the docs: "for any production-ready application, start with a Flow."
+> CrewAI is the 2026 role-based multi-agent framework. Four primitives: Agent, Task, Crew, Process. Two top-level shapes: Crews (autonomous, role-based collaboration) and Flows (event-driven, deterministic). The docs are blunt: "for any production-ready application, start with a Flow."
 
 **Type:** Learn + Build
 **Languages:** Python (stdlib)
 **Prerequisites:** Phase 14 · 12 (Workflow Patterns), Phase 14 · 14 (Actor Model)
-**Time:** ~60 minutes
+**Time:** ~75 minutes
 
 ## Learning Objectives
 
-- Name CrewAI's four primitives — Agent, Task, Crew, Process — and the role of each.
-- Distinguish Crews (autonomous role-based collaboration) from Flows (event-driven deterministic workflows).
-- Explain why the docs recommend starting with Flows for production and Crews for exploration.
-- Implement a stdlib Crew runner plus a stdlib Flow runner; show when each shines.
+- Name CrewAI's four primitives (Agent, Task, Crew, Process) and what each owns.
+- Distinguish Sequential, Hierarchical, and Consensual processes; pick one per workload.
+- Distinguish Crews (autonomous role-based) from Flows (event-driven deterministic), and explain the docs' production recommendation.
+- Wire tools with the `@tool` decorator and `BaseTool` subclass; reason about structured outputs vs free text.
+- Name the four CrewAI memory types and when each pays off.
+- Implement a stdlib three-agent crew (researcher, writer, editor) that produces a brief.
+- Spot the three CrewAI failure modes: prompt-bloat, manager-LLM tax, brittle handoffs.
 
 ## The Problem
 
-Teams adopting multi-agent frameworks hit the same wall: "autonomous collaboration" sounds great, but when customers file a bug you need deterministic replay. CrewAI splits this explicitly — Crews for creative collaboration, Flows for event-driven, auditable, production-shaped workflows.
+Teams adopting multi-agent frameworks hit the same wall. "Autonomous collaboration" sounds great in a demo. Then a customer files a bug and you need deterministic replay. Or finance asks how much an LLM-routed crew costs per run. Or on-call needs to know which agent stalled at 3 AM.
+
+Free-form LLM-routed crews answer none of those cleanly. Pure DAGs answer them all but lose the exploratory shape a brainstorming agent needs.
+
+CrewAI's split is honest about the trade. Crews for collaborative, role-based, exploratory work. Flows for event-driven, code-owned, auditable production. Same framework, two shapes, pick per surface.
 
 ## The Concept
 
 ### Four primitives
 
-- **Agent.** Role + goal + backstory + tools. The backstory is load-bearing — it shapes tone and judgment.
-- **Task.** Description + expected_output + assigned agent. Reusable unit of work.
-- **Crew.** Container that sequences Agents and Tasks. Owns the execution Process.
-- **Process.** Sequential or Hierarchical (with a manager Agent) or Consensual.
+CrewAI's surface is small. Memorize this and the rest is config.
+
+- **Agent.** `role + goal + backstory + tools + (optional) llm`. The backstory is load-bearing. It shapes tone, judgment, when the agent stops. Tools are functions the agent can call (more below).
+- **Task.** `description + expected_output + agent + (optional) context + (optional) output_pydantic`. A reusable unit of work. `expected_output` is the contract. `context` lists upstream tasks whose outputs are passed in. `output_pydantic` forces a structured shape.
+- **Crew.** Container. Owns the list of `agents`, the list of `tasks`, the `process`, and optional `memory` + `verbose` + `manager_llm` settings.
+- **Process.** Execution strategy. Sequential, Hierarchical, Consensual. Picks the shape of the run.
+
+Agents do not see each other directly. Tasks reference agents. The Crew sequences tasks. The Process decides who picks the next task. That is the whole mental model.
+
+### Sequential vs Hierarchical vs Consensual
+
+- **Sequential.** Tasks run in declaration order. Output of task N is available as `context` to task N+1. Lowest cost. Most predictable. Use when the order is fixed.
+- **Hierarchical.** A manager Agent (separate LLM call) routes between specialists. CrewAI spawns the manager either from your `manager_llm` config or a default. The manager picks the next task each round and can refuse or re-route. Use when you have four or more specialists and order genuinely depends on prior output.
+- **Consensual.** Beta. Agents vote on the next step. Rarely worth the round trips outside research.
+
+Hierarchical adds a per-round LLM call (the manager) on top of every specialist call. Token cost can triple on a five-step run. Pay for it only when you need the routing.
 
 ### Crews vs Flows
 
-- **Crew.** Autonomous, LLM-driven. Good for open-ended tasks: research, brainstorming, first drafts. The framework picks the shape at runtime.
-- **Flow.** Event-driven, code-owned graph. Each step fires on a trigger (function decorator, event match). Good for production: observable, testable, deterministic.
+This is the framing the docs lead with in 2026.
 
-CrewAI 2026 docs say: start production apps with Flows; fold Crews in as sub-steps when autonomy earns its cost.
+- **Crew.** LLM-driven autonomy. The framework picks the shape at runtime. Good for: research, brainstorming, first drafts, anywhere the path is part of the answer. Hard to replay. Hard to test. Cheap to prototype.
+- **Flow.** Event-driven graph you own. `@start` marks the entry. `@listen(topic)` marks a step that fires when another step emits that topic. Each step is plain Python (can call a Crew internally). Good for: production. Observable. Testable. Deterministic.
 
-### Memory system
+The docs' 2026 production recommendation: start with a Flow. Fold Crews in as `Crew.kickoff()` calls from inside Flow steps when autonomy earns its cost. The Flow gives you the audit trail, the Crew gives you the exploration. Compose, do not pick.
 
-CrewAI ships four memory types out of the box: short-term (within run), long-term (across runs), entity (per-entity facts), contextual (retrieval-time assembly). Integrations with vector stores are first-party.
+### Tool integration
 
-### AWS Bedrock integration
+Three ways to give an Agent a tool. Pick the simplest one that fits.
 
-CrewAI has documented AWS Bedrock integration with CloudWatch, AgentOps, and Langfuse observability hooks. AWS docs cite a 5.76x speedup vs LangGraph on QA tasks in their benchmarks — take framework-specific numbers as directional, not absolute.
+1. **`@tool` decorator.** Pure functions become tools. Signature is the schema; docstring is the description the LLM sees. Best for one-off helpers.
+
+   ```python
+   from crewai.tools import tool
+
+   @tool("Search the web")
+   def search(query: str) -> str:
+       """Return top results for the query."""
+       return run_search(query)
+   ```
+
+2. **`BaseTool` subclass.** Class-based tool with explicit args schema, async support, retries. Use when the tool has state (a client, a cache) or needs structured args.
+
+   ```python
+   from crewai.tools import BaseTool
+   from pydantic import BaseModel
+
+   class SearchArgs(BaseModel):
+       query: str
+       limit: int = 10
+
+   class SearchTool(BaseTool):
+       name = "web_search"
+       description = "Search the web and return top results."
+       args_schema = SearchArgs
+
+       def _run(self, query: str, limit: int = 10) -> str:
+           return self.client.search(query, limit=limit)
+   ```
+
+3. **Built-in toolkits.** CrewAI ships first-party adapters: `SerperDevTool`, `FileReadTool`, `DirectoryReadTool`, `CodeInterpreterTool`, `RagTool`, `WebsiteSearchTool`. Wired with one import.
+
+Structured outputs use Pydantic. Pass `output_pydantic=MyModel` on the Task. CrewAI validates the LLM response against the model and either coerces or retries. Pair this with a tight `expected_output` string. Free-text outputs are fine for drafts; structured outputs are what downstream Flows can consume.
+
+### Memory hooks
+
+CrewAI ships four memory types out of the box. They compose: a Crew can enable all four at once.
+
+- **Short-term.** Conversation buffer within a single run. Wiped at the end.
+- **Long-term.** Persisted across runs. Stored in a vector DB (Chroma by default, swappable). Retrieved by similarity to the current task.
+- **Entity.** Per-entity facts. "Customer X is on the enterprise plan." Keyed by entity, not by similarity. Survives across runs.
+- **Contextual.** Assembly-time retrieval. Pulls relevant memory at the moment the Agent needs it, not preloaded.
+
+Enable on the Crew with `memory=True` or per-type config. Backed by an embeddings provider you configure (defaults to OpenAI, swappable to local). Memory is one of the places CrewAI earns its keep against thinner frameworks; pure LangGraph requires you to wire each of these yourself.
+
+### When CrewAI fits
+
+- Three to six agents with named roles and a collaborative workflow. Drafting, reviewing, planning, brainstorming.
+- Routing where the LLM's judgment about the next step is part of the value (Hierarchical).
+- Anywhere the team is happier reading `role + goal + backstory` than reading a graph definition.
+
+### When CrewAI does not fit
+
+- Deterministic DAGs with strict ordering. Use LangGraph (Lesson 13). The graph shape is the right abstraction; CrewAI's role framing is friction.
+- Sub-second latency budgets. Hierarchical adds round trips. Even Sequential serializes prompts that include backstories and prior outputs.
+- Single-agent loops. Skip the framework; an agent loop (Lesson 1) plus a tool registry is shorter.
+
+Lesson 17 (Agent Framework Tradeoffs) lays this out in a matrix. The short version: CrewAI sits in the "collaborative role-based" corner.
 
 ### Dependency shape
 
-Independent of LangChain. Python 3.10–3.13. Uses `uv` for dependency management. 30k+ GitHub stars early 2026.
+Independent of LangChain. Python 3.10 to 3.13. Uses `uv`. 30k+ GitHub stars early 2026. AWS Bedrock integration is documented; their benchmarks cite a 5.76x speedup vs LangGraph on QA tasks. Treat framework-vendor numbers as directional.
 
 ### Where this pattern goes wrong
 
-- **Crew-as-prod.** Using a free-form Crew in prod without a Flow wrapper. Output variability is high; debugging is painful.
-- **Backstory bloat.** 2000-word backstories push out context budget. Keep them tight.
-- **Process confusion.** Hierarchical process adds a manager Agent that routes; use only when you have 4+ specialists.
+- **Prompt-bloat from backstories.** A 2000-word backstory per agent and a five-agent crew burns the context budget before the first tool call. Keep backstories under 200 words. Reuse phrases across agents; do not repeat house style five times.
+- **Manager-LLM token tax.** Hierarchical process adds a manager LLM call before every specialist call. On a five-task crew that is six LLM calls instead of five, and the manager call carries the full task list plus prior outputs. Switch to Sequential unless routing depends on output.
+- **Brittle handoffs.** Task N's `expected_output` is "an outline". Task N+1 reads it as `context` and tries to parse three sections. The LLM produced four. The downstream Agent ad-libs. Fix with `output_pydantic` on Task N so Task N+1 reads a typed object, not free text.
+- **Crew-as-prod.** Free-form Crew shipped to production without a Flow wrapper. Output variability is high; replay is impossible; on-call cannot diff a bad run against a good one. Wrap with a Flow.
 
 ## Build It
 
-`code/main.py` implements stdlib versions of both:
+`code/main.py` implements stdlib versions of both shapes plus a three-agent crew.
 
-- `Agent`, `Task`, `Crew`, `SequentialCrew` (one task at a time), `HierarchicalCrew` (manager routes).
-- `Flow` with `@start()` and `@listen()` decorators (plain-function stand-ins) that fire on named events.
-- Same three-step task (research, outline, draft) implemented both ways.
+Shape:
+
+- `Agent`, `Task` dataclasses matching CrewAI's surface.
+- `SequentialCrew.kickoff(inputs)` runs tasks in declaration order, threading outputs as `context`.
+- `HierarchicalCrew.kickoff(topic)` adds a manager Agent picking the next specialist each round, stops at "done".
+- `Flow` with `@start` and `@listen(topic)` decorators, a tiny event loop, and a trace.
+- `tool(name)` decorator mirroring CrewAI's `@tool` shape.
+- `Memory` with `short_term`, `long_term`, `entity` stores; mocked similarity uses numpy.
+- Mock LLM responses are hardcoded strings keyed off role plus input prefix. No network. Deterministic.
+
+Concrete demo: researcher, writer, editor crew producing a brief on "agent engineering 2026". Researcher pulls (mocked) sources. Writer drafts. Editor tightens. Same crew runs through a Flow to show the deterministic shape.
 
 Run it:
 
@@ -66,41 +151,65 @@ Run it:
 python3 code/main.py
 ```
 
-The Crew trace is fluid and variable; the Flow trace is fixed and observable. That is the choice.
+Trace covers: sequential crew threading outputs through `context`, hierarchical crew with manager picks (researcher, writer, editor, then "done"), flow running the same three steps with explicit topics (`researched`, `drafted`, `edited`), tool calls routed through `@tool`, and long-term memory surviving across two kickoffs.
+
+The Crew trace is fluid; the manager could in principle re-order. The Flow trace is fixed. That choice is the lesson.
 
 ## Use It
 
-- **CrewAI Flow** for production.
-- **CrewAI Crew** for exploration, pairing, first drafts.
-- **LangGraph** (Lesson 13) if you want a more explicit state machine.
-- **AutoGen v0.4** (Lesson 14) if you want actor-model concurrency.
+- **CrewAI Flow** for production. Even when the Flow is one step that calls `Crew.kickoff()`. The Flow gives the audit boundary.
+- **CrewAI Crew (Sequential)** for clear-ordering collaborative work, especially first drafts and review loops.
+- **CrewAI Crew (Hierarchical)** when routing depends on output and you have four or more specialists.
+- **LangGraph** (Lesson 13) for explicit state machines, durable resume, strict ordering.
+- **AutoGen v0.4** (Lesson 14) for actor-model concurrency and fault isolation.
+- **OpenAI Agents SDK** (Lesson 16) for OpenAI-first products with handoffs and guardrails.
+- **Claude Agent SDK** (Lesson 17) for Claude-first products with subagents and session store.
 
 ## Ship It
 
-`outputs/skill-crew-or-flow.md` picks Crew vs Flow for a task and scaffolds the minimal implementation.
+`outputs/skill-crew-or-flow.md` picks Crew vs Flow for a task and scaffolds the minimal implementation. Hard rejects on Crew-without-backstory, Flow-without-explicit-topics, Hierarchical with under three specialists.
+
+## Pitfalls
+
+- **Backstory as flavor.** It shapes outputs. Test three variants per agent; variance is real. Pick one, freeze it.
+- **Skipping `expected_output`.** Without a contract per task, downstream tasks pick up whatever the LLM produced. Crew runs; audit fails.
+- **Memory always-on.** Long-term writes every run. Vector DB grows. Retrieval gets noisy. Scope writes to tasks where the fact is persistent.
+- **Manager prompt drift.** Hierarchical's manager prompt is implicit. If routing gets weird, dump it in verbose mode and read.
+- **Tool side effects in Crews.** A Crew can call a tool more times than expected. POST, DELETE, payment belong in a Flow step, never a Crew tool.
 
 ## Exercises
 
-1. Convert a Crew-based demo to a Flow. Count the touchpoints where variability drops.
-2. Add entity memory to the Crew: facts about a customer persist across tasks.
-3. Implement a Hierarchical process: a manager Agent picks which specialist runs next based on the prior output.
-4. Read CrewAI's docs intro. Port your toy to the real `crewai` API. What changes about testability?
-5. Wire AgentOps or Langfuse to one of your runs. Which traces did you miss in the stdlib version?
+1. Convert the Sequential crew to a Flow. Count the touchpoints where variability drops. Note where readability dropped.
+2. Add entity memory to the crew: facts about a customer persist across kickoffs. Verify retrieval pulls the right entity.
+3. Implement a Hierarchical process where the manager refuses to route to the editor until the writer's output has at least three paragraphs. Trace the retry.
+4. Wire a `BaseTool` subclass for a (mocked) web search. Compare the trace shape vs the `@tool` decorator version.
+5. Add `output_pydantic=Brief` to the editor task, where `Brief` has `title`, `summary`, `sections`. Make the writer task output malformed JSON once; verify CrewAI's retry behavior in the trace.
+6. Read CrewAI's docs intro. Port the toy to the real `crewai` API. Which guarantees did the stdlib version skip?
+7. Wire AgentOps or Langfuse (Lesson 24) to a real run. Which traces did you miss in the stdlib version?
 
 ## Key Terms
 
 | Term | What people say | What it actually means |
 |------|----------------|------------------------|
 | Agent | "Persona" | Role + goal + backstory + tools |
-| Task | "Unit of work" | Description + expected output + assignee |
+| Task | "Unit of work" | Description + expected output + assignee + optional structured output |
 | Crew | "Agent team" | Container for Agents + Tasks + Process |
 | Process | "Execution strategy" | Sequential / Hierarchical / Consensual |
 | Flow | "Deterministic workflow" | Event-driven, code-owned, testable |
 | Backstory | "Persona prompt" | Tone and judgment shaper for the Agent |
-| Entity memory | "Per-entity facts" | Memory scoped to a customer/account/issue |
+| `@tool` | "Function tool" | Decorator that turns a function into a tool the Agent can call |
+| `BaseTool` | "Class tool" | Class-based tool with args schema, retries, async support |
+| Entity memory | "Per-entity facts" | Memory scoped to a customer / account / issue |
+| Long-term memory | "Cross-run memory" | Vector-backed memory that survives between kickoffs |
+| Contextual memory | "Just-in-time retrieval" | Memory pulled at the moment the Agent needs it |
+| Manager LLM | "Router agent" | Extra LLM in Hierarchical process that picks the next task |
+| `expected_output` | "Task contract" | String that tells the Agent (and audit) what shape to return |
 
 ## Further Reading
 
-- [CrewAI docs introduction](https://docs.crewai.com/en/introduction) — concepts and recommended production path
-- [Anthropic, Building Effective Agents](https://www.anthropic.com/research/building-effective-agents) — when multi-agent helps and when it doesn't
-- [LangGraph overview](https://docs.langchain.com/oss/python/langgraph/overview) — the state-machine alternative
+- [CrewAI docs introduction](https://docs.crewai.com/en/introduction): concepts and the recommended production path
+- [CrewAI Flows guide](https://docs.crewai.com/en/concepts/flows): event-driven shape, `@start`, `@listen`
+- [CrewAI tools reference](https://docs.crewai.com/en/concepts/tools): `@tool`, `BaseTool`, built-in toolkits
+- [CrewAI memory](https://docs.crewai.com/en/concepts/memory): short-term, long-term, entity, contextual
+- [Anthropic, Building Effective Agents](https://www.anthropic.com/research/building-effective-agents): when multi-agent helps and when it does not
+- [LangGraph overview](https://docs.langchain.com/oss/python/langgraph/overview): the state-machine alternative

--- a/phases/14-agent-engineering/15-crewai-role-based-crews/docs/en.md
+++ b/phases/14-agent-engineering/15-crewai-role-based-crews/docs/en.md
@@ -147,7 +147,7 @@ Concrete demo: researcher, writer, editor crew producing a brief on "agent engin
 
 Run it:
 
-```
+```bash
 python3 code/main.py
 ```
 


### PR DESCRIPTION
Expands the CrewAI lesson from 5.3 KB to ~14.9 KB to match Phase 14's median lesson depth, adds a three-agent crew (researcher, writer, editor) demo with @tool decorator, four-store Memory, and Sequential / Hierarchical / Flow runs.