### PR TITLE
feat(phase-19): quiz backfill, 0/17 -> 17/17

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -12264,7 +12264,7 @@
           "path": "phases/19-capstone-projects/01-terminal-native-coding-agent",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -12295,7 +12295,7 @@
           "path": "phases/19-capstone-projects/02-rag-over-codebase",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -12326,7 +12326,7 @@
           "path": "phases/19-capstone-projects/03-realtime-voice-assistant",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -12358,7 +12358,7 @@
           "path": "phases/19-capstone-projects/04-multimodal-document-qa",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -12389,7 +12389,7 @@
           "path": "phases/19-capstone-projects/05-autonomous-research-agent",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -12420,7 +12420,7 @@
           "path": "phases/19-capstone-projects/06-devops-troubleshooting-agent",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -12451,7 +12451,7 @@
           "path": "phases/19-capstone-projects/07-end-to-end-fine-tuning-pipeline",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -12484,7 +12484,7 @@
           "path": "phases/19-capstone-projects/08-production-rag-chatbot",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -12516,7 +12516,7 @@
           "path": "phases/19-capstone-projects/09-code-migration-agent",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -12547,7 +12547,7 @@
           "path": "phases/19-capstone-projects/10-multi-agent-software-team",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -12578,7 +12578,7 @@
           "path": "phases/19-capstone-projects/11-llm-observability-dashboard",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -12610,7 +12610,7 @@
           "path": "phases/19-capstone-projects/12-video-understanding-pipeline",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -12642,7 +12642,7 @@
           "path": "phases/19-capstone-projects/13-mcp-server-with-registry",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -12674,7 +12674,7 @@
           "path": "phases/19-capstone-projects/14-speculative-decoding-server",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -12707,7 +12707,7 @@
           "path": "phases/19-capstone-projects/15-constitutional-safety-harness",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -12739,7 +12739,7 @@
           "path": "phases/19-capstone-projects/16-github-issue-to-pr-agent",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -12771,7 +12771,7 @@
           "path": "phases/19-capstone-projects/17-personal-ai-tutor",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"

--- a/phases/19-capstone-projects/01-terminal-native-coding-agent/quiz.json
+++ b/phases/19-capstone-projects/01-terminal-native-coding-agent/quiz.json
@@ -1,0 +1,90 @@
+{
+  "lesson": "01-terminal-native-coding-agent",
+  "title": "Capstone 01 — Terminal-Native Coding Agent",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "Which loop shape do 2026 terminal coding agents share?",
+      "options": [
+        "Train, evaluate, deploy, monitor",
+        "Plan, act, observe, recover",
+        "Encode, decode, sample, stream",
+        "Fetch, embed, rank, synthesize"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "pre",
+      "question": "Why does the harness run each task inside an E2B or Daytona sandbox?",
+      "options": [
+        "To benchmark token throughput on cold caches",
+        "To isolate filesystem and tool execution from the host so the worktree can be torn down on completion",
+        "To bypass model-provider rate limits",
+        "To enable GPU access for the agent loop"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Which built-in hook is the natural place to block destructive shell commands before they execute?",
+      "options": [
+        "SessionStart",
+        "PostToolUse",
+        "PreToolUse",
+        "Stop"
+      ],
+      "correct": 2,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "The capstone caps each tool result at roughly 4k tokens. Which failure mode does that primarily prevent?",
+      "options": [
+        "Sandbox escape via malicious shell metacharacters",
+        "Context poisoning and runaway cost when a tool returns a large dump",
+        "Model overfitting to tool-call traces",
+        "Stale plan state across resumed sessions"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "What does the PreCompact hook do at the 150k-token mark?",
+      "options": [
+        "Cancels the run and refunds the user budget",
+        "Summarizes older turns into a prior-state block so the plan and new observations still fit",
+        "Switches the backing model to a smaller draft model",
+        "Force-pushes the current branch to back up progress"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Which baseline does the capstone compare its harness against on a 30-issue SWE-bench Pro subset?",
+      "options": [
+        "Live-SWE-agent",
+        "mini-swe-agent",
+        "OpenCode",
+        "Aider"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Which metric set is the deliverable measuring against?",
+      "options": [
+        "pass@1, turns-per-task, and dollar-per-task",
+        "Perplexity, BLEU, and ROUGE",
+        "MRR@10 and nDCG@10",
+        "WER, MOS, and first-audio-out"
+      ],
+      "correct": 0,
+      "explanation": ""
+    }
+  ]
+}

--- a/phases/19-capstone-projects/01-terminal-native-coding-agent/quiz.json
+++ b/phases/19-capstone-projects/01-terminal-native-coding-agent/quiz.json
@@ -6,36 +6,36 @@
       "stage": "pre",
       "question": "Which loop shape do 2026 terminal coding agents share?",
       "options": [
-        "Train, evaluate, deploy, monitor",
         "Plan, act, observe, recover",
         "Encode, decode, sample, stream",
+        "Train, evaluate, deploy, monitor",
         "Fetch, embed, rank, synthesize"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     },
     {
       "stage": "pre",
       "question": "Why does the harness run each task inside an E2B or Daytona sandbox?",
       "options": [
-        "To benchmark token throughput on cold caches",
         "To isolate filesystem and tool execution from the host so the worktree can be torn down on completion",
         "To bypass model-provider rate limits",
+        "To benchmark token throughput on cold caches",
         "To enable GPU access for the agent loop"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "Which built-in hook is the natural place to block destructive shell commands before they execute?",
       "options": [
-        "SessionStart",
-        "PostToolUse",
         "PreToolUse",
-        "Stop"
+        "SessionStart",
+        "Stop",
+        "PostToolUse"
       ],
-      "correct": 2,
+      "correct": 0,
       "explanation": ""
     },
     {
@@ -44,8 +44,8 @@
       "options": [
         "Sandbox escape via malicious shell metacharacters",
         "Context poisoning and runaway cost when a tool returns a large dump",
-        "Model overfitting to tool-call traces",
-        "Stale plan state across resumed sessions"
+        "Stale plan state across resumed sessions",
+        "Model overfitting to tool-call traces"
       ],
       "correct": 1,
       "explanation": ""
@@ -56,8 +56,8 @@
       "options": [
         "Cancels the run and refunds the user budget",
         "Summarizes older turns into a prior-state block so the plan and new observations still fit",
-        "Switches the backing model to a smaller draft model",
-        "Force-pushes the current branch to back up progress"
+        "Force-pushes the current branch to back up progress",
+        "Switches the backing model to a smaller draft model"
       ],
       "correct": 1,
       "explanation": ""
@@ -66,9 +66,9 @@
       "stage": "post",
       "question": "Which baseline does the capstone compare its harness against on a 30-issue SWE-bench Pro subset?",
       "options": [
-        "Live-SWE-agent",
-        "mini-swe-agent",
         "OpenCode",
+        "mini-swe-agent",
+        "Live-SWE-agent",
         "Aider"
       ],
       "correct": 1,
@@ -78,12 +78,12 @@
       "stage": "post",
       "question": "Which metric set is the deliverable measuring against?",
       "options": [
-        "pass@1, turns-per-task, and dollar-per-task",
+        "WER, MOS, and first-audio-out",
         "Perplexity, BLEU, and ROUGE",
-        "MRR@10 and nDCG@10",
-        "WER, MOS, and first-audio-out"
+        "pass@1, turns-per-task, and dollar-per-task",
+        "MRR@10 and nDCG@10"
       ],
-      "correct": 0,
+      "correct": 2,
       "explanation": ""
     }
   ]

--- a/phases/19-capstone-projects/02-rag-over-codebase/quiz.json
+++ b/phases/19-capstone-projects/02-rag-over-codebase/quiz.json
@@ -1,0 +1,90 @@
+{
+  "lesson": "02-rag-over-codebase",
+  "title": "Capstone 02 — RAG over Codebase (Cross-Repo Semantic Search)",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "Why is naive cosine search over raw chunks insufficient for cross-repo code retrieval?",
+      "options": [
+        "Cosine similarity is undefined on code embeddings",
+        "It poisons results on generated code, monorepo duplication, and rarely imported symbols",
+        "Vector indexes cannot store payloads larger than 1KB",
+        "Embedding models do not see code as tokens"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "pre",
+      "question": "What does AST-aware chunking mean in the ingestion pipeline?",
+      "options": [
+        "Splitting code into fixed 256-token windows",
+        "Cutting at tree-sitter node boundaries such as function and class spans",
+        "Dropping comments and whitespace before embedding",
+        "Compressing chunks with gzip before storage"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Which three retrievable modalities does each chunk get in this pipeline?",
+      "options": [
+        "Dense embedding, BM25 terms, and a natural-language summary",
+        "Token IDs, syntax tree, and call graph",
+        "AST, IR, and bytecode",
+        "Raw text, gzip, and hash"
+      ],
+      "correct": 0,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "What is the role of the cross-encoder reranker after the hybrid retrieval step?",
+      "options": [
+        "It compresses the chunks before sending to the synthesizer",
+        "It scores each query-candidate pair together for higher accuracy than cosine alone",
+        "It re-embeds the query in a different model",
+        "It rewrites the chunks to remove generated code"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Why does the synthesizer reject answers without (repo/path:start-end) anchors?",
+      "options": [
+        "Anchors are required by the vector database schema",
+        "Citation faithfulness gates the answer so users can verify each claim",
+        "Anchors reduce token cost on the synthesis call",
+        "Anchors are needed for downstream BM25 reranking"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "What does incremental re-index require to stay under 60 seconds on a 50-file push?",
+      "options": [
+        "Re-embedding the full 2M-LOC corpus on each commit",
+        "Re-embedding only chunks whose text changed and recomputing affected symbol edges",
+        "Throwing away the BM25 index and rebuilding it from scratch",
+        "Dropping the symbol graph entirely"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Which metric measures whether retrieved claims are verifiable in the source?",
+      "options": [
+        "MRR@10",
+        "nDCG@10",
+        "Citation faithfulness",
+        "p95 query latency"
+      ],
+      "correct": 2,
+      "explanation": ""
+    }
+  ]
+}

--- a/phases/19-capstone-projects/02-rag-over-codebase/quiz.json
+++ b/phases/19-capstone-projects/02-rag-over-codebase/quiz.json
@@ -6,72 +6,72 @@
       "stage": "pre",
       "question": "Why is naive cosine search over raw chunks insufficient for cross-repo code retrieval?",
       "options": [
-        "Cosine similarity is undefined on code embeddings",
         "It poisons results on generated code, monorepo duplication, and rarely imported symbols",
+        "Cosine similarity is undefined on code embeddings",
         "Vector indexes cannot store payloads larger than 1KB",
         "Embedding models do not see code as tokens"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     },
     {
       "stage": "pre",
       "question": "What does AST-aware chunking mean in the ingestion pipeline?",
       "options": [
-        "Splitting code into fixed 256-token windows",
-        "Cutting at tree-sitter node boundaries such as function and class spans",
+        "Compressing chunks with gzip before storage",
         "Dropping comments and whitespace before embedding",
-        "Compressing chunks with gzip before storage"
+        "Cutting at tree-sitter node boundaries such as function and class spans",
+        "Splitting code into fixed 256-token windows"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "Which three retrievable modalities does each chunk get in this pipeline?",
       "options": [
-        "Dense embedding, BM25 terms, and a natural-language summary",
         "Token IDs, syntax tree, and call graph",
         "AST, IR, and bytecode",
-        "Raw text, gzip, and hash"
+        "Raw text, gzip, and hash",
+        "Dense embedding, BM25 terms, and a natural-language summary"
       ],
-      "correct": 0,
+      "correct": 3,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "What is the role of the cross-encoder reranker after the hybrid retrieval step?",
       "options": [
-        "It compresses the chunks before sending to the synthesizer",
-        "It scores each query-candidate pair together for higher accuracy than cosine alone",
+        "It rewrites the chunks to remove generated code",
         "It re-embeds the query in a different model",
-        "It rewrites the chunks to remove generated code"
+        "It compresses the chunks before sending to the synthesizer",
+        "It scores each query-candidate pair together for higher accuracy than cosine alone"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "Why does the synthesizer reject answers without (repo/path:start-end) anchors?",
       "options": [
-        "Anchors are required by the vector database schema",
         "Citation faithfulness gates the answer so users can verify each claim",
         "Anchors reduce token cost on the synthesis call",
-        "Anchors are needed for downstream BM25 reranking"
+        "Anchors are needed for downstream BM25 reranking",
+        "Anchors are required by the vector database schema"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     },
     {
       "stage": "post",
       "question": "What does incremental re-index require to stay under 60 seconds on a 50-file push?",
       "options": [
-        "Re-embedding the full 2M-LOC corpus on each commit",
         "Re-embedding only chunks whose text changed and recomputing affected symbol edges",
-        "Throwing away the BM25 index and rebuilding it from scratch",
-        "Dropping the symbol graph entirely"
+        "Re-embedding the full 2M-LOC corpus on each commit",
+        "Dropping the symbol graph entirely",
+        "Throwing away the BM25 index and rebuilding it from scratch"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     },
     {
@@ -79,11 +79,11 @@
       "question": "Which metric measures whether retrieved claims are verifiable in the source?",
       "options": [
         "MRR@10",
-        "nDCG@10",
         "Citation faithfulness",
+        "nDCG@10",
         "p95 query latency"
       ],
-      "correct": 2,
+      "correct": 1,
       "explanation": ""
     }
   ]

--- a/phases/19-capstone-projects/03-realtime-voice-assistant/quiz.json
+++ b/phases/19-capstone-projects/03-realtime-voice-assistant/quiz.json
@@ -6,21 +6,21 @@
       "stage": "pre",
       "question": "Why can a voice agent not be built by stitching three blocking REST calls?",
       "options": [
-        "REST is incompatible with WebRTC",
-        "End-to-end latency below 800ms requires pipelined streaming at every stage",
         "REST endpoints have a 30-second hard timeout",
-        "JSON serialization is too slow for audio data"
+        "REST is incompatible with WebRTC",
+        "JSON serialization is too slow for audio data",
+        "End-to-end latency below 800ms requires pipelined streaming at every stage"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
       "stage": "pre",
       "question": "What is the role of the turn-detector alongside VAD?",
       "options": [
-        "Detects which speaker is talking in a multi-party call",
-        "Reads partial transcripts and scores whether the user has actually finished their utterance",
         "Trains a custom voice clone for the agent",
+        "Reads partial transcripts and scores whether the user has actually finished their utterance",
+        "Detects which speaker is talking in a multi-party call",
         "Mixes background music into the output stream"
       ],
       "correct": 1,
@@ -31,23 +31,23 @@
       "question": "When the user starts speaking while the agent is mid-response, what must happen for barge-in to feel right?",
       "options": [
         "The TTS finishes the current sentence before yielding",
+        "The pipeline buffers user audio until TTS completes",
         "The TTS is canceled immediately, remaining LLM output is dropped, and ASR re-arms",
-        "The agent raises the TTS volume to assert priority",
-        "The pipeline buffers user audio until TTS completes"
+        "The agent raises the TTS volume to assert priority"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "Why is a short filler such as \"one second, let me check\" emitted when a tool exceeds about 300ms?",
       "options": [
-        "It improves WER on the next utterance",
         "It avoids silence so the conversation does not stall while the side-channel tool runs",
         "It triggers a fallback ASR model",
-        "It resets the WebRTC jitter buffer"
+        "It resets the WebRTC jitter buffer",
+        "It improves WER on the next utterance"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     },
     {
@@ -55,11 +55,11 @@
       "question": "The first audio chunk must leave the server within roughly how long of the first LLM token?",
       "options": [
         "20ms",
-        "200ms",
         "800ms",
-        "2 seconds"
+        "2 seconds",
+        "200ms"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
@@ -68,10 +68,10 @@
       "options": [
         "WER",
         "MOS",
-        "False-cutoff rate",
-        "Acceptance rate"
+        "Acceptance rate",
+        "False-cutoff rate"
       ],
-      "correct": 2,
+      "correct": 3,
       "explanation": ""
     },
     {
@@ -79,11 +79,11 @@
       "question": "Under 3% packet loss, which two adaptive behaviors does the pipeline rely on?",
       "options": [
         "Switching to a larger LLM and disabling TTS",
-        "Holding partial transcripts and raising the VAD speech-gate threshold",
         "Falling back to PSTN audio codecs",
+        "Holding partial transcripts and raising the VAD speech-gate threshold",
         "Restarting the LiveKit room"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     }
   ]

--- a/phases/19-capstone-projects/03-realtime-voice-assistant/quiz.json
+++ b/phases/19-capstone-projects/03-realtime-voice-assistant/quiz.json
@@ -1,0 +1,90 @@
+{
+  "lesson": "03-realtime-voice-assistant",
+  "title": "Capstone 03 — Real-Time Voice Assistant (ASR to LLM to TTS)",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "Why can a voice agent not be built by stitching three blocking REST calls?",
+      "options": [
+        "REST is incompatible with WebRTC",
+        "End-to-end latency below 800ms requires pipelined streaming at every stage",
+        "REST endpoints have a 30-second hard timeout",
+        "JSON serialization is too slow for audio data"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "pre",
+      "question": "What is the role of the turn-detector alongside VAD?",
+      "options": [
+        "Detects which speaker is talking in a multi-party call",
+        "Reads partial transcripts and scores whether the user has actually finished their utterance",
+        "Trains a custom voice clone for the agent",
+        "Mixes background music into the output stream"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "When the user starts speaking while the agent is mid-response, what must happen for barge-in to feel right?",
+      "options": [
+        "The TTS finishes the current sentence before yielding",
+        "The TTS is canceled immediately, remaining LLM output is dropped, and ASR re-arms",
+        "The agent raises the TTS volume to assert priority",
+        "The pipeline buffers user audio until TTS completes"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Why is a short filler such as \"one second, let me check\" emitted when a tool exceeds about 300ms?",
+      "options": [
+        "It improves WER on the next utterance",
+        "It avoids silence so the conversation does not stall while the side-channel tool runs",
+        "It triggers a fallback ASR model",
+        "It resets the WebRTC jitter buffer"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "The first audio chunk must leave the server within roughly how long of the first LLM token?",
+      "options": [
+        "20ms",
+        "200ms",
+        "800ms",
+        "2 seconds"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Which metric directly measures inappropriate barge-in or over-eager turn closure?",
+      "options": [
+        "WER",
+        "MOS",
+        "False-cutoff rate",
+        "Acceptance rate"
+      ],
+      "correct": 2,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Under 3% packet loss, which two adaptive behaviors does the pipeline rely on?",
+      "options": [
+        "Switching to a larger LLM and disabling TTS",
+        "Holding partial transcripts and raising the VAD speech-gate threshold",
+        "Falling back to PSTN audio codecs",
+        "Restarting the LiveKit room"
+      ],
+      "correct": 1,
+      "explanation": ""
+    }
+  ]
+}

--- a/phases/19-capstone-projects/04-multimodal-document-qa/quiz.json
+++ b/phases/19-capstone-projects/04-multimodal-document-qa/quiz.json
@@ -6,9 +6,9 @@
       "stage": "pre",
       "question": "Why does the 2026 frontier prefer vision-first late interaction over OCR-then-text on financial PDFs and scientific papers?",
       "options": [
-        "OCR is slower than rendering",
-        "OCR pipelines mangle rotated tables, dense equations, and chart imagery, losing half the signal",
         "Vision models are cheaper per page",
+        "OCR pipelines mangle rotated tables, dense equations, and chart imagery, losing half the signal",
+        "OCR is slower than rendering",
         "OCR cannot run on GPUs"
       ],
       "correct": 1,
@@ -18,24 +18,24 @@
       "stage": "pre",
       "question": "What does late interaction mean in ColPali-style retrieval?",
       "options": [
-        "Embeddings are computed after the user clicks a result",
         "Each query token scores against every patch token, and per-token maxima are summed via MaxSim",
-        "The reranker only runs on the final candidate",
-        "Embeddings are deferred until eval time"
+        "Embeddings are deferred until eval time",
+        "Embeddings are computed after the user clicks a result",
+        "The reranker only runs on the final candidate"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "Roughly how many patch vectors does a ColQwen embedding produce per page, and what storage problem does that create?",
       "options": [
-        "1 vector per page, no storage issue",
         "Around 2048 patch vectors per page, ballooning raw storage compared with single-vector indexes",
         "Exactly 128 vectors, fitting cleanly in any vector DB",
+        "1 vector per page, no storage issue",
         "16 vectors with negligible storage overhead"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     },
     {
@@ -44,8 +44,8 @@
       "options": [
         "Removes duplicate PDF pages before ingestion",
         "Compresses the multi-vector index by keeping high-signal patches at about 50% with negligible accuracy loss",
-        "Crops bounding boxes around evidence regions",
-        "Rewrites the query embedding for shorter vectors"
+        "Rewrites the query embedding for shorter vectors",
+        "Crops bounding boxes around evidence regions"
       ],
       "correct": 1,
       "explanation": ""
@@ -54,36 +54,36 @@
       "stage": "check",
       "question": "Why is an OCR text channel still spliced in for some pages?",
       "options": [
-        "OCR is the primary retrieval modality",
-        "Equation-dense and table-heavy pages benefit from a text fallback alongside the image",
         "It improves PDF rendering quality",
-        "VLMs cannot read images at 180 DPI"
+        "VLMs cannot read images at 180 DPI",
+        "OCR is the primary retrieval modality",
+        "Equation-dense and table-heavy pages benefit from a text fallback alongside the image"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
       "stage": "post",
       "question": "Which benchmark does this capstone target for vision-first retrieval evaluation?",
       "options": [
-        "MMLU-Pro",
-        "ViDoRe v3",
+        "RewardBench-2",
         "SWE-bench Pro",
-        "RewardBench-2"
+        "ViDoRe v3",
+        "MMLU-Pro"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     },
     {
       "stage": "post",
       "question": "What does the rubric mean by evidence-region grounding?",
       "options": [
-        "Fraction of cited bounding boxes that actually contain the answer span",
-        "Total number of pages retrieved per query",
+        "Compression ratio achieved by DocPruner",
         "Re-ranker latency at the p99 tail",
-        "Compression ratio achieved by DocPruner"
+        "Total number of pages retrieved per query",
+        "Fraction of cited bounding boxes that actually contain the answer span"
       ],
-      "correct": 0,
+      "correct": 3,
       "explanation": ""
     }
   ]

--- a/phases/19-capstone-projects/04-multimodal-document-qa/quiz.json
+++ b/phases/19-capstone-projects/04-multimodal-document-qa/quiz.json
@@ -1,0 +1,90 @@
+{
+  "lesson": "04-multimodal-document-qa",
+  "title": "Capstone 04 — Multimodal Document QA (Vision-First PDF, Tables, Charts)",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "Why does the 2026 frontier prefer vision-first late interaction over OCR-then-text on financial PDFs and scientific papers?",
+      "options": [
+        "OCR is slower than rendering",
+        "OCR pipelines mangle rotated tables, dense equations, and chart imagery, losing half the signal",
+        "Vision models are cheaper per page",
+        "OCR cannot run on GPUs"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "pre",
+      "question": "What does late interaction mean in ColPali-style retrieval?",
+      "options": [
+        "Embeddings are computed after the user clicks a result",
+        "Each query token scores against every patch token, and per-token maxima are summed via MaxSim",
+        "The reranker only runs on the final candidate",
+        "Embeddings are deferred until eval time"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Roughly how many patch vectors does a ColQwen embedding produce per page, and what storage problem does that create?",
+      "options": [
+        "1 vector per page, no storage issue",
+        "Around 2048 patch vectors per page, ballooning raw storage compared with single-vector indexes",
+        "Exactly 128 vectors, fitting cleanly in any vector DB",
+        "16 vectors with negligible storage overhead"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "What does DocPruner do in this pipeline?",
+      "options": [
+        "Removes duplicate PDF pages before ingestion",
+        "Compresses the multi-vector index by keeping high-signal patches at about 50% with negligible accuracy loss",
+        "Crops bounding boxes around evidence regions",
+        "Rewrites the query embedding for shorter vectors"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Why is an OCR text channel still spliced in for some pages?",
+      "options": [
+        "OCR is the primary retrieval modality",
+        "Equation-dense and table-heavy pages benefit from a text fallback alongside the image",
+        "It improves PDF rendering quality",
+        "VLMs cannot read images at 180 DPI"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Which benchmark does this capstone target for vision-first retrieval evaluation?",
+      "options": [
+        "MMLU-Pro",
+        "ViDoRe v3",
+        "SWE-bench Pro",
+        "RewardBench-2"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "What does the rubric mean by evidence-region grounding?",
+      "options": [
+        "Fraction of cited bounding boxes that actually contain the answer span",
+        "Total number of pages retrieved per query",
+        "Re-ranker latency at the p99 tail",
+        "Compression ratio achieved by DocPruner"
+      ],
+      "correct": 0,
+      "explanation": ""
+    }
+  ]
+}

--- a/phases/19-capstone-projects/05-autonomous-research-agent/quiz.json
+++ b/phases/19-capstone-projects/05-autonomous-research-agent/quiz.json
@@ -6,10 +6,10 @@
       "stage": "pre",
       "question": "What search shape does the AI-Scientist-class agent use to explore experiments?",
       "options": [
-        "Breadth-first expansion with random scoring",
+        "Beam search over token outputs",
         "Best-first tree search over experiment nodes with a novelty x quality x budget score",
         "Pure reinforcement learning from human feedback",
-        "Beam search over token outputs"
+        "Breadth-first expansion with random scoring"
       ],
       "correct": 1,
       "explanation": ""
@@ -19,20 +19,20 @@
       "question": "Why is the sandbox configured with --network=none and bounded resource caps?",
       "options": [
         "To force the agent to use prompt caching",
-        "To prevent network egress and contain experiment side effects within a reproducible envelope",
+        "To enforce deterministic floating-point arithmetic",
         "To allow GPU passthrough by default",
-        "To enforce deterministic floating-point arithmetic"
+        "To prevent network egress and contain experiment side effects within a reproducible envelope"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "What is the role of the vision critique step in the writer loop?",
       "options": [
-        "Generates new experiment ideas from screenshots",
-        "Compiles the LaTeX draft to PDF, then has a VLM critique layout, figure legibility, and claim-evidence alignment",
         "Translates figures into bar charts",
+        "Compiles the LaTeX draft to PDF, then has a VLM critique layout, figure legibility, and claim-evidence alignment",
+        "Generates new experiment ideas from screenshots",
         "Replaces matplotlib at render time"
       ],
       "correct": 1,
@@ -43,47 +43,47 @@
       "question": "How does the reviewer ensemble gate the pipeline?",
       "options": [
         "A single judge accepts or rejects on a binary flag",
-        "Five judges score on NeurIPS-style rubrics and the weighted aggregate must clear a threshold, otherwise the draft loops back to the writer",
         "Reviewers vote anonymously and the majority wins",
-        "Reviews run after publication only"
+        "Reviews run after publication only",
+        "Five judges score on NeurIPS-style rubrics and the weighted aggregate must clear a threshold, otherwise the draft loops back to the writer"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "Which cost discipline does the capstone enforce per paper?",
       "options": [
-        "Unbounded compute, hard wall-clock only",
         "A $30 hard budget tracked through Langfuse counters and pre-run estimates",
         "Cost-only optimization without quality checks",
+        "Unbounded compute, hard wall-clock only",
         "GPU-hours tracked but never capped"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     },
     {
       "stage": "post",
       "question": "Which scoring function ranks tree nodes for further expansion?",
       "options": [
-        "Output length and token count",
         "Novelty x quality x remaining budget",
+        "Citation count of related papers",
         "Random uniform priority",
-        "Citation count of related papers"
+        "Output length and token count"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     },
     {
       "stage": "post",
       "question": "What does the red-team report exercise against the system?",
       "options": [
-        "Latency tail under packet loss",
-        "Sandbox-escape attempts such as fork bombs, network exfiltration, and filesystem escapes",
         "Caching hit rate on system prompts",
-        "Multi-tenant data leakage in the vector DB"
+        "Multi-tenant data leakage in the vector DB",
+        "Latency tail under packet loss",
+        "Sandbox-escape attempts such as fork bombs, network exfiltration, and filesystem escapes"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     }
   ]

--- a/phases/19-capstone-projects/05-autonomous-research-agent/quiz.json
+++ b/phases/19-capstone-projects/05-autonomous-research-agent/quiz.json
@@ -1,0 +1,90 @@
+{
+  "lesson": "05-autonomous-research-agent",
+  "title": "Capstone 05 — Autonomous Research Agent (AI-Scientist Class)",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "What search shape does the AI-Scientist-class agent use to explore experiments?",
+      "options": [
+        "Breadth-first expansion with random scoring",
+        "Best-first tree search over experiment nodes with a novelty x quality x budget score",
+        "Pure reinforcement learning from human feedback",
+        "Beam search over token outputs"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "pre",
+      "question": "Why is the sandbox configured with --network=none and bounded resource caps?",
+      "options": [
+        "To force the agent to use prompt caching",
+        "To prevent network egress and contain experiment side effects within a reproducible envelope",
+        "To allow GPU passthrough by default",
+        "To enforce deterministic floating-point arithmetic"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "What is the role of the vision critique step in the writer loop?",
+      "options": [
+        "Generates new experiment ideas from screenshots",
+        "Compiles the LaTeX draft to PDF, then has a VLM critique layout, figure legibility, and claim-evidence alignment",
+        "Translates figures into bar charts",
+        "Replaces matplotlib at render time"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "How does the reviewer ensemble gate the pipeline?",
+      "options": [
+        "A single judge accepts or rejects on a binary flag",
+        "Five judges score on NeurIPS-style rubrics and the weighted aggregate must clear a threshold, otherwise the draft loops back to the writer",
+        "Reviewers vote anonymously and the majority wins",
+        "Reviews run after publication only"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Which cost discipline does the capstone enforce per paper?",
+      "options": [
+        "Unbounded compute, hard wall-clock only",
+        "A $30 hard budget tracked through Langfuse counters and pre-run estimates",
+        "Cost-only optimization without quality checks",
+        "GPU-hours tracked but never capped"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Which scoring function ranks tree nodes for further expansion?",
+      "options": [
+        "Output length and token count",
+        "Novelty x quality x remaining budget",
+        "Random uniform priority",
+        "Citation count of related papers"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "What does the red-team report exercise against the system?",
+      "options": [
+        "Latency tail under packet loss",
+        "Sandbox-escape attempts such as fork bombs, network exfiltration, and filesystem escapes",
+        "Caching hit rate on system prompts",
+        "Multi-tenant data leakage in the vector DB"
+      ],
+      "correct": 1,
+      "explanation": ""
+    }
+  ]
+}

--- a/phases/19-capstone-projects/06-devops-troubleshooting-agent/quiz.json
+++ b/phases/19-capstone-projects/06-devops-troubleshooting-agent/quiz.json
@@ -1,0 +1,90 @@
+{
+  "lesson": "06-devops-troubleshooting-agent",
+  "title": "Capstone 06 — DevOps Troubleshooting Agent for Kubernetes",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "What is the default permission posture for the troubleshooting agent's RBAC surface?",
+      "options": [
+        "Cluster-admin so it can self-heal",
+        "Read-only by default, with destructive verbs gated behind a separate server and human approval",
+        "Namespace-admin in the affected namespace only",
+        "Equivalent to the on-call engineer"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "pre",
+      "question": "What is the knowledge graph the agent walks during root cause analysis?",
+      "options": [
+        "A graph of GitHub commits and PR reviews",
+        "Nodes are K8s objects plus telemetry sources; edges encode ownership, scheduling, and observation",
+        "Prometheus metric names organized by team",
+        "A flat list of recently restarted pods"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "How are root-cause hypotheses ranked for the Slack brief?",
+      "options": [
+        "By model log-probability alone",
+        "By an evidence score combining recency, specificity, graph-path length, and citation count",
+        "By the order they were generated",
+        "By alphabetic alert name"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Why does the audit log record commands the agent considered as well as those executed?",
+      "options": [
+        "Replay attacks require both lists",
+        "Reviewers can catch near-misses where the agent almost ran a destructive command",
+        "The Slack API needs both for delivery",
+        "ArgoCD only accepts considered commands"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Which mechanism prevents the agent from rolling back unilaterally on a bad deploy?",
+      "options": [
+        "A second LLM-judge votes on the rollback",
+        "Destructive tools live on a separate MCP server behind an approval token from a Slack card",
+        "PagerDuty automatically pauses the deployment",
+        "Branch protection on the GitOps repo"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "What is the p50 time-to-hypothesis target the rubric measures?",
+      "options": [
+        "Under 30 seconds",
+        "Under 5 minutes from alert to Slack brief",
+        "Under 1 hour",
+        "Under the next on-call shift"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "How big is the synthetic incident suite used to score RCA accuracy?",
+      "options": [
+        "5 scenarios",
+        "20 scenarios covering OOMKill, DNS flap, HPA thrash, PVC fill, and more",
+        "100 randomly sampled production alerts",
+        "1 scripted demo incident"
+      ],
+      "correct": 1,
+      "explanation": ""
+    }
+  ]
+}

--- a/phases/19-capstone-projects/06-devops-troubleshooting-agent/quiz.json
+++ b/phases/19-capstone-projects/06-devops-troubleshooting-agent/quiz.json
@@ -6,84 +6,84 @@
       "stage": "pre",
       "question": "What is the default permission posture for the troubleshooting agent's RBAC surface?",
       "options": [
-        "Cluster-admin so it can self-heal",
         "Read-only by default, with destructive verbs gated behind a separate server and human approval",
         "Namespace-admin in the affected namespace only",
-        "Equivalent to the on-call engineer"
+        "Equivalent to the on-call engineer",
+        "Cluster-admin so it can self-heal"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     },
     {
       "stage": "pre",
       "question": "What is the knowledge graph the agent walks during root cause analysis?",
       "options": [
-        "A graph of GitHub commits and PR reviews",
         "Nodes are K8s objects plus telemetry sources; edges encode ownership, scheduling, and observation",
+        "A flat list of recently restarted pods",
         "Prometheus metric names organized by team",
-        "A flat list of recently restarted pods"
+        "A graph of GitHub commits and PR reviews"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "How are root-cause hypotheses ranked for the Slack brief?",
       "options": [
-        "By model log-probability alone",
         "By an evidence score combining recency, specificity, graph-path length, and citation count",
-        "By the order they were generated",
-        "By alphabetic alert name"
+        "By model log-probability alone",
+        "By alphabetic alert name",
+        "By the order they were generated"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "Why does the audit log record commands the agent considered as well as those executed?",
       "options": [
-        "Replay attacks require both lists",
         "Reviewers can catch near-misses where the agent almost ran a destructive command",
+        "ArgoCD only accepts considered commands",
         "The Slack API needs both for delivery",
-        "ArgoCD only accepts considered commands"
+        "Replay attacks require both lists"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "Which mechanism prevents the agent from rolling back unilaterally on a bad deploy?",
       "options": [
-        "A second LLM-judge votes on the rollback",
         "Destructive tools live on a separate MCP server behind an approval token from a Slack card",
-        "PagerDuty automatically pauses the deployment",
-        "Branch protection on the GitOps repo"
+        "A second LLM-judge votes on the rollback",
+        "Branch protection on the GitOps repo",
+        "PagerDuty automatically pauses the deployment"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     },
     {
       "stage": "post",
       "question": "What is the p50 time-to-hypothesis target the rubric measures?",
       "options": [
-        "Under 30 seconds",
-        "Under 5 minutes from alert to Slack brief",
+        "Under the next on-call shift",
         "Under 1 hour",
-        "Under the next on-call shift"
+        "Under 5 minutes from alert to Slack brief",
+        "Under 30 seconds"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     },
     {
       "stage": "post",
       "question": "How big is the synthetic incident suite used to score RCA accuracy?",
       "options": [
+        "1 scripted demo incident",
         "5 scenarios",
-        "20 scenarios covering OOMKill, DNS flap, HPA thrash, PVC fill, and more",
         "100 randomly sampled production alerts",
-        "1 scripted demo incident"
+        "20 scenarios covering OOMKill, DNS flap, HPA thrash, PVC fill, and more"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     }
   ]

--- a/phases/19-capstone-projects/07-end-to-end-fine-tuning-pipeline/quiz.json
+++ b/phases/19-capstone-projects/07-end-to-end-fine-tuning-pipeline/quiz.json
@@ -1,0 +1,90 @@
+{
+  "lesson": "07-end-to-end-fine-tuning-pipeline",
+  "title": "Capstone 07 — End-to-End Fine-Tuning Pipeline (Data to SFT to DPO to Serve)",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "What does the contamination check guard against during data preparation?",
+      "options": [
+        "GPU driver mismatches between training and serving",
+        "Test-set leakage from public benchmarks such as MMLU-Pro and MT-Bench-v2 into training data",
+        "Tokenizer drift between SFT and DPO stages",
+        "GGUF version skew across llama.cpp builds"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "pre",
+      "question": "Why does the pipeline compose SFT then DPO (or GRPO) rather than DPO alone?",
+      "options": [
+        "DPO cannot run on quantized weights",
+        "SFT establishes domain behavior on labeled completions while DPO or GRPO aligns the model against preference pairs or verifiable rewards",
+        "Axolotl does not implement DPO",
+        "DPO requires a separate base model architecture"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "What does EAGLE-3 contribute to the vLLM serving stage?",
+      "options": [
+        "A new prompt-caching layer",
+        "Draft heads that predict N tokens ahead; the target verifies in one pass for 2-3x throughput",
+        "An automatic data dedup step",
+        "An OPA policy for tool calls"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Which metric reports how well a speculative-decoding draft aligns with the target model?",
+      "options": [
+        "Perplexity",
+        "Acceptance rate",
+        "Coverage delta",
+        "PSI"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Which trio of quants does the pipeline ship for deployment flexibility?",
+      "options": [
+        "FP32, FP16, BF16",
+        "GPTQ-INT4-Marlin, AWQ-INT4, and GGUF-Q4_K_M",
+        "ONNX, CoreML, TFLite",
+        "INT8 only across three runtimes"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Which framework convention does the 2026 model card follow in this capstone?",
+      "options": [
+        "OpenAI's model card format",
+        "Model Openness Framework (MOF) 2026 template covering data, training, eval, safety, license, and reproducibility",
+        "Datasheets for Datasets",
+        "HuggingFace YAML front-matter only"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Which HPA metric is used to autoscale the serving replicas?",
+      "options": [
+        "CPU utilization",
+        "Queue-wait time",
+        "Network egress bytes",
+        "GPU temperature"
+      ],
+      "correct": 1,
+      "explanation": ""
+    }
+  ]
+}

--- a/phases/19-capstone-projects/07-end-to-end-fine-tuning-pipeline/quiz.json
+++ b/phases/19-capstone-projects/07-end-to-end-fine-tuning-pipeline/quiz.json
@@ -6,22 +6,22 @@
       "stage": "pre",
       "question": "What does the contamination check guard against during data preparation?",
       "options": [
-        "GPU driver mismatches between training and serving",
-        "Test-set leakage from public benchmarks such as MMLU-Pro and MT-Bench-v2 into training data",
         "Tokenizer drift between SFT and DPO stages",
-        "GGUF version skew across llama.cpp builds"
+        "GPU driver mismatches between training and serving",
+        "GGUF version skew across llama.cpp builds",
+        "Test-set leakage from public benchmarks such as MMLU-Pro and MT-Bench-v2 into training data"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
       "stage": "pre",
       "question": "Why does the pipeline compose SFT then DPO (or GRPO) rather than DPO alone?",
       "options": [
-        "DPO cannot run on quantized weights",
-        "SFT establishes domain behavior on labeled completions while DPO or GRPO aligns the model against preference pairs or verifiable rewards",
         "Axolotl does not implement DPO",
-        "DPO requires a separate base model architecture"
+        "SFT establishes domain behavior on labeled completions while DPO or GRPO aligns the model against preference pairs or verifiable rewards",
+        "DPO requires a separate base model architecture",
+        "DPO cannot run on quantized weights"
       ],
       "correct": 1,
       "explanation": ""
@@ -31,33 +31,33 @@
       "question": "What does EAGLE-3 contribute to the vLLM serving stage?",
       "options": [
         "A new prompt-caching layer",
-        "Draft heads that predict N tokens ahead; the target verifies in one pass for 2-3x throughput",
+        "An OPA policy for tool calls",
         "An automatic data dedup step",
-        "An OPA policy for tool calls"
+        "Draft heads that predict N tokens ahead; the target verifies in one pass for 2-3x throughput"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "Which metric reports how well a speculative-decoding draft aligns with the target model?",
       "options": [
-        "Perplexity",
         "Acceptance rate",
         "Coverage delta",
-        "PSI"
+        "PSI",
+        "Perplexity"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "Which trio of quants does the pipeline ship for deployment flexibility?",
       "options": [
-        "FP32, FP16, BF16",
-        "GPTQ-INT4-Marlin, AWQ-INT4, and GGUF-Q4_K_M",
         "ONNX, CoreML, TFLite",
-        "INT8 only across three runtimes"
+        "GPTQ-INT4-Marlin, AWQ-INT4, and GGUF-Q4_K_M",
+        "INT8 only across three runtimes",
+        "FP32, FP16, BF16"
       ],
       "correct": 1,
       "explanation": ""
@@ -66,10 +66,10 @@
       "stage": "post",
       "question": "Which framework convention does the 2026 model card follow in this capstone?",
       "options": [
-        "OpenAI's model card format",
-        "Model Openness Framework (MOF) 2026 template covering data, training, eval, safety, license, and reproducibility",
         "Datasheets for Datasets",
-        "HuggingFace YAML front-matter only"
+        "Model Openness Framework (MOF) 2026 template covering data, training, eval, safety, license, and reproducibility",
+        "HuggingFace YAML front-matter only",
+        "OpenAI's model card format"
       ],
       "correct": 1,
       "explanation": ""
@@ -78,12 +78,12 @@
       "stage": "post",
       "question": "Which HPA metric is used to autoscale the serving replicas?",
       "options": [
-        "CPU utilization",
         "Queue-wait time",
-        "Network egress bytes",
-        "GPU temperature"
+        "CPU utilization",
+        "GPU temperature",
+        "Network egress bytes"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     }
   ]

--- a/phases/19-capstone-projects/08-production-rag-chatbot/quiz.json
+++ b/phases/19-capstone-projects/08-production-rag-chatbot/quiz.json
@@ -1,0 +1,90 @@
+{
+  "lesson": "08-production-rag-chatbot",
+  "title": "Capstone 08 — Production RAG Chatbot for a Regulated Vertical",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "Why does prompt caching matter so much in a regulated-domain RAG chatbot?",
+      "options": [
+        "It removes the need for a vector database",
+        "At 60-80% hit rate it cuts per-query cost 3-5x by discounting stable prefix tokens",
+        "It eliminates hallucinations",
+        "It improves recall on the rerank stage"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "pre",
+      "question": "What goes into the cache header versus the uncached suffix of each request?",
+      "options": [
+        "User question first, system prompt last",
+        "System prompt and static policies in the cache header, reranked context as cache extension, user question as the uncached suffix",
+        "Random text padding to hit cache size",
+        "Only the retrieved documents"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "How does the retrieval layer respect jurisdiction tags like GDPR or HIPAA?",
+      "options": [
+        "It rewrites the user question per region",
+        "Role and jurisdiction filters apply before the hybrid search merge so chunks outside the user's scope are never reranked",
+        "It runs a separate index per country",
+        "It blocks the response after generation only"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Which layered guardrail combination does the synthesis stage pass output through?",
+      "options": [
+        "Just an output PII regex",
+        "Llama Guard 4, NeMo Guardrails policy rails, and Presidio PII scrub, plus citation enforcement",
+        "Only Llama Guard 4 on input",
+        "A single LLM-judge faithfulness check"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "What does the drift dashboard alert on?",
+      "options": [
+        "Any new document added to the index",
+        "A retrieval-quality drop, for example a 5% week-over-week dip in nDCG or citation score",
+        "A change in the underlying LLM provider",
+        "Latency above 200ms"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "How big is the golden set used to gate the deliverable's correctness rubric?",
+      "options": [
+        "20 questions",
+        "200 expert-labeled question/answer pairs with citations",
+        "2000 synthetic questions",
+        "5 demo queries"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Which RAGAS scores are tracked online per turn?",
+      "options": [
+        "Throughput, GPU utilization, and queue depth",
+        "Faithfulness, answer relevance, and context precision",
+        "Token count and dollar cost",
+        "BLEU, ROUGE, and METEOR"
+      ],
+      "correct": 1,
+      "explanation": ""
+    }
+  ]
+}

--- a/phases/19-capstone-projects/08-production-rag-chatbot/quiz.json
+++ b/phases/19-capstone-projects/08-production-rag-chatbot/quiz.json
@@ -18,33 +18,33 @@
       "stage": "pre",
       "question": "What goes into the cache header versus the uncached suffix of each request?",
       "options": [
-        "User question first, system prompt last",
-        "System prompt and static policies in the cache header, reranked context as cache extension, user question as the uncached suffix",
         "Random text padding to hit cache size",
-        "Only the retrieved documents"
+        "Only the retrieved documents",
+        "User question first, system prompt last",
+        "System prompt and static policies in the cache header, reranked context as cache extension, user question as the uncached suffix"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "How does the retrieval layer respect jurisdiction tags like GDPR or HIPAA?",
       "options": [
-        "It rewrites the user question per region",
-        "Role and jurisdiction filters apply before the hybrid search merge so chunks outside the user's scope are never reranked",
         "It runs a separate index per country",
-        "It blocks the response after generation only"
+        "It blocks the response after generation only",
+        "It rewrites the user question per region",
+        "Role and jurisdiction filters apply before the hybrid search merge so chunks outside the user's scope are never reranked"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "Which layered guardrail combination does the synthesis stage pass output through?",
       "options": [
-        "Just an output PII regex",
-        "Llama Guard 4, NeMo Guardrails policy rails, and Presidio PII scrub, plus citation enforcement",
         "Only Llama Guard 4 on input",
+        "Llama Guard 4, NeMo Guardrails policy rails, and Presidio PII scrub, plus citation enforcement",
+        "Just an output PII regex",
         "A single LLM-judge faithfulness check"
       ],
       "correct": 1,
@@ -54,22 +54,22 @@
       "stage": "check",
       "question": "What does the drift dashboard alert on?",
       "options": [
-        "Any new document added to the index",
-        "A retrieval-quality drop, for example a 5% week-over-week dip in nDCG or citation score",
         "A change in the underlying LLM provider",
-        "Latency above 200ms"
+        "Latency above 200ms",
+        "A retrieval-quality drop, for example a 5% week-over-week dip in nDCG or citation score",
+        "Any new document added to the index"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     },
     {
       "stage": "post",
       "question": "How big is the golden set used to gate the deliverable's correctness rubric?",
       "options": [
-        "20 questions",
+        "5 demo queries",
         "200 expert-labeled question/answer pairs with citations",
-        "2000 synthetic questions",
-        "5 demo queries"
+        "20 questions",
+        "2000 synthetic questions"
       ],
       "correct": 1,
       "explanation": ""
@@ -79,11 +79,11 @@
       "question": "Which RAGAS scores are tracked online per turn?",
       "options": [
         "Throughput, GPU utilization, and queue depth",
+        "BLEU, ROUGE, and METEOR",
         "Faithfulness, answer relevance, and context precision",
-        "Token count and dollar cost",
-        "BLEU, ROUGE, and METEOR"
+        "Token count and dollar cost"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     }
   ]

--- a/phases/19-capstone-projects/09-code-migration-agent/quiz.json
+++ b/phases/19-capstone-projects/09-code-migration-agent/quiz.json
@@ -1,0 +1,90 @@
+{
+  "lesson": "09-code-migration-agent",
+  "title": "Capstone 09 — Code Migration Agent (Repo-Level Language / Runtime Upgrade)",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "Why does the pipeline combine a deterministic substrate with an agent layer rather than using just one?",
+      "options": [
+        "Determinism is needed only for the build system",
+        "OpenRewrite or libcst handles 70-80% of mechanical rewrites safely and cheaply, leaving the agent for the ambiguous long tail",
+        "Agents alone are faster than recipes",
+        "Deterministic recipes are slower than LLMs"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "pre",
+      "question": "What signal does the pipeline use as ground truth for a successful migration?",
+      "options": [
+        "Agent self-grading on a rubric",
+        "Green CI in the sandbox without a coverage regression beyond a small threshold",
+        "Diff size below a hard limit",
+        "Reviewer approval on the PR"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Which budget caps does the agent loop enforce per repo?",
+      "options": [
+        "Unlimited time and cost; abort only on errors",
+        "30 minutes wall-clock, $8 cost, and 20 agent turns",
+        "1 hour wall-clock and 100 turns",
+        "No turn limit, $100 ceiling"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "What gate fires when coverage drops more than about 2% after migration?",
+      "options": [
+        "The agent automatically force-pushes a fix",
+        "The repo gets filed under a coverage_regression failure class instead of opening a clean PR",
+        "The deterministic substrate replays its recipes",
+        "The reviewer is bypassed"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Why is the failure taxonomy treated as a deliverable rather than a side artifact?",
+      "options": [
+        "It satisfies a compliance checklist",
+        "It groups failed repos by class so future recipe authors can target the top failure modes",
+        "It is required by GitHub branch protection",
+        "It replaces the test suite"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Which public benchmark does the capstone target for Java 8 to 17 migration?",
+      "options": [
+        "SWE-bench Pro",
+        "MigrationBench from Amazon",
+        "ViDoRe v3",
+        "MMLU-Pro"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "What does the agent integration rubric measure about the fix distribution?",
+      "options": [
+        "The number of force-pushes per repo",
+        "The fraction of fixes handled by OpenRewrite versus authored by the agent layer",
+        "Tokenization speed of the source file",
+        "Number of dependencies pinned"
+      ],
+      "correct": 1,
+      "explanation": ""
+    }
+  ]
+}

--- a/phases/19-capstone-projects/09-code-migration-agent/quiz.json
+++ b/phases/19-capstone-projects/09-code-migration-agent/quiz.json
@@ -6,12 +6,12 @@
       "stage": "pre",
       "question": "Why does the pipeline combine a deterministic substrate with an agent layer rather than using just one?",
       "options": [
-        "Determinism is needed only for the build system",
         "OpenRewrite or libcst handles 70-80% of mechanical rewrites safely and cheaply, leaving the agent for the ambiguous long tail",
         "Agents alone are faster than recipes",
-        "Deterministic recipes are slower than LLMs"
+        "Deterministic recipes are slower than LLMs",
+        "Determinism is needed only for the build system"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     },
     {
@@ -19,11 +19,11 @@
       "question": "What signal does the pipeline use as ground truth for a successful migration?",
       "options": [
         "Agent self-grading on a rubric",
-        "Green CI in the sandbox without a coverage regression beyond a small threshold",
+        "Reviewer approval on the PR",
         "Diff size below a hard limit",
-        "Reviewer approval on the PR"
+        "Green CI in the sandbox without a coverage regression beyond a small threshold"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
@@ -31,21 +31,21 @@
       "question": "Which budget caps does the agent loop enforce per repo?",
       "options": [
         "Unlimited time and cost; abort only on errors",
-        "30 minutes wall-clock, $8 cost, and 20 agent turns",
+        "No turn limit, $100 ceiling",
         "1 hour wall-clock and 100 turns",
-        "No turn limit, $100 ceiling"
+        "30 minutes wall-clock, $8 cost, and 20 agent turns"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "What gate fires when coverage drops more than about 2% after migration?",
       "options": [
-        "The agent automatically force-pushes a fix",
+        "The reviewer is bypassed",
         "The repo gets filed under a coverage_regression failure class instead of opening a clean PR",
         "The deterministic substrate replays its recipes",
-        "The reviewer is bypassed"
+        "The agent automatically force-pushes a fix"
       ],
       "correct": 1,
       "explanation": ""
@@ -54,10 +54,10 @@
       "stage": "check",
       "question": "Why is the failure taxonomy treated as a deliverable rather than a side artifact?",
       "options": [
-        "It satisfies a compliance checklist",
+        "It replaces the test suite",
         "It groups failed repos by class so future recipe authors can target the top failure modes",
         "It is required by GitHub branch protection",
-        "It replaces the test suite"
+        "It satisfies a compliance checklist"
       ],
       "correct": 1,
       "explanation": ""
@@ -66,24 +66,24 @@
       "stage": "post",
       "question": "Which public benchmark does the capstone target for Java 8 to 17 migration?",
       "options": [
-        "SWE-bench Pro",
         "MigrationBench from Amazon",
-        "ViDoRe v3",
-        "MMLU-Pro"
+        "SWE-bench Pro",
+        "MMLU-Pro",
+        "ViDoRe v3"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     },
     {
       "stage": "post",
       "question": "What does the agent integration rubric measure about the fix distribution?",
       "options": [
-        "The number of force-pushes per repo",
-        "The fraction of fixes handled by OpenRewrite versus authored by the agent layer",
         "Tokenization speed of the source file",
-        "Number of dependencies pinned"
+        "The number of force-pushes per repo",
+        "Number of dependencies pinned",
+        "The fraction of fixes handled by OpenRewrite versus authored by the agent layer"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     }
   ]

--- a/phases/19-capstone-projects/10-multi-agent-software-team/quiz.json
+++ b/phases/19-capstone-projects/10-multi-agent-software-team/quiz.json
@@ -1,0 +1,90 @@
+{
+  "lesson": "10-multi-agent-software-team",
+  "title": "Capstone 10 — Multi-Agent Software Engineering Team",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "Why does a single-agent harness hit a ceiling on large tasks even with a 200k-token context?",
+      "options": [
+        "Single agents cannot make tool calls",
+        "Context cannot hold the architecture plan, four parallel codebase slices, reviewer commentary, and test output at once",
+        "Models lack support for git",
+        "Sandboxes refuse to host more than one process"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "pre",
+      "question": "What does the architect role own in this factory shape?",
+      "options": [
+        "Running the test suite in a clean sandbox",
+        "Reading the issue and emitting a plan with subtasks that have explicit interfaces",
+        "Force-merging branches when coders disagree",
+        "Reviewing the merged diff for hallucinations"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Why does each coder work in its own git worktree plus a Daytona sandbox?",
+      "options": [
+        "Worktrees are faster to clone than branches",
+        "Isolated working trees let N coders implement subtasks in parallel without stepping on shared files",
+        "Daytona is the only sandbox that supports SSH",
+        "The architect requires worktree IDs"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "What constraint is placed on the reviewer to keep it honest?",
+      "options": [
+        "It cannot approve diffs it authored or proposed",
+        "It must approve every diff it reads",
+        "It can only run after the tester signs off",
+        "It must be the same model as the architect"
+      ],
+      "correct": 0,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Why does the rubric weigh token efficiency against a single-agent baseline?",
+      "options": [
+        "Multi-agent is always cheaper",
+        "Role boundaries add summary and handoff context, so the real question is whether the factory wins per dollar",
+        "Single-agent has no observability story",
+        "Token cost is unrelated to performance"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Which artifact is produced from each failed issue during the post-mortem?",
+      "options": [
+        "A new architect plan template",
+        "A handoff-failure histogram identifying which role boundary broke (plan, merge, review, test)",
+        "A force-push log",
+        "An updated A2A protocol spec"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Which evaluation set does the capstone use to score pass@1 across roles?",
+      "options": [
+        "SWE-bench Pro 50-issue subset",
+        "MigrationBench",
+        "MT-Bench-v2",
+        "HumanEval-Java"
+      ],
+      "correct": 0,
+      "explanation": ""
+    }
+  ]
+}

--- a/phases/19-capstone-projects/10-multi-agent-software-team/quiz.json
+++ b/phases/19-capstone-projects/10-multi-agent-software-team/quiz.json
@@ -7,21 +7,21 @@
       "question": "Why does a single-agent harness hit a ceiling on large tasks even with a 200k-token context?",
       "options": [
         "Single agents cannot make tool calls",
+        "Sandboxes refuse to host more than one process",
         "Context cannot hold the architecture plan, four parallel codebase slices, reviewer commentary, and test output at once",
-        "Models lack support for git",
-        "Sandboxes refuse to host more than one process"
+        "Models lack support for git"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     },
     {
       "stage": "pre",
       "question": "What does the architect role own in this factory shape?",
       "options": [
-        "Running the test suite in a clean sandbox",
+        "Reviewing the merged diff for hallucinations",
         "Reading the issue and emitting a plan with subtasks that have explicit interfaces",
-        "Force-merging branches when coders disagree",
-        "Reviewing the merged diff for hallucinations"
+        "Running the test suite in a clean sandbox",
+        "Force-merging branches when coders disagree"
       ],
       "correct": 1,
       "explanation": ""
@@ -31,23 +31,23 @@
       "question": "Why does each coder work in its own git worktree plus a Daytona sandbox?",
       "options": [
         "Worktrees are faster to clone than branches",
-        "Isolated working trees let N coders implement subtasks in parallel without stepping on shared files",
         "Daytona is the only sandbox that supports SSH",
+        "Isolated working trees let N coders implement subtasks in parallel without stepping on shared files",
         "The architect requires worktree IDs"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "What constraint is placed on the reviewer to keep it honest?",
       "options": [
+        "It can only run after the tester signs off",
         "It cannot approve diffs it authored or proposed",
         "It must approve every diff it reads",
-        "It can only run after the tester signs off",
         "It must be the same model as the architect"
       ],
-      "correct": 0,
+      "correct": 1,
       "explanation": ""
     },
     {
@@ -67,11 +67,11 @@
       "question": "Which artifact is produced from each failed issue during the post-mortem?",
       "options": [
         "A new architect plan template",
-        "A handoff-failure histogram identifying which role boundary broke (plan, merge, review, test)",
+        "An updated A2A protocol spec",
         "A force-push log",
-        "An updated A2A protocol spec"
+        "A handoff-failure histogram identifying which role boundary broke (plan, merge, review, test)"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
@@ -79,9 +79,9 @@
       "question": "Which evaluation set does the capstone use to score pass@1 across roles?",
       "options": [
         "SWE-bench Pro 50-issue subset",
-        "MigrationBench",
+        "HumanEval-Java",
         "MT-Bench-v2",
-        "HumanEval-Java"
+        "MigrationBench"
       ],
       "correct": 0,
       "explanation": ""

--- a/phases/19-capstone-projects/11-llm-observability-dashboard/quiz.json
+++ b/phases/19-capstone-projects/11-llm-observability-dashboard/quiz.json
@@ -7,23 +7,23 @@
       "question": "Which ingest schema do Langfuse, Phoenix, and OpenLLMetry converge on?",
       "options": [
         "Proprietary JSON per vendor",
-        "OpenTelemetry GenAI semantic conventions over OTLP HTTP",
         "Prometheus exposition format",
+        "OpenTelemetry GenAI semantic conventions over OTLP HTTP",
         "Plain CSV log files"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     },
     {
       "stage": "pre",
       "question": "Why separate ClickHouse and Postgres in the storage tier?",
       "options": [
-        "ClickHouse cannot store strings",
-        "ClickHouse handles columnar analytics over spans while Postgres holds users, sessions, and app metadata",
+        "They are interchangeable and one is chosen at random",
         "Postgres is faster for span ingest",
-        "They are interchangeable and one is chosen at random"
+        "ClickHouse cannot store strings",
+        "ClickHouse handles columnar analytics over spans while Postgres holds users, sessions, and app metadata"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
@@ -31,9 +31,9 @@
       "question": "What does the tail-sampling processor in the OpenTelemetry Collector do?",
       "options": [
         "Decides whether to keep a trace after it completes, using rules like keep errors plus sample successes",
+        "Replays old traces into Postgres",
         "Streams every byte unconditionally",
-        "Truncates spans below 100ms",
-        "Replays old traces into Postgres"
+        "Truncates spans below 100ms"
       ],
       "correct": 0,
       "explanation": ""
@@ -42,34 +42,34 @@
       "stage": "check",
       "question": "How does the dashboard detect drift across weeks?",
       "options": [
-        "Counts unique trace IDs",
         "Computes PSI or KL divergence on pooled prompt embeddings and watches eval-score trends",
+        "Manual eyeballing of the dashboard",
         "Reads the latest deploy timestamp",
-        "Manual eyeballing of the dashboard"
+        "Counts unique trace IDs"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "What is the deliverable's MTTR target on an injected PII-leak regression?",
       "options": [
-        "Under 5 minutes from bug deployed to Slack alert",
         "Under 1 hour",
+        "Within 24 hours",
         "Within the next on-call shift",
-        "Within 24 hours"
+        "Under 5 minutes from bug deployed to Slack alert"
       ],
-      "correct": 0,
+      "correct": 3,
       "explanation": ""
     },
     {
       "stage": "post",
       "question": "Which SDK families must produce canonical GenAI spans to meet the trace-coverage rubric?",
       "options": [
-        "OpenAI and Anthropic only",
-        "At least six: OpenAI, Anthropic, Google GenAI, LangChain, LlamaIndex, and vLLM",
         "Only vLLM",
-        "Any one SDK is enough"
+        "At least six: OpenAI, Anthropic, Google GenAI, LangChain, LlamaIndex, and vLLM",
+        "Any one SDK is enough",
+        "OpenAI and Anthropic only"
       ],
       "correct": 1,
       "explanation": ""
@@ -78,12 +78,12 @@
       "stage": "post",
       "question": "How are evaluation results linked back to the original LLM call?",
       "options": [
-        "As a separate Postgres table with no trace ID",
-        "As eval spans written as children of the parent trace in ClickHouse",
+        "As a CSV emailed nightly",
         "As Slack messages only",
-        "As a CSV emailed nightly"
+        "As a separate Postgres table with no trace ID",
+        "As eval spans written as children of the parent trace in ClickHouse"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     }
   ]

--- a/phases/19-capstone-projects/11-llm-observability-dashboard/quiz.json
+++ b/phases/19-capstone-projects/11-llm-observability-dashboard/quiz.json
@@ -1,0 +1,90 @@
+{
+  "lesson": "11-llm-observability-dashboard",
+  "title": "Capstone 11 — LLM Observability & Eval Dashboard",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "Which ingest schema do Langfuse, Phoenix, and OpenLLMetry converge on?",
+      "options": [
+        "Proprietary JSON per vendor",
+        "OpenTelemetry GenAI semantic conventions over OTLP HTTP",
+        "Prometheus exposition format",
+        "Plain CSV log files"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "pre",
+      "question": "Why separate ClickHouse and Postgres in the storage tier?",
+      "options": [
+        "ClickHouse cannot store strings",
+        "ClickHouse handles columnar analytics over spans while Postgres holds users, sessions, and app metadata",
+        "Postgres is faster for span ingest",
+        "They are interchangeable and one is chosen at random"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "What does the tail-sampling processor in the OpenTelemetry Collector do?",
+      "options": [
+        "Decides whether to keep a trace after it completes, using rules like keep errors plus sample successes",
+        "Streams every byte unconditionally",
+        "Truncates spans below 100ms",
+        "Replays old traces into Postgres"
+      ],
+      "correct": 0,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "How does the dashboard detect drift across weeks?",
+      "options": [
+        "Counts unique trace IDs",
+        "Computes PSI or KL divergence on pooled prompt embeddings and watches eval-score trends",
+        "Reads the latest deploy timestamp",
+        "Manual eyeballing of the dashboard"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "What is the deliverable's MTTR target on an injected PII-leak regression?",
+      "options": [
+        "Under 5 minutes from bug deployed to Slack alert",
+        "Under 1 hour",
+        "Within the next on-call shift",
+        "Within 24 hours"
+      ],
+      "correct": 0,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Which SDK families must produce canonical GenAI spans to meet the trace-coverage rubric?",
+      "options": [
+        "OpenAI and Anthropic only",
+        "At least six: OpenAI, Anthropic, Google GenAI, LangChain, LlamaIndex, and vLLM",
+        "Only vLLM",
+        "Any one SDK is enough"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "How are evaluation results linked back to the original LLM call?",
+      "options": [
+        "As a separate Postgres table with no trace ID",
+        "As eval spans written as children of the parent trace in ClickHouse",
+        "As Slack messages only",
+        "As a CSV emailed nightly"
+      ],
+      "correct": 1,
+      "explanation": ""
+    }
+  ]
+}

--- a/phases/19-capstone-projects/12-video-understanding-pipeline/quiz.json
+++ b/phases/19-capstone-projects/12-video-understanding-pipeline/quiz.json
@@ -1,0 +1,90 @@
+{
+  "lesson": "12-video-understanding-pipeline",
+  "title": "Capstone 12 — Video Understanding Pipeline (Scene, QA, Search)",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "Why is a scene-level index still needed even when a long-context VLM can read a 2-hour video natively?",
+      "options": [
+        "Long-context VLMs cannot stream output",
+        "Ingesting 100 hours of video into a queryable corpus needs scene-level retrieval, even when individual videos can be read whole",
+        "Scene cuts are the only thing a VLM understands",
+        "Vector indexes do not support video files"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "pre",
+      "question": "Which three vector types does each scene get in the multi-vector index?",
+      "options": [
+        "Caption embedding, keyframe embedding, and transcript embedding",
+        "Audio waveform, mel-spectrogram, and MFCCs",
+        "Hash, gzip, and CRC",
+        "Pose, depth, and optical flow"
+      ],
+      "correct": 0,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "How are results from the three retrieval streams merged at query time?",
+      "options": [
+        "By taking the union without scoring",
+        "Via reciprocal rank fusion across the three ranked lists",
+        "By picking the caption hit only",
+        "By averaging cosine similarities"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "What does the temporal grounding step refine inside the top scene?",
+      "options": [
+        "The keyframe embedding dimensionality",
+        "The (start, end) timestamp window that contains the answer",
+        "The transcript word timestamps from Whisper",
+        "The number of vectors stored in Qdrant"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Which question class is reported separately because it is a known hallucination hotspot?",
+      "options": [
+        "Descriptive questions about scenery",
+        "Counting and action-type questions, where VLMs miscount or mis-order events",
+        "Speaker identification questions",
+        "Translation questions"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Which grounding metric does the rubric measure on a held-out set?",
+      "options": [
+        "MRR@10",
+        "Temporal-grounding intersection-over-union (IoU)",
+        "Perplexity",
+        "Acceptance rate"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Why does the pipeline require cited timestamps in answers?",
+      "options": [
+        "Timestamps are required by Qdrant payloads",
+        "They let the viewer jump to the exact (video_id, start, end) so users can verify the claim",
+        "They reduce the embedding dimension",
+        "Timestamps are required by Whisper output"
+      ],
+      "correct": 1,
+      "explanation": ""
+    }
+  ]
+}

--- a/phases/19-capstone-projects/12-video-understanding-pipeline/quiz.json
+++ b/phases/19-capstone-projects/12-video-understanding-pipeline/quiz.json
@@ -7,11 +7,11 @@
       "question": "Why is a scene-level index still needed even when a long-context VLM can read a 2-hour video natively?",
       "options": [
         "Long-context VLMs cannot stream output",
+        "Vector indexes do not support video files",
         "Ingesting 100 hours of video into a queryable corpus needs scene-level retrieval, even when individual videos can be read whole",
-        "Scene cuts are the only thing a VLM understands",
-        "Vector indexes do not support video files"
+        "Scene cuts are the only thing a VLM understands"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     },
     {
@@ -30,24 +30,24 @@
       "stage": "check",
       "question": "How are results from the three retrieval streams merged at query time?",
       "options": [
-        "By taking the union without scoring",
-        "Via reciprocal rank fusion across the three ranked lists",
         "By picking the caption hit only",
-        "By averaging cosine similarities"
+        "By averaging cosine similarities",
+        "Via reciprocal rank fusion across the three ranked lists",
+        "By taking the union without scoring"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "What does the temporal grounding step refine inside the top scene?",
       "options": [
-        "The keyframe embedding dimensionality",
-        "The (start, end) timestamp window that contains the answer",
         "The transcript word timestamps from Whisper",
-        "The number of vectors stored in Qdrant"
+        "The number of vectors stored in Qdrant",
+        "The (start, end) timestamp window that contains the answer",
+        "The keyframe embedding dimensionality"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     },
     {
@@ -55,35 +55,35 @@
       "question": "Which question class is reported separately because it is a known hallucination hotspot?",
       "options": [
         "Descriptive questions about scenery",
-        "Counting and action-type questions, where VLMs miscount or mis-order events",
         "Speaker identification questions",
-        "Translation questions"
+        "Translation questions",
+        "Counting and action-type questions, where VLMs miscount or mis-order events"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
       "stage": "post",
       "question": "Which grounding metric does the rubric measure on a held-out set?",
       "options": [
-        "MRR@10",
         "Temporal-grounding intersection-over-union (IoU)",
+        "Acceptance rate",
         "Perplexity",
-        "Acceptance rate"
+        "MRR@10"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     },
     {
       "stage": "post",
       "question": "Why does the pipeline require cited timestamps in answers?",
       "options": [
-        "Timestamps are required by Qdrant payloads",
-        "They let the viewer jump to the exact (video_id, start, end) so users can verify the claim",
         "They reduce the embedding dimension",
-        "Timestamps are required by Whisper output"
+        "Timestamps are required by Whisper output",
+        "Timestamps are required by Qdrant payloads",
+        "They let the viewer jump to the exact (video_id, start, end) so users can verify the claim"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     }
   ]

--- a/phases/19-capstone-projects/13-mcp-server-with-registry/quiz.json
+++ b/phases/19-capstone-projects/13-mcp-server-with-registry/quiz.json
@@ -1,0 +1,90 @@
+{
+  "lesson": "13-mcp-server-with-registry",
+  "title": "Capstone 13 — MCP Server with Registry and Governance",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "Why does the 2026 MCP revision favor StreamableHTTP for production servers?",
+      "options": [
+        "It encrypts payloads automatically",
+        "It is stateless by default, so a single endpoint behind a load balancer can scale horizontally",
+        "It removes the need for authentication",
+        "It is the only transport that supports tool calls"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "pre",
+      "question": "Which authorization model gates tool calls in this capstone?",
+      "options": [
+        "API keys per IP address",
+        "OAuth 2.1 tokens carrying per-tool scopes, checked at tool-call time",
+        "Mutual TLS without scopes",
+        "A shared admin password"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "What is the role of the .well-known/mcp-capabilities document?",
+      "options": [
+        "Stores audit logs for the server",
+        "Exposes the tool manifest, transport URL, and auth requirements so the registry can validate and index the server",
+        "Lists outbound IP ranges",
+        "Holds the OPA policy bundle"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Why do destructive tools live on a separate MCP server in this design?",
+      "options": [
+        "They require a different programming language",
+        "They are gated behind an approval token elevated via a Slack card within a short window",
+        "They cannot be exposed over StreamableHTTP",
+        "They run on slower hardware"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "What does OPA / Rego decide on every tool call?",
+      "options": [
+        "Which model to invoke",
+        "Whether the caller's scopes permit invocation, plus PII redaction and payload caps",
+        "How the server should re-rank the response",
+        "Where to write the audit log"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Which evidence demonstrates StreamableHTTP horizontal scaling in the load test?",
+      "options": [
+        "Adding a second replica and showing the load balancer redistributing without session stickiness",
+        "Running everything in a single process",
+        "Reducing concurrency to one client",
+        "Switching to stdio transport"
+      ],
+      "correct": 0,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Why does the audit log scrub PII via Presidio before being persisted per tenant?",
+      "options": [
+        "To meet enterprise security requirements while keeping per-call lineage queryable",
+        "To make logs shorter",
+        "Presidio reduces ClickHouse write amplification",
+        "PII improves search performance"
+      ],
+      "correct": 0,
+      "explanation": ""
+    }
+  ]
+}

--- a/phases/19-capstone-projects/13-mcp-server-with-registry/quiz.json
+++ b/phases/19-capstone-projects/13-mcp-server-with-registry/quiz.json
@@ -6,24 +6,24 @@
       "stage": "pre",
       "question": "Why does the 2026 MCP revision favor StreamableHTTP for production servers?",
       "options": [
-        "It encrypts payloads automatically",
-        "It is stateless by default, so a single endpoint behind a load balancer can scale horizontally",
         "It removes the need for authentication",
-        "It is the only transport that supports tool calls"
+        "It is the only transport that supports tool calls",
+        "It encrypts payloads automatically",
+        "It is stateless by default, so a single endpoint behind a load balancer can scale horizontally"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
       "stage": "pre",
       "question": "Which authorization model gates tool calls in this capstone?",
       "options": [
-        "API keys per IP address",
         "OAuth 2.1 tokens carrying per-tool scopes, checked at tool-call time",
-        "Mutual TLS without scopes",
-        "A shared admin password"
+        "A shared admin password",
+        "API keys per IP address",
+        "Mutual TLS without scopes"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     },
     {
@@ -31,23 +31,23 @@
       "question": "What is the role of the .well-known/mcp-capabilities document?",
       "options": [
         "Stores audit logs for the server",
-        "Exposes the tool manifest, transport URL, and auth requirements so the registry can validate and index the server",
         "Lists outbound IP ranges",
-        "Holds the OPA policy bundle"
+        "Holds the OPA policy bundle",
+        "Exposes the tool manifest, transport URL, and auth requirements so the registry can validate and index the server"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "Why do destructive tools live on a separate MCP server in this design?",
       "options": [
-        "They require a different programming language",
-        "They are gated behind an approval token elevated via a Slack card within a short window",
         "They cannot be exposed over StreamableHTTP",
-        "They run on slower hardware"
+        "They run on slower hardware",
+        "They are gated behind an approval token elevated via a Slack card within a short window",
+        "They require a different programming language"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     },
     {
@@ -55,35 +55,35 @@
       "question": "What does OPA / Rego decide on every tool call?",
       "options": [
         "Which model to invoke",
-        "Whether the caller's scopes permit invocation, plus PII redaction and payload caps",
+        "Where to write the audit log",
         "How the server should re-rank the response",
-        "Where to write the audit log"
+        "Whether the caller's scopes permit invocation, plus PII redaction and payload caps"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
       "stage": "post",
       "question": "Which evidence demonstrates StreamableHTTP horizontal scaling in the load test?",
       "options": [
-        "Adding a second replica and showing the load balancer redistributing without session stickiness",
-        "Running everything in a single process",
         "Reducing concurrency to one client",
-        "Switching to stdio transport"
+        "Switching to stdio transport",
+        "Running everything in a single process",
+        "Adding a second replica and showing the load balancer redistributing without session stickiness"
       ],
-      "correct": 0,
+      "correct": 3,
       "explanation": ""
     },
     {
       "stage": "post",
       "question": "Why does the audit log scrub PII via Presidio before being persisted per tenant?",
       "options": [
-        "To meet enterprise security requirements while keeping per-call lineage queryable",
         "To make logs shorter",
+        "To meet enterprise security requirements while keeping per-call lineage queryable",
         "Presidio reduces ClickHouse write amplification",
         "PII improves search performance"
       ],
-      "correct": 0,
+      "correct": 1,
       "explanation": ""
     }
   ]

--- a/phases/19-capstone-projects/14-speculative-decoding-server/quiz.json
+++ b/phases/19-capstone-projects/14-speculative-decoding-server/quiz.json
@@ -1,0 +1,90 @@
+{
+  "lesson": "14-speculative-decoding-server",
+  "title": "Capstone 14 — Speculative-Decoding Inference Server",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "What is the two-layer mechanism behind speculative decoding?",
+      "options": [
+        "A retrieval cache and a reranker",
+        "A draft model proposes k candidate tokens; the target model verifies them in a single pass",
+        "Two target models alternate per token",
+        "An embedding model and a synthesizer"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "pre",
+      "question": "What does EAGLE-3 do that ngram drafts do not?",
+      "options": [
+        "It runs only on CPUs",
+        "It trains draft heads on the target model's hidden states for higher acceptance rates",
+        "It avoids tokenization entirely",
+        "It replaces the target model"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Why is p99 tail latency reported across batch sizes 1, 8, and 32?",
+      "options": [
+        "Steady-state tokens-per-second can hide that the verify pass on rejection is more expensive than vanilla decoding",
+        "p99 only matters at batch size 32",
+        "vLLM cannot serve batch sizes below 8",
+        "Tail latency is independent of batch size"
+      ],
+      "correct": 0,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Why does acceptance rate drift when the traffic distribution shifts?",
+      "options": [
+        "Quantization changes at runtime",
+        "Draft alignment depends on the input distribution: ShareGPT, code, and domain data exercise different patterns",
+        "vLLM rotates models hourly",
+        "The OS scheduler reshuffles GPU memory"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Which Kubernetes HPA signal does the deployment scale on?",
+      "options": [
+        "CPU utilization",
+        "Queue-wait time on inference requests",
+        "Cluster autoscaler nodes",
+        "Disk IOPS"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "What does P-EAGLE add over serial EAGLE-3?",
+      "options": [
+        "Quantization to FP4 weights",
+        "Parallel speculation across a tree of draft branches verified in one target pass",
+        "Removal of the target model",
+        "Automatic dataset curation"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Which throughput target does the rubric demand against the non-speculative baseline?",
+      "options": [
+        "Roughly 1.1x at matched quality",
+        "At least 2.5x at matched quality on two models",
+        "Exactly 10x throughput at any quality",
+        "Any improvement above baseline"
+      ],
+      "correct": 1,
+      "explanation": ""
+    }
+  ]
+}

--- a/phases/19-capstone-projects/14-speculative-decoding-server/quiz.json
+++ b/phases/19-capstone-projects/14-speculative-decoding-server/quiz.json
@@ -6,22 +6,22 @@
       "stage": "pre",
       "question": "What is the two-layer mechanism behind speculative decoding?",
       "options": [
-        "A retrieval cache and a reranker",
-        "A draft model proposes k candidate tokens; the target model verifies them in a single pass",
         "Two target models alternate per token",
-        "An embedding model and a synthesizer"
+        "An embedding model and a synthesizer",
+        "A retrieval cache and a reranker",
+        "A draft model proposes k candidate tokens; the target model verifies them in a single pass"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
       "stage": "pre",
       "question": "What does EAGLE-3 do that ngram drafts do not?",
       "options": [
-        "It runs only on CPUs",
+        "It replaces the target model",
         "It trains draft heads on the target model's hidden states for higher acceptance rates",
         "It avoids tokenization entirely",
-        "It replaces the target model"
+        "It runs only on CPUs"
       ],
       "correct": 1,
       "explanation": ""
@@ -31,8 +31,8 @@
       "question": "Why is p99 tail latency reported across batch sizes 1, 8, and 32?",
       "options": [
         "Steady-state tokens-per-second can hide that the verify pass on rejection is more expensive than vanilla decoding",
-        "p99 only matters at batch size 32",
         "vLLM cannot serve batch sizes below 8",
+        "p99 only matters at batch size 32",
         "Tail latency is independent of batch size"
       ],
       "correct": 0,
@@ -42,10 +42,10 @@
       "stage": "check",
       "question": "Why does acceptance rate drift when the traffic distribution shifts?",
       "options": [
-        "Quantization changes at runtime",
-        "Draft alignment depends on the input distribution: ShareGPT, code, and domain data exercise different patterns",
         "vLLM rotates models hourly",
-        "The OS scheduler reshuffles GPU memory"
+        "Draft alignment depends on the input distribution: ShareGPT, code, and domain data exercise different patterns",
+        "The OS scheduler reshuffles GPU memory",
+        "Quantization changes at runtime"
       ],
       "correct": 1,
       "explanation": ""
@@ -54,12 +54,12 @@
       "stage": "check",
       "question": "Which Kubernetes HPA signal does the deployment scale on?",
       "options": [
-        "CPU utilization",
-        "Queue-wait time on inference requests",
         "Cluster autoscaler nodes",
-        "Disk IOPS"
+        "CPU utilization",
+        "Disk IOPS",
+        "Queue-wait time on inference requests"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
@@ -67,23 +67,23 @@
       "question": "What does P-EAGLE add over serial EAGLE-3?",
       "options": [
         "Quantization to FP4 weights",
-        "Parallel speculation across a tree of draft branches verified in one target pass",
         "Removal of the target model",
+        "Parallel speculation across a tree of draft branches verified in one target pass",
         "Automatic dataset curation"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     },
     {
       "stage": "post",
       "question": "Which throughput target does the rubric demand against the non-speculative baseline?",
       "options": [
-        "Roughly 1.1x at matched quality",
         "At least 2.5x at matched quality on two models",
-        "Exactly 10x throughput at any quality",
-        "Any improvement above baseline"
+        "Any improvement above baseline",
+        "Roughly 1.1x at matched quality",
+        "Exactly 10x throughput at any quality"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     }
   ]

--- a/phases/19-capstone-projects/15-constitutional-safety-harness/quiz.json
+++ b/phases/19-capstone-projects/15-constitutional-safety-harness/quiz.json
@@ -6,58 +6,58 @@
       "stage": "pre",
       "question": "What does layered safety in this capstone mean?",
       "options": [
+        "Manual review of every response",
         "Running one strong classifier on the input only",
-        "Defense in depth across input sanitize, policy rails, classifier gate, model, output filter, and HITL tier",
         "A single rule-based regex over outputs",
-        "Manual review of every response"
+        "Defense in depth across input sanitize, policy rails, classifier gate, model, output filter, and HITL tier"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
       "stage": "pre",
       "question": "Which classifier handles multilingual coverage across roughly 132 languages?",
       "options": [
-        "Llama Guard 4",
-        "X-Guard",
+        "Nemotron 3 Content Safety",
         "ShieldGemma-2",
-        "Nemotron 3 Content Safety"
+        "X-Guard",
+        "Llama Guard 4"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "Why is over-refusal measured on a benign suite like XSTest?",
       "options": [
+        "To replace red-team scoring",
         "To benchmark token throughput",
-        "To track false-positive blocks so the model stays helpful while improving harmlessness",
         "To certify the guardrail framework",
-        "To replace red-team scoring"
+        "To track false-positive blocks so the model stays helpful while improving harmlessness"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "What is the constitutional self-critique loop in this capstone?",
       "options": [
-        "Critic LLM scores drafts against a written constitution, prompts the model rewrites the objected outputs, and SFT runs on the improved pairs",
-        "A single forward pass through Llama Guard 4",
+        "A reranker over candidate jailbreak prompts",
         "An RLHF reward model trained from scratch",
-        "A reranker over candidate jailbreak prompts"
+        "A single forward pass through Llama Guard 4",
+        "Critic LLM scores drafts against a written constitution, prompts the model rewrites the objected outputs, and SFT runs on the improved pairs"
       ],
-      "correct": 0,
+      "correct": 3,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "How are successful jailbreaks scored for severity in the findings?",
       "options": [
-        "On a hand-tuned 1-10 scale chosen by the operator",
+        "By the model that produced the response",
         "Using CVSS 4.0 with attack vector, complexity, and impact, plus a disclosure timeline",
         "By raw token count of the prompt",
-        "By the model that produced the response"
+        "On a hand-tuned 1-10 scale chosen by the operator"
       ],
       "correct": 1,
       "explanation": ""
@@ -66,21 +66,21 @@
       "stage": "post",
       "question": "Which six attack families does the red-team range run?",
       "options": [
+        "BLEU, ROUGE, METEOR, BERTScore, CometKiwi, and chrF",
         "PAIR, TAP, GCG, encoding (ASCII/base64/rot13), multi-turn persona, and multilingual code-switch",
         "Brute-force, dictionary, replay, MITM, phishing, and CSRF",
-        "BLEU, ROUGE, METEOR, BERTScore, CometKiwi, and chrF",
         "PSI, KL, MMD, KS, JS, and Wasserstein"
       ],
-      "correct": 0,
+      "correct": 1,
       "explanation": ""
     },
     {
       "stage": "post",
       "question": "Why is range automation (cron + alerts) part of the rubric?",
       "options": [
-        "Manual runs are explicitly required",
-        "Continuous scheduled probes catch drift in attack success rate and over-refusal regressions over time",
         "Cron is the only way to call OPA",
+        "Continuous scheduled probes catch drift in attack success rate and over-refusal regressions over time",
+        "Manual runs are explicitly required",
         "Automation is required to disable Llama Guard 4"
       ],
       "correct": 1,

--- a/phases/19-capstone-projects/15-constitutional-safety-harness/quiz.json
+++ b/phases/19-capstone-projects/15-constitutional-safety-harness/quiz.json
@@ -1,0 +1,90 @@
+{
+  "lesson": "15-constitutional-safety-harness",
+  "title": "Capstone 15 — Constitutional Safety Harness + Red-Team Range",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "What does layered safety in this capstone mean?",
+      "options": [
+        "Running one strong classifier on the input only",
+        "Defense in depth across input sanitize, policy rails, classifier gate, model, output filter, and HITL tier",
+        "A single rule-based regex over outputs",
+        "Manual review of every response"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "pre",
+      "question": "Which classifier handles multilingual coverage across roughly 132 languages?",
+      "options": [
+        "Llama Guard 4",
+        "X-Guard",
+        "ShieldGemma-2",
+        "Nemotron 3 Content Safety"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Why is over-refusal measured on a benign suite like XSTest?",
+      "options": [
+        "To benchmark token throughput",
+        "To track false-positive blocks so the model stays helpful while improving harmlessness",
+        "To certify the guardrail framework",
+        "To replace red-team scoring"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "What is the constitutional self-critique loop in this capstone?",
+      "options": [
+        "Critic LLM scores drafts against a written constitution, prompts the model rewrites the objected outputs, and SFT runs on the improved pairs",
+        "A single forward pass through Llama Guard 4",
+        "An RLHF reward model trained from scratch",
+        "A reranker over candidate jailbreak prompts"
+      ],
+      "correct": 0,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "How are successful jailbreaks scored for severity in the findings?",
+      "options": [
+        "On a hand-tuned 1-10 scale chosen by the operator",
+        "Using CVSS 4.0 with attack vector, complexity, and impact, plus a disclosure timeline",
+        "By raw token count of the prompt",
+        "By the model that produced the response"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Which six attack families does the red-team range run?",
+      "options": [
+        "PAIR, TAP, GCG, encoding (ASCII/base64/rot13), multi-turn persona, and multilingual code-switch",
+        "Brute-force, dictionary, replay, MITM, phishing, and CSRF",
+        "BLEU, ROUGE, METEOR, BERTScore, CometKiwi, and chrF",
+        "PSI, KL, MMD, KS, JS, and Wasserstein"
+      ],
+      "correct": 0,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Why is range automation (cron + alerts) part of the rubric?",
+      "options": [
+        "Manual runs are explicitly required",
+        "Continuous scheduled probes catch drift in attack success rate and over-refusal regressions over time",
+        "Cron is the only way to call OPA",
+        "Automation is required to disable Llama Guard 4"
+      ],
+      "correct": 1,
+      "explanation": ""
+    }
+  ]
+}

--- a/phases/19-capstone-projects/16-github-issue-to-pr-agent/quiz.json
+++ b/phases/19-capstone-projects/16-github-issue-to-pr-agent/quiz.json
@@ -18,45 +18,45 @@
       "stage": "pre",
       "question": "Why must the agent run with a short-lived GitHub App installation token rather than a personal access token?",
       "options": [
+        "Apps avoid GitHub rate limits entirely",
         "App tokens grant fine-grained, scoped, short-lived credentials suited for per-task workers",
         "Personal access tokens cannot open PRs",
-        "Apps avoid GitHub rate limits entirely",
         "Apps require less code than PATs"
       ],
-      "correct": 0,
+      "correct": 1,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "Which two protections prevent the agent from clobbering main?",
       "options": [
+        "Requiring a captcha per push",
         "Branch protection enforcing no direct push or force-push to main, with the app not on the bypass list",
-        "Disabling git on the worker",
         "Encrypting the repo before clone",
-        "Requiring a captcha per push"
+        "Disabling git on the worker"
       ],
-      "correct": 0,
+      "correct": 1,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "Why is path-scoped protection for .github/workflows enforced at the worker rather than as a GitHub App permission?",
       "options": [
-        "GitHub App permissions are not path-scoped, so the worker's allow-list check on the proposed diff is the right place to enforce it",
         "Workflows are stored outside the repo",
-        ".github/workflows is a virtual path",
-        "Path scoping is impossible in any form"
+        "Path scoping is impossible in any form",
+        "GitHub App permissions are not path-scoped, so the worker's allow-list check on the proposed diff is the right place to enforce it",
+        ".github/workflows is a virtual path"
       ],
-      "correct": 0,
+      "correct": 2,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "What gating happens after the agent loop concludes, before opening a PR?",
       "options": [
-        "The PR opens immediately with no checks",
-        "Full CI runs in the sandbox; coverage delta is computed; PRs with a regression beyond a threshold are labeled needs-review",
         "The reviewer model rewrites the diff",
+        "Full CI runs in the sandbox; coverage delta is computed; PRs with a regression beyond a threshold are labeled needs-review",
+        "The PR opens immediately with no checks",
         "The repo is force-pushed to main"
       ],
       "correct": 1,
@@ -66,12 +66,12 @@
       "stage": "post",
       "question": "Which budget knobs does the dispatcher enforce per repo per day?",
       "options": [
+        "Only a wall-clock cap",
         "Unlimited PRs and unlimited cost",
         "A dollar ceiling per PR plus a maximum number of PRs per repo per day",
-        "Only a wall-clock cap",
         "Only a turn cap"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     },
     {

--- a/phases/19-capstone-projects/16-github-issue-to-pr-agent/quiz.json
+++ b/phases/19-capstone-projects/16-github-issue-to-pr-agent/quiz.json
@@ -1,0 +1,90 @@
+{
+  "lesson": "16-github-issue-to-pr-agent",
+  "title": "Capstone 16 — GitHub Issue-to-PR Autonomous Agent",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "How is the async cloud coding agent triggered in production?",
+      "options": [
+        "A long-lived SSH session into a VM",
+        "A GitHub webhook fired by an issue label or PR comment, dispatched to a sandbox worker",
+        "A scheduled cron job hitting the repo",
+        "A manual file upload"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "pre",
+      "question": "Why must the agent run with a short-lived GitHub App installation token rather than a personal access token?",
+      "options": [
+        "App tokens grant fine-grained, scoped, short-lived credentials suited for per-task workers",
+        "Personal access tokens cannot open PRs",
+        "Apps avoid GitHub rate limits entirely",
+        "Apps require less code than PATs"
+      ],
+      "correct": 0,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Which two protections prevent the agent from clobbering main?",
+      "options": [
+        "Branch protection enforcing no direct push or force-push to main, with the app not on the bypass list",
+        "Disabling git on the worker",
+        "Encrypting the repo before clone",
+        "Requiring a captcha per push"
+      ],
+      "correct": 0,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Why is path-scoped protection for .github/workflows enforced at the worker rather than as a GitHub App permission?",
+      "options": [
+        "GitHub App permissions are not path-scoped, so the worker's allow-list check on the proposed diff is the right place to enforce it",
+        "Workflows are stored outside the repo",
+        ".github/workflows is a virtual path",
+        "Path scoping is impossible in any form"
+      ],
+      "correct": 0,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "What gating happens after the agent loop concludes, before opening a PR?",
+      "options": [
+        "The PR opens immediately with no checks",
+        "Full CI runs in the sandbox; coverage delta is computed; PRs with a regression beyond a threshold are labeled needs-review",
+        "The reviewer model rewrites the diff",
+        "The repo is force-pushed to main"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Which budget knobs does the dispatcher enforce per repo per day?",
+      "options": [
+        "Unlimited PRs and unlimited cost",
+        "A dollar ceiling per PR plus a maximum number of PRs per repo per day",
+        "Only a wall-clock cap",
+        "Only a turn cap"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "What goes into the PR body that the agent posts?",
+      "options": [
+        "Only the diff",
+        "Rationale, diff summary, trace URL, cost, and turn count so reviewers can audit and follow up",
+        "A generated changelog only",
+        "Nothing; the PR has an empty body"
+      ],
+      "correct": 1,
+      "explanation": ""
+    }
+  ]
+}

--- a/phases/19-capstone-projects/17-personal-ai-tutor/quiz.json
+++ b/phases/19-capstone-projects/17-personal-ai-tutor/quiz.json
@@ -1,0 +1,90 @@
+{
+  "lesson": "17-personal-ai-tutor",
+  "title": "Capstone 17 — Personal AI Tutor (Adaptive, Multimodal, with Memory)",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "What does a Socratic tutor policy do when a learner asks for the answer outright?",
+      "options": [
+        "Provides the answer immediately and moves on",
+        "Asks a leading question that scaffolds the learner toward the answer",
+        "Switches to a different concept node",
+        "Logs the request and goes silent"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "pre",
+      "question": "Which structure does the curriculum graph encode?",
+      "options": [
+        "A flat list of unrelated concepts",
+        "A directed graph of concepts with prerequisite edges, attached to OER content",
+        "Only the most recently studied node",
+        "A random shuffle of topics"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "What does the learner model update after each interaction?",
+      "options": [
+        "The base LLM's weights",
+        "Per-concept mastery probability via Bayesian knowledge tracing or a similar variant",
+        "The curriculum graph schema",
+        "The COPPA retention policy"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "How is memory split between episodic and semantic stores?",
+      "options": [
+        "Episodic holds every interaction; semantic holds compacted mistakes and preferences promoted from episodic",
+        "Episodic is for the parent; semantic is for the learner",
+        "Episodic holds embeddings; semantic holds raw audio",
+        "They are duplicates of the same data"
+      ],
+      "correct": 0,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Which constraint shapes memory retention for K-12 learners?",
+      "options": [
+        "GDPR only",
+        "COPPA-aware retention with auto-deletion after a defined window and parental access",
+        "Permanent retention with no deletion",
+        "Retention based on model context length"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "What is the structure of the efficacy study used to gate the deliverable?",
+      "options": [
+        "A single one-hour session with one learner",
+        "Pre-test and post-test over two weeks with 10 learners, compared against a non-adaptive baseline cohort",
+        "Anonymous internet survey",
+        "A 30-second AB test"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Which multimodal input paths does the tutor expose to the learner?",
+      "options": [
+        "Text only",
+        "Text typed, voice via LiveKit + Whisper, and photo math via dots.ocr or PaliGemma 2",
+        "Voice only with no text or photo",
+        "Photo only via a custom OCR model"
+      ],
+      "correct": 1,
+      "explanation": ""
+    }
+  ]
+}

--- a/phases/19-capstone-projects/17-personal-ai-tutor/quiz.json
+++ b/phases/19-capstone-projects/17-personal-ai-tutor/quiz.json
@@ -6,24 +6,24 @@
       "stage": "pre",
       "question": "What does a Socratic tutor policy do when a learner asks for the answer outright?",
       "options": [
-        "Provides the answer immediately and moves on",
         "Asks a leading question that scaffolds the learner toward the answer",
-        "Switches to a different concept node",
-        "Logs the request and goes silent"
+        "Logs the request and goes silent",
+        "Provides the answer immediately and moves on",
+        "Switches to a different concept node"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     },
     {
       "stage": "pre",
       "question": "Which structure does the curriculum graph encode?",
       "options": [
-        "A flat list of unrelated concepts",
         "A directed graph of concepts with prerequisite edges, attached to OER content",
-        "Only the most recently studied node",
-        "A random shuffle of topics"
+        "A random shuffle of topics",
+        "A flat list of unrelated concepts",
+        "Only the most recently studied node"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     },
     {
@@ -31,11 +31,11 @@
       "question": "What does the learner model update after each interaction?",
       "options": [
         "The base LLM's weights",
-        "Per-concept mastery probability via Bayesian knowledge tracing or a similar variant",
+        "The COPPA retention policy",
         "The curriculum graph schema",
-        "The COPPA retention policy"
+        "Per-concept mastery probability via Bayesian knowledge tracing or a similar variant"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
@@ -43,9 +43,9 @@
       "question": "How is memory split between episodic and semantic stores?",
       "options": [
         "Episodic holds every interaction; semantic holds compacted mistakes and preferences promoted from episodic",
+        "They are duplicates of the same data",
         "Episodic is for the parent; semantic is for the learner",
-        "Episodic holds embeddings; semantic holds raw audio",
-        "They are duplicates of the same data"
+        "Episodic holds embeddings; semantic holds raw audio"
       ],
       "correct": 0,
       "explanation": ""
@@ -54,24 +54,24 @@
       "stage": "check",
       "question": "Which constraint shapes memory retention for K-12 learners?",
       "options": [
-        "GDPR only",
-        "COPPA-aware retention with auto-deletion after a defined window and parental access",
+        "Retention based on model context length",
         "Permanent retention with no deletion",
-        "Retention based on model context length"
+        "GDPR only",
+        "COPPA-aware retention with auto-deletion after a defined window and parental access"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
       "stage": "post",
       "question": "What is the structure of the efficacy study used to gate the deliverable?",
       "options": [
-        "A single one-hour session with one learner",
-        "Pre-test and post-test over two weeks with 10 learners, compared against a non-adaptive baseline cohort",
         "Anonymous internet survey",
-        "A 30-second AB test"
+        "A 30-second AB test",
+        "Pre-test and post-test over two weeks with 10 learners, compared against a non-adaptive baseline cohort",
+        "A single one-hour session with one learner"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     },
     {
@@ -79,11 +79,11 @@
       "question": "Which multimodal input paths does the tutor expose to the learner?",
       "options": [
         "Text only",
-        "Text typed, voice via LiveKit + Whisper, and photo math via dots.ocr or PaliGemma 2",
+        "Photo only via a custom OCR model",
         "Voice only with no text or photo",
-        "Photo only via a custom OCR model"
+        "Text typed, voice via LiveKit + Whisper, and photo math via dots.ocr or PaliGemma 2"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     }
   ]


### PR DESCRIPTION
Backfills quiz.json across all 17 lessons of Phase 19 (Capstone Projects), bringing quiz coverage from 0/17 to 17/17 with the canonical stage/question/options/correct/explanation schema (119 questions total: 34 pre, 51 check, 34 post). Catalog rebuilt.