### PR TITLE
feat(phase-05): quiz backfill, 0/29 -> 29/29

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -2636,7 +2636,7 @@
           "path": "phases/05-nlp-foundations-to-advanced/01-text-processing",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -2659,7 +2659,7 @@
           "path": "phases/05-nlp-foundations-to-advanced/02-bag-of-words-tfidf",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -2682,7 +2682,7 @@
           "path": "phases/05-nlp-foundations-to-advanced/03-word-embeddings-word2vec",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -2709,7 +2709,7 @@
           "path": "phases/05-nlp-foundations-to-advanced/04-glove-fasttext-subword",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -2736,7 +2736,7 @@
           "path": "phases/05-nlp-foundations-to-advanced/05-sentiment-analysis",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -2759,7 +2759,7 @@
           "path": "phases/05-nlp-foundations-to-advanced/06-named-entity-recognition",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -2786,7 +2786,7 @@
           "path": "phases/05-nlp-foundations-to-advanced/07-pos-tagging-parsing",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -2813,7 +2813,7 @@
           "path": "phases/05-nlp-foundations-to-advanced/08-cnns-rnns-for-text",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -2836,7 +2836,7 @@
           "path": "phases/05-nlp-foundations-to-advanced/09-sequence-to-sequence",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -2859,7 +2859,7 @@
           "path": "phases/05-nlp-foundations-to-advanced/10-attention-mechanism",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -2882,7 +2882,7 @@
           "path": "phases/05-nlp-foundations-to-advanced/11-machine-translation",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -2909,7 +2909,7 @@
           "path": "phases/05-nlp-foundations-to-advanced/12-text-summarization",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -2935,7 +2935,7 @@
           "path": "phases/05-nlp-foundations-to-advanced/13-question-answering",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -2962,7 +2962,7 @@
           "path": "phases/05-nlp-foundations-to-advanced/14-information-retrieval-search",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -2990,7 +2990,7 @@
           "path": "phases/05-nlp-foundations-to-advanced/15-topic-modeling",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -3016,7 +3016,7 @@
           "path": "phases/05-nlp-foundations-to-advanced/16-text-generation-pre-transformer",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -3039,7 +3039,7 @@
           "path": "phases/05-nlp-foundations-to-advanced/17-chatbots-rule-to-neural",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -3066,7 +3066,7 @@
           "path": "phases/05-nlp-foundations-to-advanced/18-multilingual-nlp",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -3093,7 +3093,7 @@
           "path": "phases/05-nlp-foundations-to-advanced/19-subword-tokenization",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -3119,7 +3119,7 @@
           "path": "phases/05-nlp-foundations-to-advanced/20-structured-outputs-constrained-decoding",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -3146,7 +3146,7 @@
           "path": "phases/05-nlp-foundations-to-advanced/21-nli-textual-entailment",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -3173,7 +3173,7 @@
           "path": "phases/05-nlp-foundations-to-advanced/22-embedding-models-deep-dive",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -3200,7 +3200,7 @@
           "path": "phases/05-nlp-foundations-to-advanced/23-chunking-strategies-rag",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -3227,7 +3227,7 @@
           "path": "phases/05-nlp-foundations-to-advanced/24-coreference-resolution",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -3254,7 +3254,7 @@
           "path": "phases/05-nlp-foundations-to-advanced/25-entity-linking",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -3281,7 +3281,7 @@
           "path": "phases/05-nlp-foundations-to-advanced/26-relation-extraction-kg",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -3308,7 +3308,7 @@
           "path": "phases/05-nlp-foundations-to-advanced/27-llm-evaluation-frameworks",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -3335,7 +3335,7 @@
           "path": "phases/05-nlp-foundations-to-advanced/28-long-context-evaluation",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -3362,7 +3362,7 @@
           "path": "phases/05-nlp-foundations-to-advanced/29-dialogue-state-tracking",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"

--- a/phases/05-nlp-foundations-to-advanced/01-text-processing/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/01-text-processing/quiz.json
@@ -1,0 +1,102 @@
+{
+  "lesson": "01-text-processing",
+  "title": "Text Processing — Tokenization, Stemming, Lemmatization",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "Why does a language model need preprocessing before training?",
+      "options": [
+        "Models read strings directly",
+        "Models consume discrete integer tokens, not raw text",
+        "Preprocessing improves GPU utilization",
+        "Preprocessing is required only for languages without whitespace"
+      ],
+      "correct": 1,
+      "explanation": "Models operate on integer token IDs; preprocessing bridges continuous language to discrete inputs."
+    },
+    {
+      "stage": "pre",
+      "question": "Which preprocessing operation is rule-based suffix stripping?",
+      "options": [
+        "Tokenization",
+        "Stemming",
+        "Lemmatization",
+        "POS tagging"
+      ],
+      "correct": 1,
+      "explanation": "Stemming chops suffixes with rules; it is fast but can be wrong."
+    },
+    {
+      "stage": "check",
+      "question": "What does the Porter stemmer step 1a return for the word 'ponies'?",
+      "options": [
+        "pony",
+        "ponie",
+        "poni",
+        "ponies"
+      ],
+      "correct": 2,
+      "explanation": "The 'ies' rule replaces the suffix with 'i', producing 'poni'; step 1b in real Porter cleans it up."
+    },
+    {
+      "stage": "check",
+      "question": "Why does lemmatization usually need a POS tag?",
+      "options": [
+        "Speed",
+        "Grammatical context disambiguates forms like 'better' (ADJ) versus 'better' (VERB)",
+        "Unicode handling",
+        "To reduce memory usage"
+      ],
+      "correct": 1,
+      "explanation": "Lemmas depend on grammatical role; without the tag the lookup is ambiguous."
+    },
+    {
+      "stage": "check",
+      "question": "When translating NLTK Penn Treebank POS tags to WordNet tags, what does a tag starting with 'V' map to?",
+      "options": [
+        "'n' (noun)",
+        "'v' (verb)",
+        "'a' (adjective)",
+        "'r' (adverb)"
+      ],
+      "correct": 1,
+      "explanation": "Verb-prefixed Penn Treebank tags map to WordNet 'v'."
+    },
+    {
+      "stage": "post",
+      "question": "What is 'training/inference mismatch' in NLP preprocessing?",
+      "options": [
+        "A GPU memory issue",
+        "Training and serving apply different preprocessing, so the model sees an unfamiliar distribution at inference",
+        "Different batch sizes between train and test",
+        "Mixing tokenizer libraries within a notebook"
+      ],
+      "correct": 1,
+      "explanation": "Different preprocessing at training vs inference is the most common production NLP failure."
+    },
+    {
+      "stage": "post",
+      "question": "Which tool would you reach for in a transformer pipeline instead of classical preprocessing?",
+      "options": [
+        "NLTK word_tokenize",
+        "spaCy en_core_web_sm",
+        "The model's own tokenizer (e.g. via tokenizers / transformers)",
+        "A regex tokenizer"
+      ],
+      "correct": 2,
+      "explanation": "Transformer models ship a paired tokenizer; classical preprocessing is bypassed."
+    },
+    {
+      "stage": "post",
+      "question": "Why pin NLTK and spaCy versions in requirements?",
+      "options": [
+        "Newer versions are slower",
+        "Tokenizer and lemmatizer behavior shifts between minor releases, silently changing training distribution",
+        "License compatibility",
+        "Older versions support more languages"
+      ],
+      "correct": 1,
+      "explanation": "Library upgrades can change tokenization output, drifting from the training distribution."
+    }
+  ]
+}

--- a/phases/05-nlp-foundations-to-advanced/01-text-processing/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/01-text-processing/quiz.json
@@ -6,9 +6,9 @@
       "stage": "pre",
       "question": "Why does a language model need preprocessing before training?",
       "options": [
-        "Models read strings directly",
-        "Models consume discrete integer tokens, not raw text",
         "Preprocessing improves GPU utilization",
+        "Models consume discrete integer tokens, not raw text",
+        "Models read strings directly",
         "Preprocessing is required only for languages without whitespace"
       ],
       "correct": 1,
@@ -18,36 +18,36 @@
       "stage": "pre",
       "question": "Which preprocessing operation is rule-based suffix stripping?",
       "options": [
-        "Tokenization",
         "Stemming",
+        "POS tagging",
         "Lemmatization",
-        "POS tagging"
+        "Tokenization"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Stemming chops suffixes with rules; it is fast but can be wrong."
     },
     {
       "stage": "check",
       "question": "What does the Porter stemmer step 1a return for the word 'ponies'?",
       "options": [
-        "pony",
+        "ponies",
         "ponie",
-        "poni",
-        "ponies"
+        "pony",
+        "poni"
       ],
-      "correct": 2,
+      "correct": 3,
       "explanation": "The 'ies' rule replaces the suffix with 'i', producing 'poni'; step 1b in real Porter cleans it up."
     },
     {
       "stage": "check",
       "question": "Why does lemmatization usually need a POS tag?",
       "options": [
+        "Unicode handling",
         "Speed",
         "Grammatical context disambiguates forms like 'better' (ADJ) versus 'better' (VERB)",
-        "Unicode handling",
         "To reduce memory usage"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Lemmas depend on grammatical role; without the tag the lookup is ambiguous."
     },
     {
@@ -56,8 +56,8 @@
       "options": [
         "'n' (noun)",
         "'v' (verb)",
-        "'a' (adjective)",
-        "'r' (adverb)"
+        "'r' (adverb)",
+        "'a' (adjective)"
       ],
       "correct": 1,
       "explanation": "Verb-prefixed Penn Treebank tags map to WordNet 'v'."
@@ -66,9 +66,9 @@
       "stage": "post",
       "question": "What is 'training/inference mismatch' in NLP preprocessing?",
       "options": [
-        "A GPU memory issue",
-        "Training and serving apply different preprocessing, so the model sees an unfamiliar distribution at inference",
         "Different batch sizes between train and test",
+        "Training and serving apply different preprocessing, so the model sees an unfamiliar distribution at inference",
+        "A GPU memory issue",
         "Mixing tokenizer libraries within a notebook"
       ],
       "correct": 1,
@@ -79,21 +79,21 @@
       "question": "Which tool would you reach for in a transformer pipeline instead of classical preprocessing?",
       "options": [
         "NLTK word_tokenize",
-        "spaCy en_core_web_sm",
         "The model's own tokenizer (e.g. via tokenizers / transformers)",
-        "A regex tokenizer"
+        "A regex tokenizer",
+        "spaCy en_core_web_sm"
       ],
-      "correct": 2,
+      "correct": 1,
       "explanation": "Transformer models ship a paired tokenizer; classical preprocessing is bypassed."
     },
     {
       "stage": "post",
       "question": "Why pin NLTK and spaCy versions in requirements?",
       "options": [
-        "Newer versions are slower",
-        "Tokenizer and lemmatizer behavior shifts between minor releases, silently changing training distribution",
         "License compatibility",
-        "Older versions support more languages"
+        "Tokenizer and lemmatizer behavior shifts between minor releases, silently changing training distribution",
+        "Older versions support more languages",
+        "Newer versions are slower"
       ],
       "correct": 1,
       "explanation": "Library upgrades can change tokenization output, drifting from the training distribution."

--- a/phases/05-nlp-foundations-to-advanced/02-bag-of-words-tfidf/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/02-bag-of-words-tfidf/quiz.json
@@ -1,0 +1,102 @@
+{
+  "lesson": "02-bag-of-words-tfidf",
+  "title": "Bag of Words, TF-IDF, and Text Representation",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "What does Bag of Words throw away?",
+      "options": [
+        "Vocabulary size",
+        "Token order",
+        "Punctuation",
+        "Document length"
+      ],
+      "correct": 1,
+      "explanation": "BoW counts tokens per document but discards their sequence."
+    },
+    {
+      "stage": "pre",
+      "question": "Why scale TF by an IDF factor?",
+      "options": [
+        "To accelerate training",
+        "Words that appear in every document carry little discriminative signal and should be downweighted",
+        "To normalize document length",
+        "To remove punctuation"
+      ],
+      "correct": 1,
+      "explanation": "IDF penalizes ubiquitous words and boosts rare ones."
+    },
+    {
+      "stage": "check",
+      "question": "In the smoothed IDF formula log((N+1)/(df+1)) + 1, what does the trailing +1 ensure?",
+      "options": [
+        "Numerical stability for large N",
+        "A word that appears in every document still has IDF 1 instead of 0",
+        "Compatibility with raw counts",
+        "Faster computation"
+      ],
+      "correct": 1,
+      "explanation": "The +1 keeps ubiquitous words at IDF=1 so they are not zeroed out, matching scikit-learn's default."
+    },
+    {
+      "stage": "check",
+      "question": "Why L2-normalize TF-IDF rows before cosine similarity?",
+      "options": [
+        "To compress the vocabulary",
+        "Longer documents would otherwise dominate similarity scores; normalization puts all docs on the unit hypersphere",
+        "To remove zero entries",
+        "To convert sparse vectors to dense"
+      ],
+      "correct": 1,
+      "explanation": "L2 normalization removes document-length bias and turns cosine similarity into a dot product."
+    },
+    {
+      "stage": "check",
+      "question": "Which TfidfVectorizer setting is risky to enable for sentiment analysis?",
+      "options": [
+        "sublinear_tf=True",
+        "ngram_range=(1, 2)",
+        "stop_words='english'",
+        "min_df=2"
+      ],
+      "correct": 2,
+      "explanation": "English stopword lists drop negations like 'not', which carry sentiment signal."
+    },
+    {
+      "stage": "post",
+      "question": "Which task does TF-IDF still win in 2026?",
+      "options": [
+        "Open-ended dialogue",
+        "Spam detection, log anomaly flagging, and low-latency narrow classification",
+        "Machine translation",
+        "Image captioning"
+      ],
+      "correct": 1,
+      "explanation": "TF-IDF beats embeddings when word presence is the signal and explainability or speed matter."
+    },
+    {
+      "stage": "post",
+      "question": "Why does TF-IDF fail on the pair 'The movie was not good' vs 'The movie was excellent'?",
+      "options": [
+        "TF-IDF cannot handle stopwords",
+        "Both documents share most tokens; bag-of-words has no notion of negation or word order",
+        "TF-IDF requires bigrams to work",
+        "Embeddings overlap is too high"
+      ],
+      "correct": 1,
+      "explanation": "Without word order or syntactic context, BoW cannot model that 'not' flips the sentiment of 'good'."
+    },
+    {
+      "stage": "post",
+      "question": "What is the TF-IDF weighted embedding hybrid?",
+      "options": [
+        "Concatenating BoW and dense embeddings",
+        "Using TF-IDF weights as a pooling weight over per-token embeddings before averaging",
+        "Training BERT on TF-IDF features",
+        "Running PCA on TF-IDF then re-embedding"
+      ],
+      "correct": 1,
+      "explanation": "The hybrid weights each token's embedding by its TF-IDF score and averages, blending semantic capacity with rare-word emphasis."
+    }
+  ]
+}

--- a/phases/05-nlp-foundations-to-advanced/02-bag-of-words-tfidf/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/02-bag-of-words-tfidf/quiz.json
@@ -6,34 +6,34 @@
       "stage": "pre",
       "question": "What does Bag of Words throw away?",
       "options": [
-        "Vocabulary size",
         "Token order",
-        "Punctuation",
-        "Document length"
+        "Vocabulary size",
+        "Document length",
+        "Punctuation"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "BoW counts tokens per document but discards their sequence."
     },
     {
       "stage": "pre",
       "question": "Why scale TF by an IDF factor?",
       "options": [
-        "To accelerate training",
         "Words that appear in every document carry little discriminative signal and should be downweighted",
         "To normalize document length",
+        "To accelerate training",
         "To remove punctuation"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "IDF penalizes ubiquitous words and boosts rare ones."
     },
     {
       "stage": "check",
       "question": "In the smoothed IDF formula log((N+1)/(df+1)) + 1, what does the trailing +1 ensure?",
       "options": [
-        "Numerical stability for large N",
+        "Faster computation",
         "A word that appears in every document still has IDF 1 instead of 0",
         "Compatibility with raw counts",
-        "Faster computation"
+        "Numerical stability for large N"
       ],
       "correct": 1,
       "explanation": "The +1 keeps ubiquitous words at IDF=1 so they are not zeroed out, matching scikit-learn's default."
@@ -42,24 +42,24 @@
       "stage": "check",
       "question": "Why L2-normalize TF-IDF rows before cosine similarity?",
       "options": [
+        "To convert sparse vectors to dense",
         "To compress the vocabulary",
-        "Longer documents would otherwise dominate similarity scores; normalization puts all docs on the unit hypersphere",
         "To remove zero entries",
-        "To convert sparse vectors to dense"
+        "Longer documents would otherwise dominate similarity scores; normalization puts all docs on the unit hypersphere"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "L2 normalization removes document-length bias and turns cosine similarity into a dot product."
     },
     {
       "stage": "check",
       "question": "Which TfidfVectorizer setting is risky to enable for sentiment analysis?",
       "options": [
-        "sublinear_tf=True",
-        "ngram_range=(1, 2)",
         "stop_words='english'",
-        "min_df=2"
+        "ngram_range=(1, 2)",
+        "min_df=2",
+        "sublinear_tf=True"
       ],
-      "correct": 2,
+      "correct": 0,
       "explanation": "English stopword lists drop negations like 'not', which carry sentiment signal."
     },
     {
@@ -67,11 +67,11 @@
       "question": "Which task does TF-IDF still win in 2026?",
       "options": [
         "Open-ended dialogue",
-        "Spam detection, log anomaly flagging, and low-latency narrow classification",
         "Machine translation",
+        "Spam detection, log anomaly flagging, and low-latency narrow classification",
         "Image captioning"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "TF-IDF beats embeddings when word presence is the signal and explainability or speed matter."
     },
     {
@@ -79,23 +79,23 @@
       "question": "Why does TF-IDF fail on the pair 'The movie was not good' vs 'The movie was excellent'?",
       "options": [
         "TF-IDF cannot handle stopwords",
-        "Both documents share most tokens; bag-of-words has no notion of negation or word order",
         "TF-IDF requires bigrams to work",
-        "Embeddings overlap is too high"
+        "Embeddings overlap is too high",
+        "Both documents share most tokens; bag-of-words has no notion of negation or word order"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "Without word order or syntactic context, BoW cannot model that 'not' flips the sentiment of 'good'."
     },
     {
       "stage": "post",
       "question": "What is the TF-IDF weighted embedding hybrid?",
       "options": [
-        "Concatenating BoW and dense embeddings",
         "Using TF-IDF weights as a pooling weight over per-token embeddings before averaging",
-        "Training BERT on TF-IDF features",
-        "Running PCA on TF-IDF then re-embedding"
+        "Running PCA on TF-IDF then re-embedding",
+        "Concatenating BoW and dense embeddings",
+        "Training BERT on TF-IDF features"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "The hybrid weights each token's embedding by its TF-IDF score and averages, blending semantic capacity with rare-word emphasis."
     }
   ]

--- a/phases/05-nlp-foundations-to-advanced/03-word-embeddings-word2vec/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/03-word-embeddings-word2vec/quiz.json
@@ -1,0 +1,102 @@
+{
+  "lesson": "03-word-embeddings-word2vec",
+  "title": "Word Embeddings — Word2Vec from Scratch",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "What is the distributional hypothesis?",
+      "options": [
+        "Words are uniformly distributed across documents",
+        "You shall know a word by the company it keeps",
+        "Frequent words carry the most meaning",
+        "All words can be embedded in 300 dimensions"
+      ],
+      "correct": 1,
+      "explanation": "Firth's (1957) distributional hypothesis: similar contexts imply similar meanings."
+    },
+    {
+      "stage": "pre",
+      "question": "Why is plain softmax over the vocabulary impractical in Word2Vec?",
+      "options": [
+        "Softmax has no gradient",
+        "Computing softmax over 100k+ vocabulary terms is prohibitively expensive per training step",
+        "Softmax cannot model probabilities",
+        "It causes vanishing gradients"
+      ],
+      "correct": 1,
+      "explanation": "Full-vocabulary softmax is too expensive; negative sampling reformulates it as binary classification."
+    },
+    {
+      "stage": "check",
+      "question": "What is the difference between skip-gram and CBOW?",
+      "options": [
+        "Skip-gram predicts the center word from context; CBOW does the reverse",
+        "Skip-gram predicts context words from the center; CBOW predicts the center from context",
+        "Skip-gram uses bigrams; CBOW uses unigrams",
+        "Skip-gram trains a deep network; CBOW is shallow"
+      ],
+      "correct": 1,
+      "explanation": "Skip-gram: center -> context. CBOW: context -> center."
+    },
+    {
+      "stage": "check",
+      "question": "In negative sampling, what is the objective for the positive pair (center, context)?",
+      "options": [
+        "Minimize their dot product",
+        "Maximize sigmoid(W[center] dot W'[context]) so it is close to 1",
+        "Decorrelate the vectors",
+        "Force them to be orthogonal"
+      ],
+      "correct": 1,
+      "explanation": "Positive pairs train sigmoid near 1; sampled negatives train sigmoid near 0."
+    },
+    {
+      "stage": "check",
+      "question": "After training Word2Vec, which weight matrix becomes the word embeddings?",
+      "options": [
+        "The hidden-to-output W' matrix",
+        "The input-to-hidden W matrix (center-word table)",
+        "Both, multiplied together",
+        "A separate post-training projection"
+      ],
+      "correct": 1,
+      "explanation": "The center-word table W is the standard embedding output; W' is often discarded or averaged in."
+    },
+    {
+      "stage": "post",
+      "question": "Why does Word2Vec fail on polysemy (e.g. 'bank')?",
+      "options": [
+        "Negative sampling drops rare meanings",
+        "It assigns one static vector per word, so 'river bank' and 'financial bank' share the same vector",
+        "The window size is too small",
+        "It ignores rare words"
+      ],
+      "correct": 1,
+      "explanation": "Static embeddings cannot disambiguate senses; contextual embeddings (ELMo/BERT) fix this."
+    },
+    {
+      "stage": "post",
+      "question": "When would you still reach for Word2Vec over a transformer in 2026?",
+      "options": [
+        "When dialog quality matters",
+        "Lightweight, on-device, domain-specific retrieval where a single row lookup is the latency budget",
+        "When you need contextual disambiguation",
+        "When inputs are very long"
+      ],
+      "correct": 1,
+      "explanation": "Word2Vec wins on tiny latency budgets, on-device inference, or fast domain-specific training."
+    },
+    {
+      "stage": "post",
+      "question": "What enables the famous analogy 'king - man + woman ~ queen'?",
+      "options": [
+        "The model encodes royalty as a flag bit",
+        "Vector arithmetic captures linear directions like 'royal' that transfer across genders",
+        "Skip-gram trains on royal vocabularies",
+        "Cosine similarity is invariant to gender"
+      ],
+      "correct": 1,
+      "explanation": "Directions in embedding space encode relational features, so adding/subtracting moves systematically."
+    }
+  ]
+}

--- a/phases/05-nlp-foundations-to-advanced/03-word-embeddings-word2vec/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/03-word-embeddings-word2vec/quiz.json
@@ -6,33 +6,33 @@
       "stage": "pre",
       "question": "What is the distributional hypothesis?",
       "options": [
-        "Words are uniformly distributed across documents",
         "You shall know a word by the company it keeps",
-        "Frequent words carry the most meaning",
-        "All words can be embedded in 300 dimensions"
+        "Words are uniformly distributed across documents",
+        "All words can be embedded in 300 dimensions",
+        "Frequent words carry the most meaning"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Firth's (1957) distributional hypothesis: similar contexts imply similar meanings."
     },
     {
       "stage": "pre",
       "question": "Why is plain softmax over the vocabulary impractical in Word2Vec?",
       "options": [
-        "Softmax has no gradient",
         "Computing softmax over 100k+ vocabulary terms is prohibitively expensive per training step",
         "Softmax cannot model probabilities",
+        "Softmax has no gradient",
         "It causes vanishing gradients"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Full-vocabulary softmax is too expensive; negative sampling reformulates it as binary classification."
     },
     {
       "stage": "check",
       "question": "What is the difference between skip-gram and CBOW?",
       "options": [
-        "Skip-gram predicts the center word from context; CBOW does the reverse",
-        "Skip-gram predicts context words from the center; CBOW predicts the center from context",
         "Skip-gram uses bigrams; CBOW uses unigrams",
+        "Skip-gram predicts context words from the center; CBOW predicts the center from context",
+        "Skip-gram predicts the center word from context; CBOW does the reverse",
         "Skip-gram trains a deep network; CBOW is shallow"
       ],
       "correct": 1,
@@ -42,22 +42,22 @@
       "stage": "check",
       "question": "In negative sampling, what is the objective for the positive pair (center, context)?",
       "options": [
-        "Minimize their dot product",
         "Maximize sigmoid(W[center] dot W'[context]) so it is close to 1",
-        "Decorrelate the vectors",
-        "Force them to be orthogonal"
+        "Force them to be orthogonal",
+        "Minimize their dot product",
+        "Decorrelate the vectors"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Positive pairs train sigmoid near 1; sampled negatives train sigmoid near 0."
     },
     {
       "stage": "check",
       "question": "After training Word2Vec, which weight matrix becomes the word embeddings?",
       "options": [
-        "The hidden-to-output W' matrix",
+        "A separate post-training projection",
         "The input-to-hidden W matrix (center-word table)",
         "Both, multiplied together",
-        "A separate post-training projection"
+        "The hidden-to-output W' matrix"
       ],
       "correct": 1,
       "explanation": "The center-word table W is the standard embedding output; W' is often discarded or averaged in."
@@ -66,24 +66,24 @@
       "stage": "post",
       "question": "Why does Word2Vec fail on polysemy (e.g. 'bank')?",
       "options": [
-        "Negative sampling drops rare meanings",
-        "It assigns one static vector per word, so 'river bank' and 'financial bank' share the same vector",
         "The window size is too small",
-        "It ignores rare words"
+        "It ignores rare words",
+        "Negative sampling drops rare meanings",
+        "It assigns one static vector per word, so 'river bank' and 'financial bank' share the same vector"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "Static embeddings cannot disambiguate senses; contextual embeddings (ELMo/BERT) fix this."
     },
     {
       "stage": "post",
       "question": "When would you still reach for Word2Vec over a transformer in 2026?",
       "options": [
-        "When dialog quality matters",
         "Lightweight, on-device, domain-specific retrieval where a single row lookup is the latency budget",
         "When you need contextual disambiguation",
-        "When inputs are very long"
+        "When inputs are very long",
+        "When dialog quality matters"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Word2Vec wins on tiny latency budgets, on-device inference, or fast domain-specific training."
     },
     {
@@ -91,11 +91,11 @@
       "question": "What enables the famous analogy 'king - man + woman ~ queen'?",
       "options": [
         "The model encodes royalty as a flag bit",
-        "Vector arithmetic captures linear directions like 'royal' that transfer across genders",
         "Skip-gram trains on royal vocabularies",
+        "Vector arithmetic captures linear directions like 'royal' that transfer across genders",
         "Cosine similarity is invariant to gender"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Directions in embedding space encode relational features, so adding/subtracting moves systematically."
     }
   ]

--- a/phases/05-nlp-foundations-to-advanced/04-glove-fasttext-subword/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/04-glove-fasttext-subword/quiz.json
@@ -1,0 +1,102 @@
+{
+  "lesson": "04-glove-fasttext-subword",
+  "title": "GloVe, FastText, and Subword Embeddings",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "What did GloVe contribute over Word2Vec?",
+      "options": [
+        "A deeper neural network",
+        "Direct factorization of the word-word co-occurrence matrix with a weighted loss",
+        "Subword n-gram embeddings",
+        "Byte-level tokenization"
+      ],
+      "correct": 1,
+      "explanation": "GloVe factorizes the global co-occurrence matrix with a thoughtfully weighted log-loss."
+    },
+    {
+      "stage": "pre",
+      "question": "What problem does FastText solve that Word2Vec and GloVe do not?",
+      "options": [
+        "Polysemy disambiguation",
+        "Producing vectors for unseen words by composing character n-grams",
+        "Reducing training cost",
+        "Multilingual transfer"
+      ],
+      "correct": 1,
+      "explanation": "FastText composes a word vector from its subword n-grams, so OOV words still get a sensible vector."
+    },
+    {
+      "stage": "check",
+      "question": "In GloVe, what role does the weighting function f(x) = (x/x_max)^alpha play?",
+      "options": [
+        "Initializes weights randomly",
+        "Downweights extremely frequent pairs so they do not dominate the loss",
+        "Normalizes vectors to unit length",
+        "Selects negative samples"
+      ],
+      "correct": 1,
+      "explanation": "The weighting prevents ubiquitous co-occurrences like (the, and) from dominating training."
+    },
+    {
+      "stage": "check",
+      "question": "How does the BPE merge step pick which pair to combine next?",
+      "options": [
+        "The lexicographically first pair",
+        "The most frequent adjacent token pair across the corpus",
+        "The pair with highest IDF",
+        "A random pair"
+      ],
+      "correct": 1,
+      "explanation": "BPE iteratively merges the most frequent adjacent pair."
+    },
+    {
+      "stage": "check",
+      "question": "Why does GPT-2 use byte-level BPE?",
+      "options": [
+        "Bytes train faster than characters",
+        "The base vocabulary of 256 bytes covers any input, eliminating out-of-vocabulary entirely",
+        "Bytes preserve casing implicitly",
+        "Byte BPE skips merge training"
+      ],
+      "correct": 1,
+      "explanation": "Starting from 256 bytes means every UTF-8 string tokenizes; nothing is OOV."
+    },
+    {
+      "stage": "post",
+      "question": "Which tokenizer should you use when fine-tuning a pretrained transformer?",
+      "options": [
+        "Whichever has the largest vocabulary",
+        "The exact tokenizer the model shipped with; mismatch breaks the embeddings",
+        "Always SentencePiece",
+        "Always byte-level BPE"
+      ],
+      "correct": 1,
+      "explanation": "Tokenizer-model mismatch silently corrupts inputs; always pair the shipped tokenizer with its model."
+    },
+    {
+      "stage": "post",
+      "question": "When would you pick FastText over GloVe for pretrained word vectors?",
+      "options": [
+        "When the corpus is very small",
+        "For morphologically rich languages or domains with frequent neologisms and misspellings",
+        "When latency is tightest",
+        "When you need a 50d model"
+      ],
+      "correct": 1,
+      "explanation": "FastText's subword composition handles inflections, neologisms, and misspellings that GloVe cannot."
+    },
+    {
+      "stage": "post",
+      "question": "What unit forms the base of WordPiece, BPE, and SentencePiece vocabularies?",
+      "options": [
+        "Whole words",
+        "Subword pieces (characters, n-grams, or learned merges) below the word level",
+        "Sentences",
+        "Paragraphs"
+      ],
+      "correct": 1,
+      "explanation": "All three are subword tokenizers; they differ in how merges or pieces are learned, not in being subword."
+    }
+  ]
+}

--- a/phases/05-nlp-foundations-to-advanced/04-glove-fasttext-subword/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/04-glove-fasttext-subword/quiz.json
@@ -6,58 +6,58 @@
       "stage": "pre",
       "question": "What did GloVe contribute over Word2Vec?",
       "options": [
-        "A deeper neural network",
         "Direct factorization of the word-word co-occurrence matrix with a weighted loss",
-        "Subword n-gram embeddings",
-        "Byte-level tokenization"
+        "Byte-level tokenization",
+        "A deeper neural network",
+        "Subword n-gram embeddings"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "GloVe factorizes the global co-occurrence matrix with a thoughtfully weighted log-loss."
     },
     {
       "stage": "pre",
       "question": "What problem does FastText solve that Word2Vec and GloVe do not?",
       "options": [
-        "Polysemy disambiguation",
-        "Producing vectors for unseen words by composing character n-grams",
         "Reducing training cost",
-        "Multilingual transfer"
+        "Multilingual transfer",
+        "Producing vectors for unseen words by composing character n-grams",
+        "Polysemy disambiguation"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "FastText composes a word vector from its subword n-grams, so OOV words still get a sensible vector."
     },
     {
       "stage": "check",
       "question": "In GloVe, what role does the weighting function f(x) = (x/x_max)^alpha play?",
       "options": [
-        "Initializes weights randomly",
         "Downweights extremely frequent pairs so they do not dominate the loss",
-        "Normalizes vectors to unit length",
-        "Selects negative samples"
+        "Selects negative samples",
+        "Initializes weights randomly",
+        "Normalizes vectors to unit length"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "The weighting prevents ubiquitous co-occurrences like (the, and) from dominating training."
     },
     {
       "stage": "check",
       "question": "How does the BPE merge step pick which pair to combine next?",
       "options": [
+        "A random pair",
         "The lexicographically first pair",
         "The most frequent adjacent token pair across the corpus",
-        "The pair with highest IDF",
-        "A random pair"
+        "The pair with highest IDF"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "BPE iteratively merges the most frequent adjacent pair."
     },
     {
       "stage": "check",
       "question": "Why does GPT-2 use byte-level BPE?",
       "options": [
-        "Bytes train faster than characters",
+        "Byte BPE skips merge training",
         "The base vocabulary of 256 bytes covers any input, eliminating out-of-vocabulary entirely",
-        "Bytes preserve casing implicitly",
-        "Byte BPE skips merge training"
+        "Bytes train faster than characters",
+        "Bytes preserve casing implicitly"
       ],
       "correct": 1,
       "explanation": "Starting from 256 bytes means every UTF-8 string tokenizes; nothing is OOV."
@@ -66,9 +66,9 @@
       "stage": "post",
       "question": "Which tokenizer should you use when fine-tuning a pretrained transformer?",
       "options": [
-        "Whichever has the largest vocabulary",
-        "The exact tokenizer the model shipped with; mismatch breaks the embeddings",
         "Always SentencePiece",
+        "The exact tokenizer the model shipped with; mismatch breaks the embeddings",
+        "Whichever has the largest vocabulary",
         "Always byte-level BPE"
       ],
       "correct": 1,
@@ -78,10 +78,10 @@
       "stage": "post",
       "question": "When would you pick FastText over GloVe for pretrained word vectors?",
       "options": [
-        "When the corpus is very small",
+        "When you need a 50d model",
         "For morphologically rich languages or domains with frequent neologisms and misspellings",
         "When latency is tightest",
-        "When you need a 50d model"
+        "When the corpus is very small"
       ],
       "correct": 1,
       "explanation": "FastText's subword composition handles inflections, neologisms, and misspellings that GloVe cannot."
@@ -90,12 +90,12 @@
       "stage": "post",
       "question": "What unit forms the base of WordPiece, BPE, and SentencePiece vocabularies?",
       "options": [
-        "Whole words",
-        "Subword pieces (characters, n-grams, or learned merges) below the word level",
         "Sentences",
-        "Paragraphs"
+        "Whole words",
+        "Paragraphs",
+        "Subword pieces (characters, n-grams, or learned merges) below the word level"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "All three are subword tokenizers; they differ in how merges or pieces are learned, not in being subword."
     }
   ]

--- a/phases/05-nlp-foundations-to-advanced/05-sentiment-analysis/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/05-sentiment-analysis/quiz.json
@@ -1,0 +1,102 @@
+{
+  "lesson": "05-sentiment-analysis",
+  "title": "Sentiment Analysis",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "Why is 'The food was not great' a hard case for naive BoW classifiers?",
+      "options": [
+        "It contains too few tokens",
+        "Negation flips meaning, but bag of words discards the link between 'not' and 'great'",
+        "It mixes English and French",
+        "It has no punctuation"
+      ],
+      "correct": 1,
+      "explanation": "BoW cannot bind 'not' to the word it negates, so the classifier misses the polarity flip."
+    },
+    {
+      "stage": "pre",
+      "question": "What two steps make up classical sentiment analysis?",
+      "options": [
+        "Translate, then classify",
+        "Represent (vectorize text) and classify (linear model on the vector)",
+        "Embed, then cluster",
+        "Search, then rank"
+      ],
+      "correct": 1,
+      "explanation": "Classical sentiment is feature extraction followed by a linear classifier."
+    },
+    {
+      "stage": "check",
+      "question": "Why does Naive Bayes work despite its 'naive' independence assumption?",
+      "options": [
+        "The assumption is actually true for text",
+        "With sparse text features and moderate data the classifier mostly cares which side each word leans toward, not exact joint probabilities",
+        "Naive Bayes secretly learns interactions",
+        "Laplace smoothing fixes dependence"
+      ],
+      "correct": 1,
+      "explanation": "Even with wrong independence, leaning-direction information per word is enough to classify well."
+    },
+    {
+      "stage": "check",
+      "question": "Why include 'NOT_' prefixed tokens during preprocessing?",
+      "options": [
+        "To shrink the vocabulary",
+        "To turn 'good' versus 'NOT_good' into separate features that the classifier can weight oppositely",
+        "To normalize case",
+        "To stem the words"
+      ],
+      "correct": 1,
+      "explanation": "Negation scoping splits negated forms into distinct features so a BoW classifier can model the flip."
+    },
+    {
+      "stage": "check",
+      "question": "Why is removing stopwords risky for sentiment analysis?",
+      "options": [
+        "Stopword lists are too long",
+        "Negation words ('not', 'no', 'never') are usually treated as stopwords but carry sentiment signal",
+        "Stopword removal breaks tokenization",
+        "It increases sparsity"
+      ],
+      "correct": 1,
+      "explanation": "Default stopword lists drop negations and similar carriers of sentiment."
+    },
+    {
+      "stage": "post",
+      "question": "Which metric should you report when sentiment classes are imbalanced?",
+      "options": [
+        "Accuracy alone",
+        "Macro-F1 (mean of per-class F1s, equal-weighted)",
+        "Micro-F1 only",
+        "Mean squared error"
+      ],
+      "correct": 1,
+      "explanation": "Macro-F1 forces the minority class to count; accuracy or micro-F1 hides it."
+    },
+    {
+      "stage": "post",
+      "question": "When should you skip classical models and reach for a transformer for sentiment?",
+      "options": [
+        "When you have under 100 examples",
+        "Sarcasm detection, long shifting documents, aspect-based sentiment, or low-resource languages",
+        "When you need explainability",
+        "When latency is critical"
+      ],
+      "correct": 1,
+      "explanation": "Sarcasm, aspect-based, and cross-lingual sentiment exceed classical BoW models' reach."
+    },
+    {
+      "stage": "post",
+      "question": "Why is L2 regularization important for logistic regression on text?",
+      "options": [
+        "Speeds up matrix inversion",
+        "Sparse high-dimensional text features otherwise let the model memorize training examples",
+        "Required to compute gradients",
+        "Avoids ReLU dead units"
+      ],
+      "correct": 1,
+      "explanation": "L2 prevents overfitting in the sparse-feature, high-dimensional regime of text."
+    }
+  ]
+}

--- a/phases/05-nlp-foundations-to-advanced/05-sentiment-analysis/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/05-sentiment-analysis/quiz.json
@@ -6,12 +6,12 @@
       "stage": "pre",
       "question": "Why is 'The food was not great' a hard case for naive BoW classifiers?",
       "options": [
-        "It contains too few tokens",
-        "Negation flips meaning, but bag of words discards the link between 'not' and 'great'",
+        "It has no punctuation",
         "It mixes English and French",
-        "It has no punctuation"
+        "Negation flips meaning, but bag of words discards the link between 'not' and 'great'",
+        "It contains too few tokens"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "BoW cannot bind 'not' to the word it negates, so the classifier misses the polarity flip."
     },
     {
@@ -19,59 +19,59 @@
       "question": "What two steps make up classical sentiment analysis?",
       "options": [
         "Translate, then classify",
-        "Represent (vectorize text) and classify (linear model on the vector)",
         "Embed, then cluster",
+        "Represent (vectorize text) and classify (linear model on the vector)",
         "Search, then rank"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Classical sentiment is feature extraction followed by a linear classifier."
     },
     {
       "stage": "check",
       "question": "Why does Naive Bayes work despite its 'naive' independence assumption?",
       "options": [
-        "The assumption is actually true for text",
         "With sparse text features and moderate data the classifier mostly cares which side each word leans toward, not exact joint probabilities",
         "Naive Bayes secretly learns interactions",
+        "The assumption is actually true for text",
         "Laplace smoothing fixes dependence"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Even with wrong independence, leaning-direction information per word is enough to classify well."
     },
     {
       "stage": "check",
       "question": "Why include 'NOT_' prefixed tokens during preprocessing?",
       "options": [
-        "To shrink the vocabulary",
-        "To turn 'good' versus 'NOT_good' into separate features that the classifier can weight oppositely",
         "To normalize case",
-        "To stem the words"
+        "To stem the words",
+        "To turn 'good' versus 'NOT_good' into separate features that the classifier can weight oppositely",
+        "To shrink the vocabulary"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Negation scoping splits negated forms into distinct features so a BoW classifier can model the flip."
     },
     {
       "stage": "check",
       "question": "Why is removing stopwords risky for sentiment analysis?",
       "options": [
-        "Stopword lists are too long",
         "Negation words ('not', 'no', 'never') are usually treated as stopwords but carry sentiment signal",
-        "Stopword removal breaks tokenization",
-        "It increases sparsity"
+        "Stopword lists are too long",
+        "It increases sparsity",
+        "Stopword removal breaks tokenization"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Default stopword lists drop negations and similar carriers of sentiment."
     },
     {
       "stage": "post",
       "question": "Which metric should you report when sentiment classes are imbalanced?",
       "options": [
-        "Accuracy alone",
         "Macro-F1 (mean of per-class F1s, equal-weighted)",
-        "Micro-F1 only",
-        "Mean squared error"
+        "Accuracy alone",
+        "Mean squared error",
+        "Micro-F1 only"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Macro-F1 forces the minority class to count; accuracy or micro-F1 hides it."
     },
     {
@@ -79,23 +79,23 @@
       "question": "When should you skip classical models and reach for a transformer for sentiment?",
       "options": [
         "When you have under 100 examples",
-        "Sarcasm detection, long shifting documents, aspect-based sentiment, or low-resource languages",
+        "When latency is critical",
         "When you need explainability",
-        "When latency is critical"
+        "Sarcasm detection, long shifting documents, aspect-based sentiment, or low-resource languages"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "Sarcasm, aspect-based, and cross-lingual sentiment exceed classical BoW models' reach."
     },
     {
       "stage": "post",
       "question": "Why is L2 regularization important for logistic regression on text?",
       "options": [
-        "Speeds up matrix inversion",
-        "Sparse high-dimensional text features otherwise let the model memorize training examples",
         "Required to compute gradients",
-        "Avoids ReLU dead units"
+        "Avoids ReLU dead units",
+        "Speeds up matrix inversion",
+        "Sparse high-dimensional text features otherwise let the model memorize training examples"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "L2 prevents overfitting in the sparse-feature, high-dimensional regime of text."
     }
   ]

--- a/phases/05-nlp-foundations-to-advanced/06-named-entity-recognition/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/06-named-entity-recognition/quiz.json
@@ -1,0 +1,102 @@
+{
+  "lesson": "06-named-entity-recognition",
+  "title": "Named Entity Recognition",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "What is BIO tagging?",
+      "options": [
+        "A binary entity vs non-entity scheme",
+        "Per-token labels: B-TYPE for entity start, I-TYPE for inside, O for outside",
+        "A tokenization style",
+        "A tree representation of entities"
+      ],
+      "correct": 1,
+      "explanation": "BIO turns span extraction into token classification with B/I/O prefixes."
+    },
+    {
+      "stage": "pre",
+      "question": "Why are rule-based gazetteers brittle in production NER?",
+      "options": [
+        "They are slow",
+        "They have zero coverage on new entities and cannot disambiguate (e.g. Apple fruit vs company)",
+        "They require GPUs",
+        "They cannot handle multi-token entities"
+      ],
+      "correct": 1,
+      "explanation": "Gazetteers can match known strings but cannot disambiguate sense or generalize to unseen names."
+    },
+    {
+      "stage": "check",
+      "question": "What is the key advantage of a CRF over an HMM for NER?",
+      "options": [
+        "CRFs are faster",
+        "CRFs are discriminative and can mix arbitrary features (shape, capitalization, neighbors)",
+        "CRFs never need training data",
+        "CRFs avoid the Viterbi algorithm"
+      ],
+      "correct": 1,
+      "explanation": "CRFs are discriminative and let you condition on rich, overlapping features."
+    },
+    {
+      "stage": "check",
+      "question": "In a BiLSTM-CRF architecture, what role does the CRF layer play?",
+      "options": [
+        "Replaces embeddings",
+        "Enforces valid BIO tag sequences by modeling tag-to-tag transitions on top of LSTM emissions",
+        "Pretrains the LSTM",
+        "Performs tokenization"
+      ],
+      "correct": 1,
+      "explanation": "The CRF on top of LSTM features models inter-label dependencies and rules out illegal sequences."
+    },
+    {
+      "stage": "check",
+      "question": "Why must NER be evaluated with entity-level F1, not token-level F1?",
+      "options": [
+        "Entity-level F1 is easier to compute",
+        "Predicted spans must match true spans exactly; token-level F1 overstates accuracy by counting partial matches",
+        "Token-level F1 cannot handle BIO",
+        "Entity-level F1 is required by HuggingFace"
+      ],
+      "correct": 1,
+      "explanation": "Span exact-match is the meaningful metric; token-level F1 inflates scores via partial overlap."
+    },
+    {
+      "stage": "post",
+      "question": "What does aggregation_strategy='simple' do in the HuggingFace NER pipeline?",
+      "options": [
+        "Skips tokenization",
+        "Merges contiguous B-X and I-X tokens into a single span",
+        "Returns only the most confident entity",
+        "Lowercases the output"
+      ],
+      "correct": 1,
+      "explanation": "It merges contiguous BIO tokens of the same type into span-level entities."
+    },
+    {
+      "stage": "post",
+      "question": "Why does standard BIO fail on nested entities?",
+      "options": [
+        "BIO cannot represent multi-token entities",
+        "BIO is a flat per-token scheme and cannot express two overlapping spans of different types",
+        "BIO drops the type label",
+        "BIO requires a transformer"
+      ],
+      "correct": 1,
+      "explanation": "BIO assigns one label per token; nested spans need multi-pass or span-based models."
+    },
+    {
+      "stage": "post",
+      "question": "When does classical NER (CRF or BiLSTM-CRF) still beat an LLM in 2026?",
+      "options": [
+        "On open-domain narrative",
+        "Under tight latency budgets, abundant labels, stable ontologies, or non-generative regulatory constraints",
+        "Whenever the input is in English",
+        "On nested entities"
+      ],
+      "correct": 1,
+      "explanation": "Classical NER wins on latency, labeled-data regimes, fixed ontologies, and on-prem constraints."
+    }
+  ]
+}

--- a/phases/05-nlp-foundations-to-advanced/06-named-entity-recognition/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/06-named-entity-recognition/quiz.json
@@ -6,46 +6,46 @@
       "stage": "pre",
       "question": "What is BIO tagging?",
       "options": [
-        "A binary entity vs non-entity scheme",
         "Per-token labels: B-TYPE for entity start, I-TYPE for inside, O for outside",
+        "A binary entity vs non-entity scheme",
         "A tokenization style",
         "A tree representation of entities"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "BIO turns span extraction into token classification with B/I/O prefixes."
     },
     {
       "stage": "pre",
       "question": "Why are rule-based gazetteers brittle in production NER?",
       "options": [
+        "They require GPUs",
         "They are slow",
         "They have zero coverage on new entities and cannot disambiguate (e.g. Apple fruit vs company)",
-        "They require GPUs",
         "They cannot handle multi-token entities"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Gazetteers can match known strings but cannot disambiguate sense or generalize to unseen names."
     },
     {
       "stage": "check",
       "question": "What is the key advantage of a CRF over an HMM for NER?",
       "options": [
-        "CRFs are faster",
-        "CRFs are discriminative and can mix arbitrary features (shape, capitalization, neighbors)",
+        "CRFs avoid the Viterbi algorithm",
         "CRFs never need training data",
-        "CRFs avoid the Viterbi algorithm"
+        "CRFs are discriminative and can mix arbitrary features (shape, capitalization, neighbors)",
+        "CRFs are faster"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "CRFs are discriminative and let you condition on rich, overlapping features."
     },
     {
       "stage": "check",
       "question": "In a BiLSTM-CRF architecture, what role does the CRF layer play?",
       "options": [
-        "Replaces embeddings",
+        "Performs tokenization",
         "Enforces valid BIO tag sequences by modeling tag-to-tag transitions on top of LSTM emissions",
         "Pretrains the LSTM",
-        "Performs tokenization"
+        "Replaces embeddings"
       ],
       "correct": 1,
       "explanation": "The CRF on top of LSTM features models inter-label dependencies and rules out illegal sequences."
@@ -66,22 +66,22 @@
       "stage": "post",
       "question": "What does aggregation_strategy='simple' do in the HuggingFace NER pipeline?",
       "options": [
+        "Lowercases the output",
         "Skips tokenization",
         "Merges contiguous B-X and I-X tokens into a single span",
-        "Returns only the most confident entity",
-        "Lowercases the output"
+        "Returns only the most confident entity"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "It merges contiguous BIO tokens of the same type into span-level entities."
     },
     {
       "stage": "post",
       "question": "Why does standard BIO fail on nested entities?",
       "options": [
-        "BIO cannot represent multi-token entities",
+        "BIO requires a transformer",
         "BIO is a flat per-token scheme and cannot express two overlapping spans of different types",
-        "BIO drops the type label",
-        "BIO requires a transformer"
+        "BIO cannot represent multi-token entities",
+        "BIO drops the type label"
       ],
       "correct": 1,
       "explanation": "BIO assigns one label per token; nested spans need multi-pass or span-based models."
@@ -90,12 +90,12 @@
       "stage": "post",
       "question": "When does classical NER (CRF or BiLSTM-CRF) still beat an LLM in 2026?",
       "options": [
-        "On open-domain narrative",
-        "Under tight latency budgets, abundant labels, stable ontologies, or non-generative regulatory constraints",
+        "On nested entities",
         "Whenever the input is in English",
-        "On nested entities"
+        "On open-domain narrative",
+        "Under tight latency budgets, abundant labels, stable ontologies, or non-generative regulatory constraints"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "Classical NER wins on latency, labeled-data regimes, fixed ontologies, and on-prem constraints."
     }
   ]

--- a/phases/05-nlp-foundations-to-advanced/07-pos-tagging-parsing/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/07-pos-tagging-parsing/quiz.json
@@ -6,12 +6,12 @@
       "stage": "pre",
       "question": "What is the goal of POS tagging?",
       "options": [
+        "Detect sentiment",
         "Translate the sentence",
-        "Assign a grammatical category (noun, verb, etc.) to each token",
         "Extract named entities",
-        "Detect sentiment"
+        "Assign a grammatical category (noun, verb, etc.) to each token"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "POS tagging labels each token with its part of speech."
     },
     {
@@ -19,11 +19,11 @@
       "question": "Which tagset is the default for cross-lingual work?",
       "options": [
         "Penn Treebank",
-        "Universal Dependencies",
         "Stanford Dependencies",
+        "Universal Dependencies",
         "CoNLL-2003"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Universal Dependencies provides a coarser, language-agnostic 17-tag set."
     },
     {
@@ -31,47 +31,47 @@
       "question": "What does a bigram HMM POS tagger model?",
       "options": [
         "P(tags) only",
-        "P(tag | previous tag) transitions plus P(word | tag) emissions, decoded with Viterbi",
         "Dependency parses",
-        "Embedding similarities"
+        "Embedding similarities",
+        "P(tag | previous tag) transitions plus P(word | tag) emissions, decoded with Viterbi"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "Bigram HMM uses tag transitions and word emissions; Viterbi finds the highest-probability sequence."
     },
     {
       "stage": "check",
       "question": "What does the Viterbi algorithm compute for an HMM tagger?",
       "options": [
-        "The marginal probability of each tag",
         "The single highest-probability tag sequence via dynamic programming over the tag lattice",
-        "The forward probabilities only",
-        "The transition matrix"
+        "The transition matrix",
+        "The marginal probability of each tag",
+        "The forward probabilities only"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Viterbi finds the argmax sequence with O(n * |T|^2) dynamic programming."
     },
     {
       "stage": "check",
       "question": "What does dependency parsing produce?",
       "options": [
-        "A constituency tree of NP/VP/PP labels",
         "A tree where each word has one head word and a labeled grammatical relation",
         "A flat BIO sequence",
+        "A constituency tree of NP/VP/PP labels",
         "A coreference chain"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Dependency parses give per-word (head, relation) edges; constituency parses give nested phrase structures."
     },
     {
       "stage": "post",
       "question": "Why is the accuracy ceiling on PTB POS tagging around 97-98%?",
       "options": [
-        "Hardware limitations",
-        "Human annotators only agree about 97% of the time, so models above ~98% may be overfitting test data",
         "Models cannot exceed 98% in any task",
-        "Universal Dependencies caps at 98%"
+        "Universal Dependencies caps at 98%",
+        "Human annotators only agree about 97% of the time, so models above ~98% may be overfitting test data",
+        "Hardware limitations"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Annotator disagreement bounds the achievable accuracy; very high numbers often signal overfitting."
     },
     {
@@ -90,12 +90,12 @@
       "stage": "post",
       "question": "Which library should you reach for in most production POS / parse tasks?",
       "options": [
-        "Roll your own parser",
-        "spaCy (or stanza/trankit for top accuracy or wider language coverage)",
+        "scikit-learn",
         "NumPy",
-        "scikit-learn"
+        "spaCy (or stanza/trankit for top accuracy or wider language coverage)",
+        "Roll your own parser"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "spaCy ships fast production-grade POS + dependency parsers; stanza/trankit cover broader languages."
     }
   ]

--- a/phases/05-nlp-foundations-to-advanced/07-pos-tagging-parsing/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/07-pos-tagging-parsing/quiz.json
@@ -1,0 +1,102 @@
+{
+  "lesson": "07-pos-tagging-parsing",
+  "title": "POS Tagging and Syntactic Parsing",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "What is the goal of POS tagging?",
+      "options": [
+        "Translate the sentence",
+        "Assign a grammatical category (noun, verb, etc.) to each token",
+        "Extract named entities",
+        "Detect sentiment"
+      ],
+      "correct": 1,
+      "explanation": "POS tagging labels each token with its part of speech."
+    },
+    {
+      "stage": "pre",
+      "question": "Which tagset is the default for cross-lingual work?",
+      "options": [
+        "Penn Treebank",
+        "Universal Dependencies",
+        "Stanford Dependencies",
+        "CoNLL-2003"
+      ],
+      "correct": 1,
+      "explanation": "Universal Dependencies provides a coarser, language-agnostic 17-tag set."
+    },
+    {
+      "stage": "check",
+      "question": "What does a bigram HMM POS tagger model?",
+      "options": [
+        "P(tags) only",
+        "P(tag | previous tag) transitions plus P(word | tag) emissions, decoded with Viterbi",
+        "Dependency parses",
+        "Embedding similarities"
+      ],
+      "correct": 1,
+      "explanation": "Bigram HMM uses tag transitions and word emissions; Viterbi finds the highest-probability sequence."
+    },
+    {
+      "stage": "check",
+      "question": "What does the Viterbi algorithm compute for an HMM tagger?",
+      "options": [
+        "The marginal probability of each tag",
+        "The single highest-probability tag sequence via dynamic programming over the tag lattice",
+        "The forward probabilities only",
+        "The transition matrix"
+      ],
+      "correct": 1,
+      "explanation": "Viterbi finds the argmax sequence with O(n * |T|^2) dynamic programming."
+    },
+    {
+      "stage": "check",
+      "question": "What does dependency parsing produce?",
+      "options": [
+        "A constituency tree of NP/VP/PP labels",
+        "A tree where each word has one head word and a labeled grammatical relation",
+        "A flat BIO sequence",
+        "A coreference chain"
+      ],
+      "correct": 1,
+      "explanation": "Dependency parses give per-word (head, relation) edges; constituency parses give nested phrase structures."
+    },
+    {
+      "stage": "post",
+      "question": "Why is the accuracy ceiling on PTB POS tagging around 97-98%?",
+      "options": [
+        "Hardware limitations",
+        "Human annotators only agree about 97% of the time, so models above ~98% may be overfitting test data",
+        "Models cannot exceed 98% in any task",
+        "Universal Dependencies caps at 98%"
+      ],
+      "correct": 1,
+      "explanation": "Annotator disagreement bounds the achievable accuracy; very high numbers often signal overfitting."
+    },
+    {
+      "stage": "post",
+      "question": "Why does POS tagging still matter in 2026 LLM pipelines?",
+      "options": [
+        "LLMs cannot run without it",
+        "Lemmatization, aspect-based sentiment, query decomposition, structured-output validation, and cross-lingual transfer all still consume POS or dependency parses",
+        "Required for tokenization",
+        "Replaces transformers"
+      ],
+      "correct": 1,
+      "explanation": "POS and dependency parses feed many structured downstream tasks even when LLMs generate the prose."
+    },
+    {
+      "stage": "post",
+      "question": "Which library should you reach for in most production POS / parse tasks?",
+      "options": [
+        "Roll your own parser",
+        "spaCy (or stanza/trankit for top accuracy or wider language coverage)",
+        "NumPy",
+        "scikit-learn"
+      ],
+      "correct": 1,
+      "explanation": "spaCy ships fast production-grade POS + dependency parsers; stanza/trankit cover broader languages."
+    }
+  ]
+}

--- a/phases/05-nlp-foundations-to-advanced/08-cnns-rnns-for-text/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/08-cnns-rnns-for-text/quiz.json
@@ -7,35 +7,35 @@
       "question": "What is a 1D convolutional filter of width 3 over word embeddings effectively learning?",
       "options": [
         "A learnable bigram detector",
+        "A position embedding",
         "A learnable trigram (n-gram) detector",
-        "A unigram count",
-        "A position embedding"
+        "A unigram count"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "A width-3 filter spans three consecutive tokens, acting as a learnable trigram detector."
     },
     {
       "stage": "pre",
       "question": "Why does an LSTM use a cell state with mostly additive interactions?",
       "options": [
-        "To avoid matrix inversion",
         "Additive flow lets gradients propagate through long sequences without vanishing or exploding",
         "Faster softmax",
-        "It saves memory"
+        "It saves memory",
+        "To avoid matrix inversion"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "The cell-state highway keeps gradients stable across hundreds of steps, fixing vanishing-gradient issues."
     },
     {
       "stage": "check",
       "question": "Why does TextCNN use global max-pooling after the convolutional layer?",
       "options": [
+        "To enable backpropagation",
         "To remove embeddings",
-        "Max-pool gives a fixed-size, position-invariant representation by selecting the strongest activation per filter",
         "To reduce vocabulary",
-        "To enable backpropagation"
+        "Max-pool gives a fixed-size, position-invariant representation by selecting the strongest activation per filter"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "Global max-pool produces a fixed-size feature vector regardless of input length, with position invariance."
     },
     {
@@ -44,8 +44,8 @@
       "options": [
         "Faster training",
         "Each token's representation sees both left and right context, which is essential for tagging",
-        "Cheaper memory",
-        "Avoids embeddings"
+        "Avoids embeddings",
+        "Cheaper memory"
       ],
       "correct": 1,
       "explanation": "Bidirectional networks concatenate forward + backward hidden states so labels can use full context."
@@ -56,8 +56,8 @@
       "options": [
         "Max-pool is differentiable; last-state is not",
         "Information at the end of a long sequence tends to dominate the last state, hiding earlier evidence",
-        "Last-state pool ignores padding",
-        "Max-pool removes capitalization"
+        "Max-pool removes capitalization",
+        "Last-state pool ignores padding"
       ],
       "correct": 1,
       "explanation": "Max-pool aggregates strongest signal across positions; last-state can lose earlier evidence."
@@ -66,22 +66,22 @@
       "stage": "post",
       "question": "Which limitation of LSTM/RNN encoder-decoders motivated attention?",
       "options": [
-        "They cannot embed tokens",
-        "The decoder sees only a fixed-size encoder state, losing detail on long inputs; recurrence also serializes training",
+        "They require subword tokenizers",
         "They cannot use embeddings",
-        "They require subword tokenizers"
+        "The decoder sees only a fixed-size encoder state, losing detail on long inputs; recurrence also serializes training",
+        "They cannot embed tokens"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Fixed-size summarization plus serial training were two failures attention removed."
     },
     {
       "stage": "post",
       "question": "When does a TextCNN or BiLSTM still beat a transformer in 2026?",
       "options": [
-        "When latency requirements are extremely loose",
+        "On image inputs",
         "Edge / on-device, streaming token-by-token inputs, or tiny-data baselines",
         "Whenever the dataset is multilingual",
-        "On image inputs"
+        "When latency requirements are extremely loose"
       ],
       "correct": 1,
       "explanation": "Small architectures still win on edge inference, streaming inputs, and rapid baselines."
@@ -90,12 +90,12 @@
       "stage": "post",
       "question": "What is the vanishing gradient problem in plain RNNs?",
       "options": [
-        "Inputs become zero",
         "Repeated multiplication by recurrent weights smaller than 1 makes gradients toward early steps shrink toward zero",
-        "Loss becomes negative",
-        "Embedding matrix becomes singular"
+        "Embedding matrix becomes singular",
+        "Inputs become zero",
+        "Loss becomes negative"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Long-product gradients vanish (or explode) without gating; this is why LSTMs and GRUs exist."
     }
   ]

--- a/phases/05-nlp-foundations-to-advanced/08-cnns-rnns-for-text/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/08-cnns-rnns-for-text/quiz.json
@@ -1,0 +1,102 @@
+{
+  "lesson": "08-cnns-rnns-for-text",
+  "title": "CNNs and RNNs for Text",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "What is a 1D convolutional filter of width 3 over word embeddings effectively learning?",
+      "options": [
+        "A learnable bigram detector",
+        "A learnable trigram (n-gram) detector",
+        "A unigram count",
+        "A position embedding"
+      ],
+      "correct": 1,
+      "explanation": "A width-3 filter spans three consecutive tokens, acting as a learnable trigram detector."
+    },
+    {
+      "stage": "pre",
+      "question": "Why does an LSTM use a cell state with mostly additive interactions?",
+      "options": [
+        "To avoid matrix inversion",
+        "Additive flow lets gradients propagate through long sequences without vanishing or exploding",
+        "Faster softmax",
+        "It saves memory"
+      ],
+      "correct": 1,
+      "explanation": "The cell-state highway keeps gradients stable across hundreds of steps, fixing vanishing-gradient issues."
+    },
+    {
+      "stage": "check",
+      "question": "Why does TextCNN use global max-pooling after the convolutional layer?",
+      "options": [
+        "To remove embeddings",
+        "Max-pool gives a fixed-size, position-invariant representation by selecting the strongest activation per filter",
+        "To reduce vocabulary",
+        "To enable backpropagation"
+      ],
+      "correct": 1,
+      "explanation": "Global max-pool produces a fixed-size feature vector regardless of input length, with position invariance."
+    },
+    {
+      "stage": "check",
+      "question": "What is the main advantage of a bidirectional RNN over a one-way RNN for sequence labeling?",
+      "options": [
+        "Faster training",
+        "Each token's representation sees both left and right context, which is essential for tagging",
+        "Cheaper memory",
+        "Avoids embeddings"
+      ],
+      "correct": 1,
+      "explanation": "Bidirectional networks concatenate forward + backward hidden states so labels can use full context."
+    },
+    {
+      "stage": "check",
+      "question": "Why does max-pooling over an LSTM's outputs often beat using just the last hidden state for classification?",
+      "options": [
+        "Max-pool is differentiable; last-state is not",
+        "Information at the end of a long sequence tends to dominate the last state, hiding earlier evidence",
+        "Last-state pool ignores padding",
+        "Max-pool removes capitalization"
+      ],
+      "correct": 1,
+      "explanation": "Max-pool aggregates strongest signal across positions; last-state can lose earlier evidence."
+    },
+    {
+      "stage": "post",
+      "question": "Which limitation of LSTM/RNN encoder-decoders motivated attention?",
+      "options": [
+        "They cannot embed tokens",
+        "The decoder sees only a fixed-size encoder state, losing detail on long inputs; recurrence also serializes training",
+        "They cannot use embeddings",
+        "They require subword tokenizers"
+      ],
+      "correct": 1,
+      "explanation": "Fixed-size summarization plus serial training were two failures attention removed."
+    },
+    {
+      "stage": "post",
+      "question": "When does a TextCNN or BiLSTM still beat a transformer in 2026?",
+      "options": [
+        "When latency requirements are extremely loose",
+        "Edge / on-device, streaming token-by-token inputs, or tiny-data baselines",
+        "Whenever the dataset is multilingual",
+        "On image inputs"
+      ],
+      "correct": 1,
+      "explanation": "Small architectures still win on edge inference, streaming inputs, and rapid baselines."
+    },
+    {
+      "stage": "post",
+      "question": "What is the vanishing gradient problem in plain RNNs?",
+      "options": [
+        "Inputs become zero",
+        "Repeated multiplication by recurrent weights smaller than 1 makes gradients toward early steps shrink toward zero",
+        "Loss becomes negative",
+        "Embedding matrix becomes singular"
+      ],
+      "correct": 1,
+      "explanation": "Long-product gradients vanish (or explode) without gating; this is why LSTMs and GRUs exist."
+    }
+  ]
+}

--- a/phases/05-nlp-foundations-to-advanced/09-sequence-to-sequence/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/09-sequence-to-sequence/quiz.json
@@ -6,24 +6,24 @@
       "stage": "pre",
       "question": "What is the role of the encoder in a 2014-style seq2seq model?",
       "options": [
-        "Generates target tokens",
-        "Reads the source and produces a fixed-size context vector summarizing it",
+        "Computes attention weights",
         "Performs beam search",
-        "Computes attention weights"
+        "Reads the source and produces a fixed-size context vector summarizing it",
+        "Generates target tokens"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "The encoder RNN compresses the source into a final hidden state used by the decoder."
     },
     {
       "stage": "pre",
       "question": "What is teacher forcing during seq2seq training?",
       "options": [
-        "Manually labeling each decoder step",
-        "Feeding the ground-truth previous token (instead of the model's prediction) as decoder input",
         "Adding a teacher network during inference",
-        "Doubling the batch size"
+        "Doubling the batch size",
+        "Feeding the ground-truth previous token (instead of the model's prediction) as decoder input",
+        "Manually labeling each decoder step"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Teacher forcing stabilizes training by using true previous tokens; without it early errors cascade."
     },
     {
@@ -31,11 +31,11 @@
       "question": "Why does fixed context-vector seq2seq accuracy fall as input length grows?",
       "options": [
         "Padding tokens accumulate",
-        "All information about the source must fit in a single fixed-size encoder hidden state, which loses detail on long inputs",
         "Cross-entropy diverges",
+        "All information about the source must fit in a single fixed-size encoder hidden state, which loses detail on long inputs",
         "Vocabulary becomes too large"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "The fixed context-vector bottleneck means long inputs cannot be losslessly summarized."
     },
     {
@@ -43,59 +43,59 @@
       "question": "What is exposure bias?",
       "options": [
         "Bias from class imbalance",
-        "The train/inference gap from training on ground-truth tokens but generating from the model's own predictions at inference",
         "Bias in encoder embeddings",
-        "Annotator disagreement"
+        "Annotator disagreement",
+        "The train/inference gap from training on ground-truth tokens but generating from the model's own predictions at inference"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "The model never practiced recovering from its own mistakes during training, so errors cascade at inference."
     },
     {
       "stage": "check",
       "question": "Why does beam search often outperform greedy decoding for generation?",
       "options": [
-        "Beam search is faster",
         "Beam search keeps the top-k partial sequences alive at each step instead of irrevocably committing to one token",
         "Beam search avoids exposure bias",
+        "Beam search is faster",
         "Beam search lowers the loss"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Greedy commits per step; beam search explores multiple hypotheses, then picks the best complete one."
     },
     {
       "stage": "post",
       "question": "Which architectural family replaced RNN seq2seq for general generation tasks?",
       "options": [
-        "1D CNNs",
         "Transformer encoder-decoder models (BART, T5, mBART, NLLB)",
+        "Graph neural networks",
         "Naive Bayes",
-        "Graph neural networks"
+        "1D CNNs"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Transformer encoder-decoders dropped recurrence and now dominate generation tasks."
     },
     {
       "stage": "post",
       "question": "What does scheduled sampling do?",
       "options": [
-        "Adds random noise to embeddings",
         "Anneals the teacher-forcing ratio downward during training so the model learns to recover from its own predictions",
         "Schedules learning-rate decay",
-        "Reorders the training set"
+        "Reorders the training set",
+        "Adds random noise to embeddings"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Scheduled sampling gradually mixes in model predictions to close the train/inference gap."
     },
     {
       "stage": "post",
       "question": "Why does greedy decoding alone often fail for user-facing generation?",
       "options": [
-        "It requires more memory",
-        "Greedy can repeat or loop and cannot backtrack from a locally good but globally poor token choice",
         "It cannot use embeddings",
-        "It always picks <EOS> first"
+        "It always picks <EOS> first",
+        "Greedy can repeat or loop and cannot backtrack from a locally good but globally poor token choice",
+        "It requires more memory"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Greedy decoding's irrevocable per-step choice causes loops and repetition without beam search or sampling."
     }
   ]

--- a/phases/05-nlp-foundations-to-advanced/09-sequence-to-sequence/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/09-sequence-to-sequence/quiz.json
@@ -1,0 +1,102 @@
+{
+  "lesson": "09-sequence-to-sequence",
+  "title": "Sequence-to-Sequence Models",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "What is the role of the encoder in a 2014-style seq2seq model?",
+      "options": [
+        "Generates target tokens",
+        "Reads the source and produces a fixed-size context vector summarizing it",
+        "Performs beam search",
+        "Computes attention weights"
+      ],
+      "correct": 1,
+      "explanation": "The encoder RNN compresses the source into a final hidden state used by the decoder."
+    },
+    {
+      "stage": "pre",
+      "question": "What is teacher forcing during seq2seq training?",
+      "options": [
+        "Manually labeling each decoder step",
+        "Feeding the ground-truth previous token (instead of the model's prediction) as decoder input",
+        "Adding a teacher network during inference",
+        "Doubling the batch size"
+      ],
+      "correct": 1,
+      "explanation": "Teacher forcing stabilizes training by using true previous tokens; without it early errors cascade."
+    },
+    {
+      "stage": "check",
+      "question": "Why does fixed context-vector seq2seq accuracy fall as input length grows?",
+      "options": [
+        "Padding tokens accumulate",
+        "All information about the source must fit in a single fixed-size encoder hidden state, which loses detail on long inputs",
+        "Cross-entropy diverges",
+        "Vocabulary becomes too large"
+      ],
+      "correct": 1,
+      "explanation": "The fixed context-vector bottleneck means long inputs cannot be losslessly summarized."
+    },
+    {
+      "stage": "check",
+      "question": "What is exposure bias?",
+      "options": [
+        "Bias from class imbalance",
+        "The train/inference gap from training on ground-truth tokens but generating from the model's own predictions at inference",
+        "Bias in encoder embeddings",
+        "Annotator disagreement"
+      ],
+      "correct": 1,
+      "explanation": "The model never practiced recovering from its own mistakes during training, so errors cascade at inference."
+    },
+    {
+      "stage": "check",
+      "question": "Why does beam search often outperform greedy decoding for generation?",
+      "options": [
+        "Beam search is faster",
+        "Beam search keeps the top-k partial sequences alive at each step instead of irrevocably committing to one token",
+        "Beam search avoids exposure bias",
+        "Beam search lowers the loss"
+      ],
+      "correct": 1,
+      "explanation": "Greedy commits per step; beam search explores multiple hypotheses, then picks the best complete one."
+    },
+    {
+      "stage": "post",
+      "question": "Which architectural family replaced RNN seq2seq for general generation tasks?",
+      "options": [
+        "1D CNNs",
+        "Transformer encoder-decoder models (BART, T5, mBART, NLLB)",
+        "Naive Bayes",
+        "Graph neural networks"
+      ],
+      "correct": 1,
+      "explanation": "Transformer encoder-decoders dropped recurrence and now dominate generation tasks."
+    },
+    {
+      "stage": "post",
+      "question": "What does scheduled sampling do?",
+      "options": [
+        "Adds random noise to embeddings",
+        "Anneals the teacher-forcing ratio downward during training so the model learns to recover from its own predictions",
+        "Schedules learning-rate decay",
+        "Reorders the training set"
+      ],
+      "correct": 1,
+      "explanation": "Scheduled sampling gradually mixes in model predictions to close the train/inference gap."
+    },
+    {
+      "stage": "post",
+      "question": "Why does greedy decoding alone often fail for user-facing generation?",
+      "options": [
+        "It requires more memory",
+        "Greedy can repeat or loop and cannot backtrack from a locally good but globally poor token choice",
+        "It cannot use embeddings",
+        "It always picks <EOS> first"
+      ],
+      "correct": 1,
+      "explanation": "Greedy decoding's irrevocable per-step choice causes loops and repetition without beam search or sampling."
+    }
+  ]
+}

--- a/phases/05-nlp-foundations-to-advanced/10-attention-mechanism/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/10-attention-mechanism/quiz.json
@@ -1,0 +1,102 @@
+{
+  "lesson": "10-attention-mechanism",
+  "title": "Attention Mechanism — The Breakthrough",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "What problem in seq2seq did Bahdanau attention solve?",
+      "options": [
+        "Vanishing gradients in encoders",
+        "The fixed-size context-vector bottleneck where the decoder only saw the encoder's final state",
+        "Tokenization mismatch",
+        "Beam search latency"
+      ],
+      "correct": 1,
+      "explanation": "Attention lets the decoder consult every encoder state, not just the last one."
+    },
+    {
+      "stage": "pre",
+      "question": "What is the attention context vector at decoder step t?",
+      "options": [
+        "The encoder's final hidden state",
+        "A weighted average of encoder hidden states where the weights come from a query-key score",
+        "The decoder's input embedding",
+        "A random projection"
+      ],
+      "correct": 1,
+      "explanation": "Context = sum of alpha_i * h_i, a step-dependent weighted average of encoder states."
+    },
+    {
+      "stage": "check",
+      "question": "In Bahdanau (additive) attention, what role does the vector v_a play?",
+      "options": [
+        "It biases the softmax",
+        "It is the projection that turns the attention-dim hidden combination into a scalar score per encoder position",
+        "It encodes positions",
+        "It controls dropout"
+      ],
+      "correct": 1,
+      "explanation": "v_a dot-products with tanh(W_a s + U_a h) to collapse a d_attn vector into a scalar score."
+    },
+    {
+      "stage": "check",
+      "question": "In Luong's 'dot' attention variant, what constraint must hold?",
+      "options": [
+        "The encoder must be bidirectional",
+        "Decoder state and encoder state must share the same dimensionality (d_s == d_h)",
+        "Beam search is required",
+        "Softmax must be log-space"
+      ],
+      "correct": 1,
+      "explanation": "dot uses s^T h with no projection, so dimensions must match exactly."
+    },
+    {
+      "stage": "check",
+      "question": "Which Q/K/V mapping describes classical (Bahdanau/Luong) attention?",
+      "options": [
+        "Q from encoder, K and V from decoder",
+        "Q = decoder state; K and V = encoder states (same tensor)",
+        "Q, K, V are three independent learned projections of the source",
+        "Q is random, K and V are learned"
+      ],
+      "correct": 1,
+      "explanation": "In classical attention, keys and values are both encoder states; transformers split K and V via learned projections."
+    },
+    {
+      "stage": "post",
+      "question": "Why is reporting raw attention weights as 'explanation' considered fragile?",
+      "options": [
+        "They are too small to plot",
+        "Research (e.g. Jain and Wallace, 2019) showed attention distributions can be permuted without changing predictions on some tasks",
+        "Attention weights are not differentiable",
+        "Attention weights leak labels"
+      ],
+      "correct": 1,
+      "explanation": "Attention weights are correlated with predictions but not faithful explanations without ablation/counterfactual checks."
+    },
+    {
+      "stage": "post",
+      "question": "Which step bridges Bahdanau attention to transformer self-attention?",
+      "options": [
+        "Adding more RNN layers",
+        "Querying a sequence against itself with separately learned Q, K, and V projections, run in parallel heads",
+        "Replacing softmax with sigmoid",
+        "Dropping beam search"
+      ],
+      "correct": 1,
+      "explanation": "Self-attention queries the same sequence, with split K and V projections, parallelized across heads."
+    },
+    {
+      "stage": "post",
+      "question": "What is one practical use case for masking in attention?",
+      "options": [
+        "Reducing model size",
+        "Setting attention weight for padding tokens to zero so they do not contribute to the context vector",
+        "Replacing dropout",
+        "Encoding positions"
+      ],
+      "correct": 1,
+      "explanation": "Masking padding (or future tokens in a decoder) prevents the softmax from spreading weight onto invalid positions."
+    }
+  ]
+}

--- a/phases/05-nlp-foundations-to-advanced/10-attention-mechanism/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/10-attention-mechanism/quiz.json
@@ -6,9 +6,9 @@
       "stage": "pre",
       "question": "What problem in seq2seq did Bahdanau attention solve?",
       "options": [
-        "Vanishing gradients in encoders",
-        "The fixed-size context-vector bottleneck where the decoder only saw the encoder's final state",
         "Tokenization mismatch",
+        "The fixed-size context-vector bottleneck where the decoder only saw the encoder's final state",
+        "Vanishing gradients in encoders",
         "Beam search latency"
       ],
       "correct": 1,
@@ -18,9 +18,9 @@
       "stage": "pre",
       "question": "What is the attention context vector at decoder step t?",
       "options": [
-        "The encoder's final hidden state",
-        "A weighted average of encoder hidden states where the weights come from a query-key score",
         "The decoder's input embedding",
+        "A weighted average of encoder hidden states where the weights come from a query-key score",
+        "The encoder's final hidden state",
         "A random projection"
       ],
       "correct": 1,
@@ -30,10 +30,10 @@
       "stage": "check",
       "question": "In Bahdanau (additive) attention, what role does the vector v_a play?",
       "options": [
-        "It biases the softmax",
+        "It controls dropout",
         "It is the projection that turns the attention-dim hidden combination into a scalar score per encoder position",
         "It encodes positions",
-        "It controls dropout"
+        "It biases the softmax"
       ],
       "correct": 1,
       "explanation": "v_a dot-products with tanh(W_a s + U_a h) to collapse a d_attn vector into a scalar score."
@@ -42,58 +42,58 @@
       "stage": "check",
       "question": "In Luong's 'dot' attention variant, what constraint must hold?",
       "options": [
-        "The encoder must be bidirectional",
         "Decoder state and encoder state must share the same dimensionality (d_s == d_h)",
-        "Beam search is required",
-        "Softmax must be log-space"
+        "The encoder must be bidirectional",
+        "Softmax must be log-space",
+        "Beam search is required"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "dot uses s^T h with no projection, so dimensions must match exactly."
     },
     {
       "stage": "check",
       "question": "Which Q/K/V mapping describes classical (Bahdanau/Luong) attention?",
       "options": [
-        "Q from encoder, K and V from decoder",
-        "Q = decoder state; K and V = encoder states (same tensor)",
         "Q, K, V are three independent learned projections of the source",
-        "Q is random, K and V are learned"
+        "Q is random, K and V are learned",
+        "Q from encoder, K and V from decoder",
+        "Q = decoder state; K and V = encoder states (same tensor)"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "In classical attention, keys and values are both encoder states; transformers split K and V via learned projections."
     },
     {
       "stage": "post",
       "question": "Why is reporting raw attention weights as 'explanation' considered fragile?",
       "options": [
+        "Attention weights leak labels",
         "They are too small to plot",
         "Research (e.g. Jain and Wallace, 2019) showed attention distributions can be permuted without changing predictions on some tasks",
-        "Attention weights are not differentiable",
-        "Attention weights leak labels"
+        "Attention weights are not differentiable"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Attention weights are correlated with predictions but not faithful explanations without ablation/counterfactual checks."
     },
     {
       "stage": "post",
       "question": "Which step bridges Bahdanau attention to transformer self-attention?",
       "options": [
+        "Dropping beam search",
         "Adding more RNN layers",
-        "Querying a sequence against itself with separately learned Q, K, and V projections, run in parallel heads",
         "Replacing softmax with sigmoid",
-        "Dropping beam search"
+        "Querying a sequence against itself with separately learned Q, K, and V projections, run in parallel heads"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "Self-attention queries the same sequence, with split K and V projections, parallelized across heads."
     },
     {
       "stage": "post",
       "question": "What is one practical use case for masking in attention?",
       "options": [
-        "Reducing model size",
-        "Setting attention weight for padding tokens to zero so they do not contribute to the context vector",
         "Replacing dropout",
-        "Encoding positions"
+        "Setting attention weight for padding tokens to zero so they do not contribute to the context vector",
+        "Encoding positions",
+        "Reducing model size"
       ],
       "correct": 1,
       "explanation": "Masking padding (or future tokens in a decoder) prevents the softmax from spreading weight onto invalid positions."

--- a/phases/05-nlp-foundations-to-advanced/11-machine-translation/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/11-machine-translation/quiz.json
@@ -1,0 +1,102 @@
+{
+  "lesson": "11-machine-translation",
+  "title": "Machine Translation",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "What does BLEU measure?",
+      "options": [
+        "Character-level F-score",
+        "N-gram precision (typically 1-4) between hypothesis and reference, with a brevity penalty",
+        "Embedding cosine similarity",
+        "Language identification accuracy"
+      ],
+      "correct": 1,
+      "explanation": "BLEU is the geometric mean of 1-4-gram precision against references, plus a brevity penalty."
+    },
+    {
+      "stage": "pre",
+      "question": "Why use sacrebleu instead of rolling your own BLEU?",
+      "options": [
+        "It runs on GPU",
+        "It normalizes tokenization so scores are comparable across papers and runs",
+        "It supports streaming",
+        "It is more accurate"
+      ],
+      "correct": 1,
+      "explanation": "sacrebleu freezes tokenization, removing a common source of incomparable BLEU numbers."
+    },
+    {
+      "stage": "check",
+      "question": "Which NLLB-specific setting controls the target language during decoding?",
+      "options": [
+        "src_lang",
+        "forced_bos_token_id set to the target language code's token id",
+        "num_beams",
+        "length_penalty"
+      ],
+      "correct": 1,
+      "explanation": "NLLB forces the first decoded token to a target-language code via forced_bos_token_id."
+    },
+    {
+      "stage": "check",
+      "question": "Which metric family is the 2026 default for production MT quality where labeled data exists?",
+      "options": [
+        "BLEU alone",
+        "Learned metrics such as COMET (and BERTScore/BLEURT) trained on human judgment",
+        "Token edit distance",
+        "Latency"
+      ],
+      "correct": 1,
+      "explanation": "Learned metrics like COMET correlate more strongly with human judgment than BLEU/chrF alone."
+    },
+    {
+      "stage": "check",
+      "question": "When does chrF tend to be more informative than BLEU?",
+      "options": [
+        "On very short sentences",
+        "For morphologically rich languages where character-level matches catch inflectional variants BLEU misses",
+        "Whenever a reference exists",
+        "When using beam search"
+      ],
+      "correct": 1,
+      "explanation": "Character F-score captures partial morphological matches that word-level BLEU undercounts."
+    },
+    {
+      "stage": "post",
+      "question": "What is off-target generation in multilingual MT?",
+      "options": [
+        "Output that is too short",
+        "The model decodes into the wrong target language (e.g. NLLB outputting Spanish when French was requested)",
+        "Output that misses punctuation",
+        "Output that drops named entities"
+      ],
+      "correct": 1,
+      "explanation": "Off-target generation is common on rare language pairs; a post-translation language-ID check catches it."
+    },
+    {
+      "stage": "post",
+      "question": "Why does fine-tuning on a few thousand high-quality domain pairs often beat much larger noisy web data?",
+      "options": [
+        "Smaller datasets train faster",
+        "Quality and domain match dominate volume; noisy parallel data introduces drift and hallucination",
+        "Web data is illegal to use",
+        "Larger data overflows GPU memory"
+      ],
+      "correct": 1,
+      "explanation": "Clean domain-aligned pairs are the largest production lever; noisy data degrades adaptation."
+    },
+    {
+      "stage": "post",
+      "question": "When is an LLM (e.g. GPT-4) likely to outperform a specialized MT model in 2026?",
+      "options": [
+        "Highest throughput batch translation",
+        "Idiomatic content, long context, stylistic adaptation via prompting, or content requiring tone control",
+        "Latency-critical browser translation",
+        "Small-language pairs with millions of parallel sentences"
+      ],
+      "correct": 1,
+      "explanation": "LLMs win on idiomatic, long-context, or style-controlled translation; specialized MT wins on throughput and latency."
+    }
+  ]
+}

--- a/phases/05-nlp-foundations-to-advanced/11-machine-translation/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/11-machine-translation/quiz.json
@@ -6,10 +6,10 @@
       "stage": "pre",
       "question": "What does BLEU measure?",
       "options": [
-        "Character-level F-score",
+        "Language identification accuracy",
         "N-gram precision (typically 1-4) between hypothesis and reference, with a brevity penalty",
-        "Embedding cosine similarity",
-        "Language identification accuracy"
+        "Character-level F-score",
+        "Embedding cosine similarity"
       ],
       "correct": 1,
       "explanation": "BLEU is the geometric mean of 1-4-gram precision against references, plus a brevity penalty."
@@ -18,22 +18,22 @@
       "stage": "pre",
       "question": "Why use sacrebleu instead of rolling your own BLEU?",
       "options": [
+        "It is more accurate",
         "It runs on GPU",
         "It normalizes tokenization so scores are comparable across papers and runs",
-        "It supports streaming",
-        "It is more accurate"
+        "It supports streaming"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "sacrebleu freezes tokenization, removing a common source of incomparable BLEU numbers."
     },
     {
       "stage": "check",
       "question": "Which NLLB-specific setting controls the target language during decoding?",
       "options": [
-        "src_lang",
+        "length_penalty",
         "forced_bos_token_id set to the target language code's token id",
         "num_beams",
-        "length_penalty"
+        "src_lang"
       ],
       "correct": 1,
       "explanation": "NLLB forces the first decoded token to a target-language code via forced_bos_token_id."
@@ -43,47 +43,47 @@
       "question": "Which metric family is the 2026 default for production MT quality where labeled data exists?",
       "options": [
         "BLEU alone",
-        "Learned metrics such as COMET (and BERTScore/BLEURT) trained on human judgment",
         "Token edit distance",
+        "Learned metrics such as COMET (and BERTScore/BLEURT) trained on human judgment",
         "Latency"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Learned metrics like COMET correlate more strongly with human judgment than BLEU/chrF alone."
     },
     {
       "stage": "check",
       "question": "When does chrF tend to be more informative than BLEU?",
       "options": [
-        "On very short sentences",
         "For morphologically rich languages where character-level matches catch inflectional variants BLEU misses",
-        "Whenever a reference exists",
-        "When using beam search"
+        "When using beam search",
+        "On very short sentences",
+        "Whenever a reference exists"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Character F-score captures partial morphological matches that word-level BLEU undercounts."
     },
     {
       "stage": "post",
       "question": "What is off-target generation in multilingual MT?",
       "options": [
-        "Output that is too short",
-        "The model decodes into the wrong target language (e.g. NLLB outputting Spanish when French was requested)",
+        "Output that drops named entities",
         "Output that misses punctuation",
-        "Output that drops named entities"
+        "The model decodes into the wrong target language (e.g. NLLB outputting Spanish when French was requested)",
+        "Output that is too short"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Off-target generation is common on rare language pairs; a post-translation language-ID check catches it."
     },
     {
       "stage": "post",
       "question": "Why does fine-tuning on a few thousand high-quality domain pairs often beat much larger noisy web data?",
       "options": [
+        "Larger data overflows GPU memory",
         "Smaller datasets train faster",
-        "Quality and domain match dominate volume; noisy parallel data introduces drift and hallucination",
         "Web data is illegal to use",
-        "Larger data overflows GPU memory"
+        "Quality and domain match dominate volume; noisy parallel data introduces drift and hallucination"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "Clean domain-aligned pairs are the largest production lever; noisy data degrades adaptation."
     },
     {
@@ -91,11 +91,11 @@
       "question": "When is an LLM (e.g. GPT-4) likely to outperform a specialized MT model in 2026?",
       "options": [
         "Highest throughput batch translation",
-        "Idiomatic content, long context, stylistic adaptation via prompting, or content requiring tone control",
         "Latency-critical browser translation",
+        "Idiomatic content, long context, stylistic adaptation via prompting, or content requiring tone control",
         "Small-language pairs with millions of parallel sentences"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "LLMs win on idiomatic, long-context, or style-controlled translation; specialized MT wins on throughput and latency."
     }
   ]

--- a/phases/05-nlp-foundations-to-advanced/12-text-summarization/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/12-text-summarization/quiz.json
@@ -8,8 +8,8 @@
       "options": [
         "Extractive uses TF-IDF; abstractive uses Word2Vec",
         "Extractive returns sentences verbatim from the source; abstractive generates new text and can hallucinate",
-        "Extractive is slower than abstractive",
-        "Extractive is multilingual only"
+        "Extractive is multilingual only",
+        "Extractive is slower than abstractive"
       ],
       "correct": 1,
       "explanation": "Extractive lifts sentences verbatim; abstractive rewrites and risks hallucination."
@@ -20,8 +20,8 @@
       "options": [
         "Embedding similarity",
         "N-gram and longest-common-subsequence overlap between system and reference summaries",
-        "Token-level perplexity",
-        "Reading time"
+        "Reading time",
+        "Token-level perplexity"
       ],
       "correct": 1,
       "explanation": "ROUGE-1/2/L measure unigram, bigram, and LCS overlap with references."
@@ -31,71 +31,71 @@
       "question": "How does TextRank score sentences in extractive summarization?",
       "options": [
         "By raw word count",
-        "By running a PageRank-style iteration over a graph where edges are sentence-similarity weights",
         "By comparing to a reference summary",
+        "By running a PageRank-style iteration over a graph where edges are sentence-similarity weights",
         "By embedding cosine to the question"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "TextRank uses PageRank over a sentence-similarity graph; highly connected sentences score highest."
     },
     {
       "stage": "check",
       "question": "Why enable stemming when computing ROUGE?",
       "options": [
-        "To speed up ROUGE",
         "Without stemming, 'running' and 'run' count as different tokens and ROUGE undercounts true overlap",
-        "Stemming is required by the rouge-score package",
-        "Stemming normalizes case"
+        "To speed up ROUGE",
+        "Stemming normalizes case",
+        "Stemming is required by the rouge-score package"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Stemming merges morphological variants so ROUGE credits semantically equivalent forms."
     },
     {
       "stage": "check",
       "question": "Which 2026 metric is purpose-built to detect summary hallucinations via NLI entailment?",
       "options": [
+        "BLEU",
         "ROUGE-L",
         "Faithfulness checks (e.g. FactCC or RAGAS faithfulness) using NLI between source and summary claims",
-        "BLEU",
         "chrF"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "NLI-based faithfulness scoring flags claims in the summary not entailed by the source."
     },
     {
       "stage": "post",
       "question": "Why is extractive summarization preferred for compliance-adjacent content?",
       "options": [
-        "It is faster",
         "Outputs are lifted verbatim from the source, eliminating the abstractive hallucination class",
-        "ROUGE scores are higher",
-        "Extractive supports longer outputs"
+        "It is faster",
+        "Extractive supports longer outputs",
+        "ROUGE scores are higher"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Verbatim extraction cannot invent content, which matters where factuality is regulated."
     },
     {
       "stage": "post",
       "question": "Which of these is an abstractive hallucination type to monitor for?",
       "options": [
+        "Punctuation drift",
         "Stopword removal",
-        "Entity swap (e.g. 'John Smith' rendered as 'John Brown'), number drift, polarity flip, or fact invention",
         "Long sentences",
-        "Punctuation drift"
+        "Entity swap (e.g. 'John Smith' rendered as 'John Brown'), number drift, polarity flip, or fact invention"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "Entity swaps, numeric drift, polarity flips, and invented facts are the canonical abstractive failure modes."
     },
     {
       "stage": "post",
       "question": "When would you reach for a Pegasus checkpoint over BART-large-CNN?",
       "options": [
+        "When evaluating BLEU",
         "When the input is short",
-        "For domains like scientific abstracts where Pegasus's gap-sentence pretraining objective is a closer fit",
         "When you need extractive output",
-        "When evaluating BLEU"
+        "For domains like scientific abstracts where Pegasus's gap-sentence pretraining objective is a closer fit"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "Pegasus's gap-sentence objective excels at long-form domain summarization (e.g. pubmed)."
     }
   ]

--- a/phases/05-nlp-foundations-to-advanced/12-text-summarization/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/12-text-summarization/quiz.json
@@ -1,0 +1,102 @@
+{
+  "lesson": "12-text-summarization",
+  "title": "Text Summarization",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "What is the key behavioral difference between extractive and abstractive summarization?",
+      "options": [
+        "Extractive uses TF-IDF; abstractive uses Word2Vec",
+        "Extractive returns sentences verbatim from the source; abstractive generates new text and can hallucinate",
+        "Extractive is slower than abstractive",
+        "Extractive is multilingual only"
+      ],
+      "correct": 1,
+      "explanation": "Extractive lifts sentences verbatim; abstractive rewrites and risks hallucination."
+    },
+    {
+      "stage": "pre",
+      "question": "What does ROUGE measure?",
+      "options": [
+        "Embedding similarity",
+        "N-gram and longest-common-subsequence overlap between system and reference summaries",
+        "Token-level perplexity",
+        "Reading time"
+      ],
+      "correct": 1,
+      "explanation": "ROUGE-1/2/L measure unigram, bigram, and LCS overlap with references."
+    },
+    {
+      "stage": "check",
+      "question": "How does TextRank score sentences in extractive summarization?",
+      "options": [
+        "By raw word count",
+        "By running a PageRank-style iteration over a graph where edges are sentence-similarity weights",
+        "By comparing to a reference summary",
+        "By embedding cosine to the question"
+      ],
+      "correct": 1,
+      "explanation": "TextRank uses PageRank over a sentence-similarity graph; highly connected sentences score highest."
+    },
+    {
+      "stage": "check",
+      "question": "Why enable stemming when computing ROUGE?",
+      "options": [
+        "To speed up ROUGE",
+        "Without stemming, 'running' and 'run' count as different tokens and ROUGE undercounts true overlap",
+        "Stemming is required by the rouge-score package",
+        "Stemming normalizes case"
+      ],
+      "correct": 1,
+      "explanation": "Stemming merges morphological variants so ROUGE credits semantically equivalent forms."
+    },
+    {
+      "stage": "check",
+      "question": "Which 2026 metric is purpose-built to detect summary hallucinations via NLI entailment?",
+      "options": [
+        "ROUGE-L",
+        "Faithfulness checks (e.g. FactCC or RAGAS faithfulness) using NLI between source and summary claims",
+        "BLEU",
+        "chrF"
+      ],
+      "correct": 1,
+      "explanation": "NLI-based faithfulness scoring flags claims in the summary not entailed by the source."
+    },
+    {
+      "stage": "post",
+      "question": "Why is extractive summarization preferred for compliance-adjacent content?",
+      "options": [
+        "It is faster",
+        "Outputs are lifted verbatim from the source, eliminating the abstractive hallucination class",
+        "ROUGE scores are higher",
+        "Extractive supports longer outputs"
+      ],
+      "correct": 1,
+      "explanation": "Verbatim extraction cannot invent content, which matters where factuality is regulated."
+    },
+    {
+      "stage": "post",
+      "question": "Which of these is an abstractive hallucination type to monitor for?",
+      "options": [
+        "Stopword removal",
+        "Entity swap (e.g. 'John Smith' rendered as 'John Brown'), number drift, polarity flip, or fact invention",
+        "Long sentences",
+        "Punctuation drift"
+      ],
+      "correct": 1,
+      "explanation": "Entity swaps, numeric drift, polarity flips, and invented facts are the canonical abstractive failure modes."
+    },
+    {
+      "stage": "post",
+      "question": "When would you reach for a Pegasus checkpoint over BART-large-CNN?",
+      "options": [
+        "When the input is short",
+        "For domains like scientific abstracts where Pegasus's gap-sentence pretraining objective is a closer fit",
+        "When you need extractive output",
+        "When evaluating BLEU"
+      ],
+      "correct": 1,
+      "explanation": "Pegasus's gap-sentence objective excels at long-form domain summarization (e.g. pubmed)."
+    }
+  ]
+}

--- a/phases/05-nlp-foundations-to-advanced/13-question-answering/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/13-question-answering/quiz.json
@@ -7,35 +7,35 @@
       "question": "What does extractive QA predict?",
       "options": [
         "A generated natural-language answer",
+        "A confidence score only",
         "Start and end token indices of the answer span within a given passage",
-        "A retrieved passage ID",
-        "A confidence score only"
+        "A retrieved passage ID"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Extractive QA outputs the span of the passage that contains the answer."
     },
     {
       "stage": "pre",
       "question": "What two components define a basic RAG pipeline?",
       "options": [
-        "Tokenizer and POS tagger",
-        "A retriever (find relevant passages) and a reader (extract or generate the answer)",
         "An encoder and a decoder trained jointly",
-        "A reranker and a translator"
+        "A reranker and a translator",
+        "Tokenizer and POS tagger",
+        "A retriever (find relevant passages) and a reader (extract or generate the answer)"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "RAG = retriever (finds relevant context) plus reader (answers from it)."
     },
     {
       "stage": "check",
       "question": "On SQuAD, what does Exact Match (EM) measure?",
       "options": [
+        "Edit distance",
         "Per-word overlap",
         "Whether the prediction matches the reference exactly after normalization (lowercase, strip punctuation, remove articles)",
-        "Edit distance",
         "Token-level F1"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "EM is strict equality after a defined normalization step; partial matches score zero."
     },
     {
@@ -54,36 +54,36 @@
       "stage": "check",
       "question": "Which RAGAS dimension targets hallucinations specifically?",
       "options": [
+        "Answer relevance",
         "Context recall",
         "Faithfulness, measured by NLI entailment between answer claims and retrieved context",
-        "Answer relevance",
         "Context precision"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Faithfulness checks each answer claim against retrieved context via NLI entailment."
     },
     {
       "stage": "post",
       "question": "Why should you measure retrieval recall before evaluating reader accuracy?",
       "options": [
-        "Reader latency depends on it",
-        "If the correct passage is not in the top-k, the reader cannot succeed regardless of how good it is",
+        "Required by transformers",
         "Recall determines ROUGE",
-        "Required by transformers"
+        "Reader latency depends on it",
+        "If the correct passage is not in the top-k, the reader cannot succeed regardless of how good it is"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "A reader cannot answer when the right passage is missing; retrieval recall bounds reader performance."
     },
     {
       "stage": "post",
       "question": "Which prompt pattern reduces hallucinations in RAG generation?",
       "options": [
-        "Asking the model to be creative",
         "Telling the model to answer only from the provided context and to reply 'I don't know' when the context is insufficient",
-        "Removing the question",
-        "Including more passages"
+        "Including more passages",
+        "Asking the model to be creative",
+        "Removing the question"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Grounding + explicit refusal instructions cuts hallucination rates substantially."
     },
     {
@@ -92,8 +92,8 @@
       "options": [
         "Conversational QA",
         "Regulated domains (legal, medical, audit) where literal quotation from authoritative sources is required",
-        "Open-domain trivia",
-        "Multilingual support"
+        "Multilingual support",
+        "Open-domain trivia"
       ],
       "correct": 1,
       "explanation": "Extractive QA gives verbatim quotes from an authoritative corpus, which compliance contexts demand."

--- a/phases/05-nlp-foundations-to-advanced/13-question-answering/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/13-question-answering/quiz.json
@@ -1,0 +1,102 @@
+{
+  "lesson": "13-question-answering",
+  "title": "Question Answering Systems",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "What does extractive QA predict?",
+      "options": [
+        "A generated natural-language answer",
+        "Start and end token indices of the answer span within a given passage",
+        "A retrieved passage ID",
+        "A confidence score only"
+      ],
+      "correct": 1,
+      "explanation": "Extractive QA outputs the span of the passage that contains the answer."
+    },
+    {
+      "stage": "pre",
+      "question": "What two components define a basic RAG pipeline?",
+      "options": [
+        "Tokenizer and POS tagger",
+        "A retriever (find relevant passages) and a reader (extract or generate the answer)",
+        "An encoder and a decoder trained jointly",
+        "A reranker and a translator"
+      ],
+      "correct": 1,
+      "explanation": "RAG = retriever (finds relevant context) plus reader (answers from it)."
+    },
+    {
+      "stage": "check",
+      "question": "On SQuAD, what does Exact Match (EM) measure?",
+      "options": [
+        "Per-word overlap",
+        "Whether the prediction matches the reference exactly after normalization (lowercase, strip punctuation, remove articles)",
+        "Edit distance",
+        "Token-level F1"
+      ],
+      "correct": 1,
+      "explanation": "EM is strict equality after a defined normalization step; partial matches score zero."
+    },
+    {
+      "stage": "check",
+      "question": "What does deepset/roberta-base-squad2 add over a SQuAD 1.1 model?",
+      "options": [
+        "Multilingual support",
+        "Training on unanswerable questions so the model can predict a null answer",
+        "Bigger context window",
+        "Cross-lingual retrieval"
+      ],
+      "correct": 1,
+      "explanation": "SQuAD 2.0 includes unanswerable items; models trained on it can predict 'no answer'."
+    },
+    {
+      "stage": "check",
+      "question": "Which RAGAS dimension targets hallucinations specifically?",
+      "options": [
+        "Context recall",
+        "Faithfulness, measured by NLI entailment between answer claims and retrieved context",
+        "Answer relevance",
+        "Context precision"
+      ],
+      "correct": 1,
+      "explanation": "Faithfulness checks each answer claim against retrieved context via NLI entailment."
+    },
+    {
+      "stage": "post",
+      "question": "Why should you measure retrieval recall before evaluating reader accuracy?",
+      "options": [
+        "Reader latency depends on it",
+        "If the correct passage is not in the top-k, the reader cannot succeed regardless of how good it is",
+        "Recall determines ROUGE",
+        "Required by transformers"
+      ],
+      "correct": 1,
+      "explanation": "A reader cannot answer when the right passage is missing; retrieval recall bounds reader performance."
+    },
+    {
+      "stage": "post",
+      "question": "Which prompt pattern reduces hallucinations in RAG generation?",
+      "options": [
+        "Asking the model to be creative",
+        "Telling the model to answer only from the provided context and to reply 'I don't know' when the context is insufficient",
+        "Removing the question",
+        "Including more passages"
+      ],
+      "correct": 1,
+      "explanation": "Grounding + explicit refusal instructions cuts hallucination rates substantially."
+    },
+    {
+      "stage": "post",
+      "question": "When is extractive QA still preferred over generative RAG in 2026?",
+      "options": [
+        "Conversational QA",
+        "Regulated domains (legal, medical, audit) where literal quotation from authoritative sources is required",
+        "Open-domain trivia",
+        "Multilingual support"
+      ],
+      "correct": 1,
+      "explanation": "Extractive QA gives verbatim quotes from an authoritative corpus, which compliance contexts demand."
+    }
+  ]
+}

--- a/phases/05-nlp-foundations-to-advanced/14-information-retrieval-search/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/14-information-retrieval-search/quiz.json
@@ -6,10 +6,10 @@
       "stage": "pre",
       "question": "What does BM25 score a document on?",
       "options": [
-        "Embedding cosine to the query",
+        "Edit distance to the query",
         "Term frequency, IDF, and document-length-normalized presence of query terms",
-        "PageRank over the corpus",
-        "Edit distance to the query"
+        "Embedding cosine to the query",
+        "PageRank over the corpus"
       ],
       "correct": 1,
       "explanation": "BM25 weighs TF saturation, IDF, and length normalization to score lexical matches."
@@ -18,58 +18,58 @@
       "stage": "pre",
       "question": "What is the main weakness of dense-only retrieval that BM25 catches?",
       "options": [
-        "Latency",
-        "Exact keyword and identifier matches (product codes, error strings, named entities) that semantic embeddings can miss",
         "Multilingual queries",
-        "Long documents"
+        "Latency",
+        "Long documents",
+        "Exact keyword and identifier matches (product codes, error strings, named entities) that semantic embeddings can miss"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "Dense embeddings can blur identifiers and exact strings; BM25 nails them."
     },
     {
       "stage": "check",
       "question": "Why does Reciprocal Rank Fusion (RRF) ignore raw scores from each retriever?",
       "options": [
-        "Raw scores are illegal to use",
-        "BM25 and dense scores live in different scales; using only rank positions makes the fusion robust to calibration",
         "RRF requires probabilities",
-        "Speeds up sorting"
+        "Raw scores are illegal to use",
+        "Speeds up sorting",
+        "BM25 and dense scores live in different scales; using only rank positions makes the fusion robust to calibration"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "RRF uses 1/(k + rank), so the two scoring systems' scales do not have to match."
     },
     {
       "stage": "check",
       "question": "Why run a cross-encoder reranker only on the top-30 fused results?",
       "options": [
-        "Cross-encoders are required at every step",
-        "Cross-encoders are slow per pair; amortizing them on a small candidate pool gives high accuracy with acceptable latency",
+        "Rerankers reduce recall",
         "Top-30 is required by FAISS",
-        "Rerankers reduce recall"
+        "Cross-encoders are required at every step",
+        "Cross-encoders are slow per pair; amortizing them on a small candidate pool gives high accuracy with acceptable latency"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "Cross-encoders score query+doc jointly; running them only on the small fused candidate pool keeps latency manageable."
     },
     {
       "stage": "check",
       "question": "Which metric is most important to optimize for RAG retrievers?",
       "options": [
-        "Latency",
-        "Recall@k, since the reader cannot answer if the correct passage is missing from the top-k",
         "BLEU",
-        "Throughput"
+        "Throughput",
+        "Recall@k, since the reader cannot answer if the correct passage is missing from the top-k",
+        "Latency"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "If the right passage is not in the retrieved top-k, the reader is guaranteed to fail."
     },
     {
       "stage": "post",
       "question": "Where do most production RAG failures originate, per 2026 industry experience?",
       "options": [
-        "The LLM choice",
+        "Reranker tuning",
         "Ingestion and chunking, not the model; bad context defeats good readers",
         "Prompt verbosity",
-        "Reranker tuning"
+        "The LLM choice"
       ],
       "correct": 1,
       "explanation": "Roughly 80% of RAG failures trace to chunking and ingestion quality, not the generative model."
@@ -78,10 +78,10 @@
       "stage": "post",
       "question": "What is the 'parent-doc' retrieval pattern?",
       "options": [
-        "Embed only parent documents",
+        "Pick the longest document",
         "Retrieve small child chunks for precision, then expand to the parent block when multiple children from the same parent appear, preserving context",
-        "Use parent doc embeddings only",
-        "Pick the longest document"
+        "Embed only parent documents",
+        "Use parent doc embeddings only"
       ],
       "correct": 1,
       "explanation": "Child-level retrieval is precise; expanding to the parent preserves the surrounding context the reader needs."
@@ -90,12 +90,12 @@
       "stage": "post",
       "question": "When should you ship three-way retrieval (BM25 + dense + SPLADE)?",
       "options": [
-        "Always",
-        "When infrastructure supports learned-sparse indexes and queries mix proper nouns with semantic intent",
+        "Only on under 1000 documents",
         "Only for English-only corpora",
-        "Only on under 1000 documents"
+        "When infrastructure supports learned-sparse indexes and queries mix proper nouns with semantic intent",
+        "Always"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Three-way retrieval outperforms two-way in 2026 benchmarks for mixed lexical-semantic queries, given SPLADE infrastructure."
     }
   ]

--- a/phases/05-nlp-foundations-to-advanced/14-information-retrieval-search/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/14-information-retrieval-search/quiz.json
@@ -1,0 +1,102 @@
+{
+  "lesson": "14-information-retrieval-search",
+  "title": "Information Retrieval and Search",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "What does BM25 score a document on?",
+      "options": [
+        "Embedding cosine to the query",
+        "Term frequency, IDF, and document-length-normalized presence of query terms",
+        "PageRank over the corpus",
+        "Edit distance to the query"
+      ],
+      "correct": 1,
+      "explanation": "BM25 weighs TF saturation, IDF, and length normalization to score lexical matches."
+    },
+    {
+      "stage": "pre",
+      "question": "What is the main weakness of dense-only retrieval that BM25 catches?",
+      "options": [
+        "Latency",
+        "Exact keyword and identifier matches (product codes, error strings, named entities) that semantic embeddings can miss",
+        "Multilingual queries",
+        "Long documents"
+      ],
+      "correct": 1,
+      "explanation": "Dense embeddings can blur identifiers and exact strings; BM25 nails them."
+    },
+    {
+      "stage": "check",
+      "question": "Why does Reciprocal Rank Fusion (RRF) ignore raw scores from each retriever?",
+      "options": [
+        "Raw scores are illegal to use",
+        "BM25 and dense scores live in different scales; using only rank positions makes the fusion robust to calibration",
+        "RRF requires probabilities",
+        "Speeds up sorting"
+      ],
+      "correct": 1,
+      "explanation": "RRF uses 1/(k + rank), so the two scoring systems' scales do not have to match."
+    },
+    {
+      "stage": "check",
+      "question": "Why run a cross-encoder reranker only on the top-30 fused results?",
+      "options": [
+        "Cross-encoders are required at every step",
+        "Cross-encoders are slow per pair; amortizing them on a small candidate pool gives high accuracy with acceptable latency",
+        "Top-30 is required by FAISS",
+        "Rerankers reduce recall"
+      ],
+      "correct": 1,
+      "explanation": "Cross-encoders score query+doc jointly; running them only on the small fused candidate pool keeps latency manageable."
+    },
+    {
+      "stage": "check",
+      "question": "Which metric is most important to optimize for RAG retrievers?",
+      "options": [
+        "Latency",
+        "Recall@k, since the reader cannot answer if the correct passage is missing from the top-k",
+        "BLEU",
+        "Throughput"
+      ],
+      "correct": 1,
+      "explanation": "If the right passage is not in the retrieved top-k, the reader is guaranteed to fail."
+    },
+    {
+      "stage": "post",
+      "question": "Where do most production RAG failures originate, per 2026 industry experience?",
+      "options": [
+        "The LLM choice",
+        "Ingestion and chunking, not the model; bad context defeats good readers",
+        "Prompt verbosity",
+        "Reranker tuning"
+      ],
+      "correct": 1,
+      "explanation": "Roughly 80% of RAG failures trace to chunking and ingestion quality, not the generative model."
+    },
+    {
+      "stage": "post",
+      "question": "What is the 'parent-doc' retrieval pattern?",
+      "options": [
+        "Embed only parent documents",
+        "Retrieve small child chunks for precision, then expand to the parent block when multiple children from the same parent appear, preserving context",
+        "Use parent doc embeddings only",
+        "Pick the longest document"
+      ],
+      "correct": 1,
+      "explanation": "Child-level retrieval is precise; expanding to the parent preserves the surrounding context the reader needs."
+    },
+    {
+      "stage": "post",
+      "question": "When should you ship three-way retrieval (BM25 + dense + SPLADE)?",
+      "options": [
+        "Always",
+        "When infrastructure supports learned-sparse indexes and queries mix proper nouns with semantic intent",
+        "Only for English-only corpora",
+        "Only on under 1000 documents"
+      ],
+      "correct": 1,
+      "explanation": "Three-way retrieval outperforms two-way in 2026 benchmarks for mixed lexical-semantic queries, given SPLADE infrastructure."
+    }
+  ]
+}

--- a/phases/05-nlp-foundations-to-advanced/15-topic-modeling/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/15-topic-modeling/quiz.json
@@ -1,0 +1,102 @@
+{
+  "lesson": "15-topic-modeling",
+  "title": "Topic Modeling — LDA and BERTopic",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "What does LDA assume about each document?",
+      "options": [
+        "Each document belongs to exactly one topic",
+        "Each document is a mixture of topics; each topic is a distribution over words",
+        "Documents are independent of topics",
+        "Documents are sentences"
+      ],
+      "correct": 1,
+      "explanation": "LDA's generative story is mixed-membership: each doc has a topic distribution, each topic a word distribution."
+    },
+    {
+      "stage": "pre",
+      "question": "What does BERTopic use to form topic clusters?",
+      "options": [
+        "Direct softmax over the vocabulary",
+        "Encode docs with a sentence transformer, reduce dimensionality with UMAP, then cluster with HDBSCAN",
+        "Train an LSTM end-to-end",
+        "Run BM25 followed by k-means"
+      ],
+      "correct": 1,
+      "explanation": "BERTopic = embeddings + UMAP + HDBSCAN, with class-based TF-IDF for topic words."
+    },
+    {
+      "stage": "check",
+      "question": "Why does scikit-learn's LDA expect raw counts (CountVectorizer), not TF-IDF?",
+      "options": [
+        "TF-IDF is too slow",
+        "LDA's probabilistic model is defined over integer term counts; TF-IDF distorts the underlying distribution",
+        "Memory limits",
+        "LDA cannot handle floats"
+      ],
+      "correct": 1,
+      "explanation": "LDA likelihood assumes counts; feeding TF-IDF values violates the model assumption."
+    },
+    {
+      "stage": "check",
+      "question": "What does HDBSCAN's -1 label mean in a BERTopic output?",
+      "options": [
+        "Top topic",
+        "An outlier cluster of documents the density-based algorithm could not confidently assign",
+        "Stopword cluster",
+        "A reserved category"
+      ],
+      "correct": 1,
+      "explanation": "HDBSCAN marks unclustered points with -1; in BERTopic these are documents that did not fit any topic."
+    },
+    {
+      "stage": "check",
+      "question": "Which coherence metric is the common default for topic-model evaluation?",
+      "options": [
+        "Accuracy",
+        "c_v coherence via NPMI over sliding windows of top topic words",
+        "BLEU",
+        "Perplexity only"
+      ],
+      "correct": 1,
+      "explanation": "c_v coherence (Roder et al., 2015) is the canonical automatic topic-coherence metric."
+    },
+    {
+      "stage": "post",
+      "question": "When is LDA usually a better fit than BERTopic?",
+      "options": [
+        "On short tweets",
+        "Long documents where mixed-membership topic distributions are useful and embeddings would truncate input",
+        "When you need a single topic per document",
+        "When embeddings are noisy"
+      ],
+      "correct": 1,
+      "explanation": "Long documents benefit from LDA's mixed-membership model; BERT encoders truncate inputs."
+    },
+    {
+      "stage": "post",
+      "question": "Why does BERTopic typically win on short text (tweets, headlines)?",
+      "options": [
+        "It is faster",
+        "Semantic similarity in embedding space captures meaning where bag-of-words counts are too sparse",
+        "It supports more languages",
+        "Short text has fewer topics"
+      ],
+      "correct": 1,
+      "explanation": "BERT embeddings provide semantic similarity for short text where word-overlap statistics fail."
+    },
+    {
+      "stage": "post",
+      "question": "What is a common LDA failure mode for which you should monitor topics?",
+      "options": [
+        "Topics that match labeled categories perfectly",
+        "Junk topics that absorb stopwords or extremely frequent terms",
+        "Topics with too few documents",
+        "Document mixtures that sum to 1"
+      ],
+      "correct": 1,
+      "explanation": "LDA can create junk topics that absorb stopwords; tighter min_df/max_df and stopword filtering mitigate."
+    }
+  ]
+}

--- a/phases/05-nlp-foundations-to-advanced/15-topic-modeling/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/15-topic-modeling/quiz.json
@@ -7,11 +7,11 @@
       "question": "What does LDA assume about each document?",
       "options": [
         "Each document belongs to exactly one topic",
+        "Documents are sentences",
         "Each document is a mixture of topics; each topic is a distribution over words",
-        "Documents are independent of topics",
-        "Documents are sentences"
+        "Documents are independent of topics"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "LDA's generative story is mixed-membership: each doc has a topic distribution, each topic a word distribution."
     },
     {
@@ -20,8 +20,8 @@
       "options": [
         "Direct softmax over the vocabulary",
         "Encode docs with a sentence transformer, reduce dimensionality with UMAP, then cluster with HDBSCAN",
-        "Train an LSTM end-to-end",
-        "Run BM25 followed by k-means"
+        "Run BM25 followed by k-means",
+        "Train an LSTM end-to-end"
       ],
       "correct": 1,
       "explanation": "BERTopic = embeddings + UMAP + HDBSCAN, with class-based TF-IDF for topic words."
@@ -32,8 +32,8 @@
       "options": [
         "TF-IDF is too slow",
         "LDA's probabilistic model is defined over integer term counts; TF-IDF distorts the underlying distribution",
-        "Memory limits",
-        "LDA cannot handle floats"
+        "LDA cannot handle floats",
+        "Memory limits"
       ],
       "correct": 1,
       "explanation": "LDA likelihood assumes counts; feeding TF-IDF values violates the model assumption."
@@ -42,10 +42,10 @@
       "stage": "check",
       "question": "What does HDBSCAN's -1 label mean in a BERTopic output?",
       "options": [
-        "Top topic",
+        "A reserved category",
         "An outlier cluster of documents the density-based algorithm could not confidently assign",
         "Stopword cluster",
-        "A reserved category"
+        "Top topic"
       ],
       "correct": 1,
       "explanation": "HDBSCAN marks unclustered points with -1; in BERTopic these are documents that did not fit any topic."
@@ -54,12 +54,12 @@
       "stage": "check",
       "question": "Which coherence metric is the common default for topic-model evaluation?",
       "options": [
-        "Accuracy",
-        "c_v coherence via NPMI over sliding windows of top topic words",
         "BLEU",
-        "Perplexity only"
+        "Accuracy",
+        "Perplexity only",
+        "c_v coherence via NPMI over sliding windows of top topic words"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "c_v coherence (Roder et al., 2015) is the canonical automatic topic-coherence metric."
     },
     {
@@ -68,8 +68,8 @@
       "options": [
         "On short tweets",
         "Long documents where mixed-membership topic distributions are useful and embeddings would truncate input",
-        "When you need a single topic per document",
-        "When embeddings are noisy"
+        "When embeddings are noisy",
+        "When you need a single topic per document"
       ],
       "correct": 1,
       "explanation": "Long documents benefit from LDA's mixed-membership model; BERT encoders truncate inputs."
@@ -78,24 +78,24 @@
       "stage": "post",
       "question": "Why does BERTopic typically win on short text (tweets, headlines)?",
       "options": [
+        "Short text has fewer topics",
         "It is faster",
         "Semantic similarity in embedding space captures meaning where bag-of-words counts are too sparse",
-        "It supports more languages",
-        "Short text has fewer topics"
+        "It supports more languages"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "BERT embeddings provide semantic similarity for short text where word-overlap statistics fail."
     },
     {
       "stage": "post",
       "question": "What is a common LDA failure mode for which you should monitor topics?",
       "options": [
+        "Document mixtures that sum to 1",
         "Topics that match labeled categories perfectly",
         "Junk topics that absorb stopwords or extremely frequent terms",
-        "Topics with too few documents",
-        "Document mixtures that sum to 1"
+        "Topics with too few documents"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "LDA can create junk topics that absorb stopwords; tighter min_df/max_df and stopword filtering mitigate."
     }
   ]

--- a/phases/05-nlp-foundations-to-advanced/16-text-generation-pre-transformer/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/16-text-generation-pre-transformer/quiz.json
@@ -1,0 +1,102 @@
+{
+  "lesson": "16-text-generation-pre-transformer",
+  "title": "Text Generation Before Transformers — N-gram Language Models",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "What does an n-gram language model estimate?",
+      "options": [
+        "P(label | document)",
+        "P(next word | previous n-1 words) from count statistics",
+        "Edit distance between words",
+        "Document embeddings"
+      ],
+      "correct": 1,
+      "explanation": "An n-gram LM models P(w | last n-1 words) via counted occurrences."
+    },
+    {
+      "stage": "pre",
+      "question": "What problem does smoothing solve in n-gram models?",
+      "options": [
+        "Numerical precision",
+        "Zero-probability assignment to n-grams unseen in training, which collapses sentence likelihoods to zero",
+        "Tokenization mismatch",
+        "Memory usage"
+      ],
+      "correct": 1,
+      "explanation": "Smoothing reallocates probability mass so unseen n-grams get non-zero probability."
+    },
+    {
+      "stage": "check",
+      "question": "What insight makes Kneser-Ney smoothing better than naive absolute discounting?",
+      "options": [
+        "It uses TF-IDF",
+        "It estimates the lower-order distribution with continuation probability (number of distinct contexts a word appears in) instead of raw frequency",
+        "It uses gradient descent",
+        "It uses bigger n"
+      ],
+      "correct": 1,
+      "explanation": "Continuation probability gives credit for context diversity, not just raw count."
+    },
+    {
+      "stage": "check",
+      "question": "What does perplexity measure?",
+      "options": [
+        "Throughput of generation",
+        "exp of the average negative log-likelihood per token on a held-out test set; lower is better",
+        "Number of distinct n-grams",
+        "Cross-entropy of labels"
+      ],
+      "correct": 1,
+      "explanation": "Perplexity = exp(- mean log P); lower means the model is less surprised by the test text."
+    },
+    {
+      "stage": "check",
+      "question": "Why must train and test sets use identical tokenization when comparing perplexity numbers?",
+      "options": [
+        "Required by gradient descent",
+        "Perplexity depends on the tokenization scheme; mismatched tokenizers produce noncomparable scores",
+        "To control batch size",
+        "To avoid OOV"
+      ],
+      "correct": 1,
+      "explanation": "Different tokenizations change the token count and likelihood, making perplexity values incomparable."
+    },
+    {
+      "stage": "post",
+      "question": "Why do generated trigram-LM sentences feel locally fluent but globally incoherent?",
+      "options": [
+        "They drop punctuation",
+        "Local trigram context guides each next word but the model has no long-range memory beyond n-1 tokens",
+        "They use Laplace smoothing",
+        "Beam search fails"
+      ],
+      "correct": 1,
+      "explanation": "Conditioning only on the last n-1 tokens makes long-range coherence accidental."
+    },
+    {
+      "stage": "post",
+      "question": "Where do n-gram models still ship in production in 2026?",
+      "options": [
+        "Open-domain chatbots",
+        "Latency-critical paths like speech recognition rescoring and on-device autocomplete via libraries such as KenLM",
+        "Multilingual translation",
+        "Summarization"
+      ],
+      "correct": 1,
+      "explanation": "KenLM-style n-gram models still serve as fast on-device or rescoring components."
+    },
+    {
+      "stage": "post",
+      "question": "Why is computing an n-gram baseline before declaring a neural LM 'good' still recommended?",
+      "options": [
+        "Required by ROUGE",
+        "If a transformer LM does not beat a tuned Kneser-Ney baseline by a wide margin on the same tokenization, something is off in the training pipeline",
+        "It speeds up training",
+        "It removes OOV"
+      ],
+      "correct": 1,
+      "explanation": "KN baselines are surprisingly strong; a neural LM should win by a large margin or you have a bug."
+    }
+  ]
+}

--- a/phases/05-nlp-foundations-to-advanced/16-text-generation-pre-transformer/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/16-text-generation-pre-transformer/quiz.json
@@ -6,12 +6,12 @@
       "stage": "pre",
       "question": "What does an n-gram language model estimate?",
       "options": [
-        "P(label | document)",
-        "P(next word | previous n-1 words) from count statistics",
         "Edit distance between words",
-        "Document embeddings"
+        "P(label | document)",
+        "Document embeddings",
+        "P(next word | previous n-1 words) from count statistics"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "An n-gram LM models P(w | last n-1 words) via counted occurrences."
     },
     {
@@ -19,35 +19,35 @@
       "question": "What problem does smoothing solve in n-gram models?",
       "options": [
         "Numerical precision",
+        "Memory usage",
         "Zero-probability assignment to n-grams unseen in training, which collapses sentence likelihoods to zero",
-        "Tokenization mismatch",
-        "Memory usage"
+        "Tokenization mismatch"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Smoothing reallocates probability mass so unseen n-grams get non-zero probability."
     },
     {
       "stage": "check",
       "question": "What insight makes Kneser-Ney smoothing better than naive absolute discounting?",
       "options": [
-        "It uses TF-IDF",
         "It estimates the lower-order distribution with continuation probability (number of distinct contexts a word appears in) instead of raw frequency",
-        "It uses gradient descent",
-        "It uses bigger n"
+        "It uses TF-IDF",
+        "It uses bigger n",
+        "It uses gradient descent"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Continuation probability gives credit for context diversity, not just raw count."
     },
     {
       "stage": "check",
       "question": "What does perplexity measure?",
       "options": [
-        "Throughput of generation",
         "exp of the average negative log-likelihood per token on a held-out test set; lower is better",
         "Number of distinct n-grams",
-        "Cross-entropy of labels"
+        "Cross-entropy of labels",
+        "Throughput of generation"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Perplexity = exp(- mean log P); lower means the model is less surprised by the test text."
     },
     {
@@ -55,11 +55,11 @@
       "question": "Why must train and test sets use identical tokenization when comparing perplexity numbers?",
       "options": [
         "Required by gradient descent",
+        "To avoid OOV",
         "Perplexity depends on the tokenization scheme; mismatched tokenizers produce noncomparable scores",
-        "To control batch size",
-        "To avoid OOV"
+        "To control batch size"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Different tokenizations change the token count and likelihood, making perplexity values incomparable."
     },
     {
@@ -67,35 +67,35 @@
       "question": "Why do generated trigram-LM sentences feel locally fluent but globally incoherent?",
       "options": [
         "They drop punctuation",
+        "Beam search fails",
         "Local trigram context guides each next word but the model has no long-range memory beyond n-1 tokens",
-        "They use Laplace smoothing",
-        "Beam search fails"
+        "They use Laplace smoothing"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Conditioning only on the last n-1 tokens makes long-range coherence accidental."
     },
     {
       "stage": "post",
       "question": "Where do n-gram models still ship in production in 2026?",
       "options": [
+        "Multilingual translation",
         "Open-domain chatbots",
         "Latency-critical paths like speech recognition rescoring and on-device autocomplete via libraries such as KenLM",
-        "Multilingual translation",
         "Summarization"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "KenLM-style n-gram models still serve as fast on-device or rescoring components."
     },
     {
       "stage": "post",
       "question": "Why is computing an n-gram baseline before declaring a neural LM 'good' still recommended?",
       "options": [
-        "Required by ROUGE",
-        "If a transformer LM does not beat a tuned Kneser-Ney baseline by a wide margin on the same tokenization, something is off in the training pipeline",
         "It speeds up training",
-        "It removes OOV"
+        "Required by ROUGE",
+        "It removes OOV",
+        "If a transformer LM does not beat a tuned Kneser-Ney baseline by a wide margin on the same tokenization, something is off in the training pipeline"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "KN baselines are surprisingly strong; a neural LM should win by a large margin or you have a bug."
     }
   ]

--- a/phases/05-nlp-foundations-to-advanced/17-chatbots-rule-to-neural/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/17-chatbots-rule-to-neural/quiz.json
@@ -6,12 +6,12 @@
       "stage": "pre",
       "question": "What does a slot-filling state machine do in a rule-based chatbot?",
       "options": [
+        "Detects sarcasm",
         "Picks the most fluent reply",
-        "Tracks which required parameters (date, destination, amount) are still missing and asks for them in sequence",
         "Embeds the user message",
-        "Detects sarcasm"
+        "Tracks which required parameters (date, destination, amount) are still missing and asks for them in sequence"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "Slot filling iteratively collects the structured parameters a task handler needs."
     },
     {
@@ -19,23 +19,23 @@
       "question": "Why is retrieval-based chat resistant to hallucination?",
       "options": [
         "It uses embeddings",
-        "It returns a canned response from a curated set rather than generating new text",
         "It rejects all queries",
+        "It returns a canned response from a curated set rather than generating new text",
         "It uses BM25"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Retrieval surfaces pre-written answers; no generation means no fabricated content."
     },
     {
       "stage": "check",
       "question": "What defines an LLM agent loop versus a single-shot LLM call?",
       "options": [
-        "Bigger context window",
-        "A controller that interleaves LLM calls with tool invocations until the model returns a final answer or the step budget is hit",
+        "Use of greedy decoding",
         "Use of softmax",
-        "Use of greedy decoding"
+        "A controller that interleaves LLM calls with tool invocations until the model returns a final answer or the step budget is hit",
+        "Bigger context window"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Agents add a plan-act-observe loop with tool calls and a termination condition."
     },
     {
@@ -43,45 +43,45 @@
       "question": "Why is hybrid routing (rules + retrieval + LLM agent) the 2026 production default?",
       "options": [
         "It is cheaper to maintain",
+        "It removes the need for evaluation",
         "No single architecture handles every request well; rules cover destructive actions, retrieval covers FAQ, agents handle ambiguous open-ended queries",
-        "It avoids embeddings",
-        "It removes the need for evaluation"
+        "It avoids embeddings"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Hybrid systems use deterministic rules for risky actions and reserve LLM agents for open-ended queries."
     },
     {
       "stage": "check",
       "question": "What is prompt injection?",
       "options": [
-        "Injecting tokens into embeddings",
-        "User-supplied (direct) or document-supplied (indirect) text that tries to override the system prompt or hijack the agent's behavior",
         "A SQL injection variant only",
-        "A type of tokenizer attack"
+        "A type of tokenizer attack",
+        "Injecting tokens into embeddings",
+        "User-supplied (direct) or document-supplied (indirect) text that tries to override the system prompt or hijack the agent's behavior"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "Prompt injection rewrites the agent's behavior via untrusted text in user input or tool outputs."
     },
     {
       "stage": "post",
       "question": "Which OWASP Top 10 (LLM Apps 2025) risk is ranked LLM01?",
       "options": [
-        "Insecure deserialization",
         "Prompt injection (direct and indirect)",
-        "SQL injection",
-        "Broken access control"
+        "Insecure deserialization",
+        "Broken access control",
+        "SQL injection"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Prompt injection is LLM01 in the OWASP LLM Apps Top 10 (2025)."
     },
     {
       "stage": "post",
       "question": "What mitigation pattern reduces indirect prompt injection by separating planning from execution?",
       "options": [
-        "Bigger model",
+        "Shorter context",
         "Plan-Verify-Execute: the agent plans first, verifies each action against the plan, then executes — preventing tool outputs from injecting new unplanned actions",
-        "Lower temperature",
-        "Shorter context"
+        "Bigger model",
+        "Lower temperature"
       ],
       "correct": 1,
       "explanation": "PVE checks each step against the agreed plan, so injected instructions from tool outputs are rejected."
@@ -91,11 +91,11 @@
       "question": "Why must destructive actions (payments, deletions) route through a structured flow even in an LLM-agent system?",
       "options": [
         "LLMs are slow",
-        "Confident fabrication, prompt injection, and scope creep mean the LLM cannot be the sole authority for irreversible side effects",
+        "Beam search is unsafe",
         "Tools cannot be called",
-        "Beam search is unsafe"
+        "Confident fabrication, prompt injection, and scope creep mean the LLM cannot be the sole authority for irreversible side effects"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "Hallucination and injection make irreversible actions through pure LLM agents unsafe; require deterministic confirmation flows."
     }
   ]

--- a/phases/05-nlp-foundations-to-advanced/17-chatbots-rule-to-neural/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/17-chatbots-rule-to-neural/quiz.json
@@ -1,0 +1,102 @@
+{
+  "lesson": "17-chatbots-rule-to-neural",
+  "title": "Chatbots — Rule-Based to Neural to LLM Agents",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "What does a slot-filling state machine do in a rule-based chatbot?",
+      "options": [
+        "Picks the most fluent reply",
+        "Tracks which required parameters (date, destination, amount) are still missing and asks for them in sequence",
+        "Embeds the user message",
+        "Detects sarcasm"
+      ],
+      "correct": 1,
+      "explanation": "Slot filling iteratively collects the structured parameters a task handler needs."
+    },
+    {
+      "stage": "pre",
+      "question": "Why is retrieval-based chat resistant to hallucination?",
+      "options": [
+        "It uses embeddings",
+        "It returns a canned response from a curated set rather than generating new text",
+        "It rejects all queries",
+        "It uses BM25"
+      ],
+      "correct": 1,
+      "explanation": "Retrieval surfaces pre-written answers; no generation means no fabricated content."
+    },
+    {
+      "stage": "check",
+      "question": "What defines an LLM agent loop versus a single-shot LLM call?",
+      "options": [
+        "Bigger context window",
+        "A controller that interleaves LLM calls with tool invocations until the model returns a final answer or the step budget is hit",
+        "Use of softmax",
+        "Use of greedy decoding"
+      ],
+      "correct": 1,
+      "explanation": "Agents add a plan-act-observe loop with tool calls and a termination condition."
+    },
+    {
+      "stage": "check",
+      "question": "Why is hybrid routing (rules + retrieval + LLM agent) the 2026 production default?",
+      "options": [
+        "It is cheaper to maintain",
+        "No single architecture handles every request well; rules cover destructive actions, retrieval covers FAQ, agents handle ambiguous open-ended queries",
+        "It avoids embeddings",
+        "It removes the need for evaluation"
+      ],
+      "correct": 1,
+      "explanation": "Hybrid systems use deterministic rules for risky actions and reserve LLM agents for open-ended queries."
+    },
+    {
+      "stage": "check",
+      "question": "What is prompt injection?",
+      "options": [
+        "Injecting tokens into embeddings",
+        "User-supplied (direct) or document-supplied (indirect) text that tries to override the system prompt or hijack the agent's behavior",
+        "A SQL injection variant only",
+        "A type of tokenizer attack"
+      ],
+      "correct": 1,
+      "explanation": "Prompt injection rewrites the agent's behavior via untrusted text in user input or tool outputs."
+    },
+    {
+      "stage": "post",
+      "question": "Which OWASP Top 10 (LLM Apps 2025) risk is ranked LLM01?",
+      "options": [
+        "Insecure deserialization",
+        "Prompt injection (direct and indirect)",
+        "SQL injection",
+        "Broken access control"
+      ],
+      "correct": 1,
+      "explanation": "Prompt injection is LLM01 in the OWASP LLM Apps Top 10 (2025)."
+    },
+    {
+      "stage": "post",
+      "question": "What mitigation pattern reduces indirect prompt injection by separating planning from execution?",
+      "options": [
+        "Bigger model",
+        "Plan-Verify-Execute: the agent plans first, verifies each action against the plan, then executes — preventing tool outputs from injecting new unplanned actions",
+        "Lower temperature",
+        "Shorter context"
+      ],
+      "correct": 1,
+      "explanation": "PVE checks each step against the agreed plan, so injected instructions from tool outputs are rejected."
+    },
+    {
+      "stage": "post",
+      "question": "Why must destructive actions (payments, deletions) route through a structured flow even in an LLM-agent system?",
+      "options": [
+        "LLMs are slow",
+        "Confident fabrication, prompt injection, and scope creep mean the LLM cannot be the sole authority for irreversible side effects",
+        "Tools cannot be called",
+        "Beam search is unsafe"
+      ],
+      "correct": 1,
+      "explanation": "Hallucination and injection make irreversible actions through pure LLM agents unsafe; require deterministic confirmation flows."
+    }
+  ]
+}

--- a/phases/05-nlp-foundations-to-advanced/18-multilingual-nlp/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/18-multilingual-nlp/quiz.json
@@ -1,0 +1,102 @@
+{
+  "lesson": "18-multilingual-nlp",
+  "title": "Multilingual NLP",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "What does zero-shot cross-lingual transfer mean?",
+      "options": [
+        "Translating without a translation model",
+        "Fine-tune a multilingual model on one source language and evaluate on a different language with no target-language labels",
+        "Tokenizing with zero merges",
+        "Training with zero examples"
+      ],
+      "correct": 1,
+      "explanation": "Zero-shot transfer: train on the source language, run on the target without target-language supervision."
+    },
+    {
+      "stage": "pre",
+      "question": "Which model family ships as the standard 100-language cross-lingual baseline?",
+      "options": [
+        "GPT-2",
+        "XLM-R (e.g. XLM-RoBERTa-base, 270M)",
+        "DistilBERT",
+        "GloVe"
+      ],
+      "correct": 1,
+      "explanation": "XLM-R is the canonical 100-language pretrained baseline for cross-lingual classification."
+    },
+    {
+      "stage": "check",
+      "question": "Why does English-as-source not always give the best transfer for a non-English target?",
+      "options": [
+        "English has too little data",
+        "Language similarity (typology, script, morphology) predicts transfer quality; a closer high-resource source can outperform English",
+        "English uses BPE",
+        "English is too short"
+      ],
+      "correct": 1,
+      "explanation": "Typologically related sources (e.g. Hindi for Indic targets) often outperform English as a fine-tune source."
+    },
+    {
+      "stage": "check",
+      "question": "What is the 'fertility tax' for low-resource languages?",
+      "options": [
+        "Smaller models train slower",
+        "Low-resource text tokenizes into more subwords per word than English, consuming context window, latency, and capacity",
+        "Tokenizers cannot handle Unicode",
+        "BPE refuses to train"
+      ],
+      "correct": 1,
+      "explanation": "Long-tail languages tokenize at much higher fertility, eating context and training efficiency."
+    },
+    {
+      "stage": "check",
+      "question": "Why is per-language evaluation required, not aggregated accuracy?",
+      "options": [
+        "Aggregates run faster",
+        "Aggregate numbers hide long-tail languages where a multilingual model can be far worse than its mean suggests",
+        "Aggregates ignore tokenization",
+        "Aggregates only work on classification"
+      ],
+      "correct": 1,
+      "explanation": "Aggregate accuracy masks poor performance on low-resource languages; per-language scores expose it."
+    },
+    {
+      "stage": "post",
+      "question": "Why is fine-tuning learning rate critical when adapting a multilingual model with few-shot data?",
+      "options": [
+        "Lower LR wastes GPU",
+        "High LR can collapse the multilingual alignment and effectively reduce the model to English-only",
+        "Required by tokenizers",
+        "It changes the vocabulary"
+      ],
+      "correct": 1,
+      "explanation": "Excessive LR drifts the shared representation; conservative LR (~2e-5) preserves cross-lingual structure."
+    },
+    {
+      "stage": "post",
+      "question": "Which mitigation directly addresses tokenizer fertility for long-tail scripts?",
+      "options": [
+        "More training epochs",
+        "Use byte-fallback (SentencePiece byte_fallback=True) or a tokenizer with broader script coverage (e.g. XLM-V)",
+        "Lower batch size",
+        "Skip stopwords"
+      ],
+      "correct": 1,
+      "explanation": "Byte fallback and broader-vocab tokenizers reduce fertility and OOV for low-resource scripts."
+    },
+    {
+      "stage": "post",
+      "question": "When is a monolingual model from scratch worth trying instead of a multilingual one?",
+      "options": [
+        "Always for English",
+        "When the target language has enough data to train a monolingual model that beats the multilingual baseline; test before assuming",
+        "Whenever the tokenizer is BPE",
+        "Only for translation"
+      ],
+      "correct": 1,
+      "explanation": "Sometimes monolingual training beats multilingual for high-resource targets; empirical comparison decides."
+    }
+  ]
+}

--- a/phases/05-nlp-foundations-to-advanced/18-multilingual-nlp/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/18-multilingual-nlp/quiz.json
@@ -6,24 +6,24 @@
       "stage": "pre",
       "question": "What does zero-shot cross-lingual transfer mean?",
       "options": [
-        "Translating without a translation model",
         "Fine-tune a multilingual model on one source language and evaluate on a different language with no target-language labels",
+        "Translating without a translation model",
         "Tokenizing with zero merges",
         "Training with zero examples"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Zero-shot transfer: train on the source language, run on the target without target-language supervision."
     },
     {
       "stage": "pre",
       "question": "Which model family ships as the standard 100-language cross-lingual baseline?",
       "options": [
+        "GloVe",
         "GPT-2",
         "XLM-R (e.g. XLM-RoBERTa-base, 270M)",
-        "DistilBERT",
-        "GloVe"
+        "DistilBERT"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "XLM-R is the canonical 100-language pretrained baseline for cross-lingual classification."
     },
     {
@@ -42,10 +42,10 @@
       "stage": "check",
       "question": "What is the 'fertility tax' for low-resource languages?",
       "options": [
-        "Smaller models train slower",
+        "BPE refuses to train",
         "Low-resource text tokenizes into more subwords per word than English, consuming context window, latency, and capacity",
-        "Tokenizers cannot handle Unicode",
-        "BPE refuses to train"
+        "Smaller models train slower",
+        "Tokenizers cannot handle Unicode"
       ],
       "correct": 1,
       "explanation": "Long-tail languages tokenize at much higher fertility, eating context and training efficiency."
@@ -54,10 +54,10 @@
       "stage": "check",
       "question": "Why is per-language evaluation required, not aggregated accuracy?",
       "options": [
-        "Aggregates run faster",
-        "Aggregate numbers hide long-tail languages where a multilingual model can be far worse than its mean suggests",
         "Aggregates ignore tokenization",
-        "Aggregates only work on classification"
+        "Aggregate numbers hide long-tail languages where a multilingual model can be far worse than its mean suggests",
+        "Aggregates only work on classification",
+        "Aggregates run faster"
       ],
       "correct": 1,
       "explanation": "Aggregate accuracy masks poor performance on low-resource languages; per-language scores expose it."
@@ -67,23 +67,23 @@
       "question": "Why is fine-tuning learning rate critical when adapting a multilingual model with few-shot data?",
       "options": [
         "Lower LR wastes GPU",
-        "High LR can collapse the multilingual alignment and effectively reduce the model to English-only",
         "Required by tokenizers",
-        "It changes the vocabulary"
+        "It changes the vocabulary",
+        "High LR can collapse the multilingual alignment and effectively reduce the model to English-only"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "Excessive LR drifts the shared representation; conservative LR (~2e-5) preserves cross-lingual structure."
     },
     {
       "stage": "post",
       "question": "Which mitigation directly addresses tokenizer fertility for long-tail scripts?",
       "options": [
-        "More training epochs",
-        "Use byte-fallback (SentencePiece byte_fallback=True) or a tokenizer with broader script coverage (e.g. XLM-V)",
+        "Skip stopwords",
         "Lower batch size",
-        "Skip stopwords"
+        "Use byte-fallback (SentencePiece byte_fallback=True) or a tokenizer with broader script coverage (e.g. XLM-V)",
+        "More training epochs"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Byte fallback and broader-vocab tokenizers reduce fertility and OOV for low-resource scripts."
     },
     {
@@ -92,8 +92,8 @@
       "options": [
         "Always for English",
         "When the target language has enough data to train a monolingual model that beats the multilingual baseline; test before assuming",
-        "Whenever the tokenizer is BPE",
-        "Only for translation"
+        "Only for translation",
+        "Whenever the tokenizer is BPE"
       ],
       "correct": 1,
       "explanation": "Sometimes monolingual training beats multilingual for high-resource targets; empirical comparison decides."

--- a/phases/05-nlp-foundations-to-advanced/19-subword-tokenization/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/19-subword-tokenization/quiz.json
@@ -1,0 +1,102 @@
+{
+  "lesson": "19-subword-tokenization",
+  "title": "Subword Tokenization — BPE, WordPiece, Unigram, SentencePiece",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "What does subword tokenization buy you over word-level vocabularies?",
+      "options": [
+        "Smaller models",
+        "Rare words decompose into known subword pieces, eliminating OOV while keeping vocabulary bounded",
+        "Faster training",
+        "Better embeddings"
+      ],
+      "correct": 1,
+      "explanation": "Subword tokens cover any input by decomposition, removing the OOV problem of word-level vocab."
+    },
+    {
+      "stage": "pre",
+      "question": "Why does GPT-2 use byte-level BPE rather than character-level BPE?",
+      "options": [
+        "Bytes are smaller",
+        "A 256-byte base vocabulary covers any UTF-8 input, guaranteeing no [UNK] tokens",
+        "Byte BPE skips merges",
+        "Required by transformers"
+      ],
+      "correct": 1,
+      "explanation": "Byte-level BPE starts from 256 bytes so every input encodes; nothing is OOV."
+    },
+    {
+      "stage": "check",
+      "question": "How does the Unigram tokenizer build its vocabulary?",
+      "options": [
+        "Greedy frequent-pair merging",
+        "Start from a large candidate set, iteratively prune tokens whose removal least hurts corpus log-likelihood",
+        "Random sampling",
+        "Greedy IDF weighting"
+      ],
+      "correct": 1,
+      "explanation": "Unigram fits a unigram LM and iteratively removes the least useful tokens to reach target vocab size."
+    },
+    {
+      "stage": "check",
+      "question": "What distinguishes WordPiece's merge criterion from BPE's?",
+      "options": [
+        "WordPiece uses bytes",
+        "WordPiece merges pairs that maximize training-corpus likelihood, while BPE merges the most frequent pair",
+        "WordPiece skips merges",
+        "WordPiece is unsupervised"
+      ],
+      "correct": 1,
+      "explanation": "WordPiece picks merges by likelihood; BPE picks by raw frequency."
+    },
+    {
+      "stage": "check",
+      "question": "Which tool trains a tokenizer directly on raw multilingual Unicode text?",
+      "options": [
+        "tiktoken",
+        "SentencePiece (encodes whitespace as a special marker and trains BPE or Unigram)",
+        "tokenizers-lite",
+        "spaCy"
+      ],
+      "correct": 1,
+      "explanation": "SentencePiece trains BPE/Unigram on raw text without pre-tokenization; tiktoken only encodes."
+    },
+    {
+      "stage": "post",
+      "question": "Why must production CI hash-check the deployed tokenizer.json?",
+      "options": [
+        "To compress storage",
+        "Tokenizer drift produces different token IDs from those the model was trained on, silently corrupting outputs",
+        "Required by Hugging Face",
+        "It reduces vocabulary size"
+      ],
+      "correct": 1,
+      "explanation": "Even small tokenizer changes shift IDs; a hash check catches drift before it reaches users."
+    },
+    {
+      "stage": "post",
+      "question": "What is a common reason a single emoji takes many tokens?",
+      "options": [
+        "Emojis are stored as floats",
+        "Multi-codepoint emojis encode into multiple UTF-8 bytes; without dedicated tokens each byte is its own subword",
+        "Emojis are reserved",
+        "Emojis are stop characters"
+      ],
+      "correct": 1,
+      "explanation": "Composite emojis encode as several bytes; byte-level tokenizers may use multiple tokens per glyph."
+    },
+    {
+      "stage": "post",
+      "question": "What heuristic guides vocabulary size for a new monolingual transformer?",
+      "options": [
+        "Always 8000",
+        "Roughly 32k for models under 1B parameters; 50-100k for 1-10B; 200k+ for multilingual or frontier models",
+        "Match training corpus size",
+        "Always 1M"
+      ],
+      "correct": 1,
+      "explanation": "Vocab size scales with model and language coverage; these are rough community defaults."
+    }
+  ]
+}

--- a/phases/05-nlp-foundations-to-advanced/19-subword-tokenization/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/19-subword-tokenization/quiz.json
@@ -6,34 +6,34 @@
       "stage": "pre",
       "question": "What does subword tokenization buy you over word-level vocabularies?",
       "options": [
-        "Smaller models",
         "Rare words decompose into known subword pieces, eliminating OOV while keeping vocabulary bounded",
+        "Smaller models",
         "Faster training",
         "Better embeddings"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Subword tokens cover any input by decomposition, removing the OOV problem of word-level vocab."
     },
     {
       "stage": "pre",
       "question": "Why does GPT-2 use byte-level BPE rather than character-level BPE?",
       "options": [
-        "Bytes are smaller",
-        "A 256-byte base vocabulary covers any UTF-8 input, guaranteeing no [UNK] tokens",
+        "Required by transformers",
         "Byte BPE skips merges",
-        "Required by transformers"
+        "A 256-byte base vocabulary covers any UTF-8 input, guaranteeing no [UNK] tokens",
+        "Bytes are smaller"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Byte-level BPE starts from 256 bytes so every input encodes; nothing is OOV."
     },
     {
       "stage": "check",
       "question": "How does the Unigram tokenizer build its vocabulary?",
       "options": [
-        "Greedy frequent-pair merging",
+        "Greedy IDF weighting",
         "Start from a large candidate set, iteratively prune tokens whose removal least hurts corpus log-likelihood",
-        "Random sampling",
-        "Greedy IDF weighting"
+        "Greedy frequent-pair merging",
+        "Random sampling"
       ],
       "correct": 1,
       "explanation": "Unigram fits a unigram LM and iteratively removes the least useful tokens to reach target vocab size."
@@ -43,44 +43,44 @@
       "question": "What distinguishes WordPiece's merge criterion from BPE's?",
       "options": [
         "WordPiece uses bytes",
+        "WordPiece is unsupervised",
         "WordPiece merges pairs that maximize training-corpus likelihood, while BPE merges the most frequent pair",
-        "WordPiece skips merges",
-        "WordPiece is unsupervised"
+        "WordPiece skips merges"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "WordPiece picks merges by likelihood; BPE picks by raw frequency."
     },
     {
       "stage": "check",
       "question": "Which tool trains a tokenizer directly on raw multilingual Unicode text?",
       "options": [
+        "spaCy",
         "tiktoken",
-        "SentencePiece (encodes whitespace as a special marker and trains BPE or Unigram)",
         "tokenizers-lite",
-        "spaCy"
+        "SentencePiece (encodes whitespace as a special marker and trains BPE or Unigram)"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "SentencePiece trains BPE/Unigram on raw text without pre-tokenization; tiktoken only encodes."
     },
     {
       "stage": "post",
       "question": "Why must production CI hash-check the deployed tokenizer.json?",
       "options": [
-        "To compress storage",
         "Tokenizer drift produces different token IDs from those the model was trained on, silently corrupting outputs",
         "Required by Hugging Face",
+        "To compress storage",
         "It reduces vocabulary size"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Even small tokenizer changes shift IDs; a hash check catches drift before it reaches users."
     },
     {
       "stage": "post",
       "question": "What is a common reason a single emoji takes many tokens?",
       "options": [
-        "Emojis are stored as floats",
-        "Multi-codepoint emojis encode into multiple UTF-8 bytes; without dedicated tokens each byte is its own subword",
         "Emojis are reserved",
+        "Multi-codepoint emojis encode into multiple UTF-8 bytes; without dedicated tokens each byte is its own subword",
+        "Emojis are stored as floats",
         "Emojis are stop characters"
       ],
       "correct": 1,
@@ -91,11 +91,11 @@
       "question": "What heuristic guides vocabulary size for a new monolingual transformer?",
       "options": [
         "Always 8000",
+        "Always 1M",
         "Roughly 32k for models under 1B parameters; 50-100k for 1-10B; 200k+ for multilingual or frontier models",
-        "Match training corpus size",
-        "Always 1M"
+        "Match training corpus size"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Vocab size scales with model and language coverage; these are rough community defaults."
     }
   ]

--- a/phases/05-nlp-foundations-to-advanced/20-structured-outputs-constrained-decoding/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/20-structured-outputs-constrained-decoding/quiz.json
@@ -1,0 +1,102 @@
+{
+  "lesson": "20-structured-outputs-constrained-decoding",
+  "title": "Structured Outputs & Constrained Decoding",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "Why is prompt-only 'return JSON' not enough for production?",
+      "options": [
+        "JSON is too verbose",
+        "Frontier models comply most of the time but not always; the small fraction of malformed outputs breaks downstream parsers",
+        "Prompting cannot describe schemas",
+        "Prompts are too long"
+      ],
+      "correct": 1,
+      "explanation": "Prompt-only structure works ~80% of the time on frontier models; production needs harder guarantees."
+    },
+    {
+      "stage": "pre",
+      "question": "What does constrained decoding modify at each generation step?",
+      "options": [
+        "The training loss",
+        "The logit vector, masking tokens that would invalidate the target grammar so only valid continuations can be sampled",
+        "The tokenizer",
+        "The KV cache"
+      ],
+      "correct": 1,
+      "explanation": "A logit processor sets invalid tokens to -inf so the softmax cannot sample them."
+    },
+    {
+      "stage": "check",
+      "question": "Why might constrained decoding be faster than free generation?",
+      "options": [
+        "The model is smaller",
+        "Forced scaffold tokens (e.g. '{\"name\": \"') can be emitted directly without sampling, and the valid-token search space shrinks",
+        "It skips backprop",
+        "It avoids softmax entirely"
+      ],
+      "correct": 1,
+      "explanation": "Determined tokens skip sampling and reduced valid-token sets shrink the decode cost."
+    },
+    {
+      "stage": "check",
+      "question": "Which schema design choice prevents premature commitment by the model?",
+      "options": [
+        "Put 'answer' first",
+        "Place reasoning fields before the answer/decision field so the model thinks before committing",
+        "Use shorter keys",
+        "Use snake_case"
+      ],
+      "correct": 1,
+      "explanation": "Field order is logic: putting reasoning first lets the model think before locking in an answer."
+    },
+    {
+      "stage": "check",
+      "question": "What is the limitation of FSM-based constrained decoding tools like Outlines?",
+      "options": [
+        "They are not deterministic",
+        "Recursive schemas have to be flattened; truly recursive structures need CFG-based engines such as XGrammar",
+        "They lock you to OpenAI",
+        "They only support enums"
+      ],
+      "correct": 1,
+      "explanation": "FSMs cannot represent unbounded recursion; CFG engines handle it."
+    },
+    {
+      "stage": "post",
+      "question": "Why is Instructor described as not modifying logits?",
+      "options": [
+        "It edits the prompt",
+        "Instructor formats the schema into the prompt and parses/retries the output; logit masking happens server-side or not at all",
+        "Required by Anthropic",
+        "It uses gradient updates"
+      ],
+      "correct": 1,
+      "explanation": "Instructor uses provider-side structured output plus client-side validation and retries, not logit masking."
+    },
+    {
+      "stage": "post",
+      "question": "What problem can a strict regex like date='YYYY-MM-DD' introduce?",
+      "options": [
+        "Regex is slow",
+        "It removes any escape hatch for unknown values, so the model fabricates a date instead of returning null/sentinel",
+        "It requires CFG support",
+        "It breaks JSON parsing"
+      ],
+      "correct": 1,
+      "explanation": "Over-strict grammars force the model to invent values; always allow null/sentinel for unknowns."
+    },
+    {
+      "stage": "post",
+      "question": "When should you reach for vLLM guided decoding vs a vendor structured-output API?",
+      "options": [
+        "Always vendor",
+        "Self-hosted inference where you control the model and want logit-level guarantees without retries",
+        "Only for tiny schemas",
+        "Only with byte-level BPE"
+      ],
+      "correct": 1,
+      "explanation": "vLLM guided decoding fits self-hosted serving with logit-level constraints; vendor APIs lock you to their stack."
+    }
+  ]
+}

--- a/phases/05-nlp-foundations-to-advanced/20-structured-outputs-constrained-decoding/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/20-structured-outputs-constrained-decoding/quiz.json
@@ -7,23 +7,23 @@
       "question": "Why is prompt-only 'return JSON' not enough for production?",
       "options": [
         "JSON is too verbose",
+        "Prompts are too long",
         "Frontier models comply most of the time but not always; the small fraction of malformed outputs breaks downstream parsers",
-        "Prompting cannot describe schemas",
-        "Prompts are too long"
+        "Prompting cannot describe schemas"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Prompt-only structure works ~80% of the time on frontier models; production needs harder guarantees."
     },
     {
       "stage": "pre",
       "question": "What does constrained decoding modify at each generation step?",
       "options": [
-        "The training loss",
-        "The logit vector, masking tokens that would invalidate the target grammar so only valid continuations can be sampled",
+        "The KV cache",
         "The tokenizer",
-        "The KV cache"
+        "The training loss",
+        "The logit vector, masking tokens that would invalidate the target grammar so only valid continuations can be sampled"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "A logit processor sets invalid tokens to -inf so the softmax cannot sample them."
     },
     {
@@ -32,8 +32,8 @@
       "options": [
         "The model is smaller",
         "Forced scaffold tokens (e.g. '{\"name\": \"') can be emitted directly without sampling, and the valid-token search space shrinks",
-        "It skips backprop",
-        "It avoids softmax entirely"
+        "It avoids softmax entirely",
+        "It skips backprop"
       ],
       "correct": 1,
       "explanation": "Determined tokens skip sampling and reduced valid-token sets shrink the decode cost."
@@ -43,11 +43,11 @@
       "question": "Which schema design choice prevents premature commitment by the model?",
       "options": [
         "Put 'answer' first",
-        "Place reasoning fields before the answer/decision field so the model thinks before committing",
         "Use shorter keys",
+        "Place reasoning fields before the answer/decision field so the model thinks before committing",
         "Use snake_case"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Field order is logic: putting reasoning first lets the model think before locking in an answer."
     },
     {
@@ -55,33 +55,33 @@
       "question": "What is the limitation of FSM-based constrained decoding tools like Outlines?",
       "options": [
         "They are not deterministic",
-        "Recursive schemas have to be flattened; truly recursive structures need CFG-based engines such as XGrammar",
         "They lock you to OpenAI",
+        "Recursive schemas have to be flattened; truly recursive structures need CFG-based engines such as XGrammar",
         "They only support enums"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "FSMs cannot represent unbounded recursion; CFG engines handle it."
     },
     {
       "stage": "post",
       "question": "Why is Instructor described as not modifying logits?",
       "options": [
-        "It edits the prompt",
         "Instructor formats the schema into the prompt and parses/retries the output; logit masking happens server-side or not at all",
+        "It uses gradient updates",
         "Required by Anthropic",
-        "It uses gradient updates"
+        "It edits the prompt"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Instructor uses provider-side structured output plus client-side validation and retries, not logit masking."
     },
     {
       "stage": "post",
       "question": "What problem can a strict regex like date='YYYY-MM-DD' introduce?",
       "options": [
-        "Regex is slow",
-        "It removes any escape hatch for unknown values, so the model fabricates a date instead of returning null/sentinel",
         "It requires CFG support",
-        "It breaks JSON parsing"
+        "It removes any escape hatch for unknown values, so the model fabricates a date instead of returning null/sentinel",
+        "It breaks JSON parsing",
+        "Regex is slow"
       ],
       "correct": 1,
       "explanation": "Over-strict grammars force the model to invent values; always allow null/sentinel for unknowns."
@@ -91,11 +91,11 @@
       "question": "When should you reach for vLLM guided decoding vs a vendor structured-output API?",
       "options": [
         "Always vendor",
-        "Self-hosted inference where you control the model and want logit-level guarantees without retries",
         "Only for tiny schemas",
-        "Only with byte-level BPE"
+        "Only with byte-level BPE",
+        "Self-hosted inference where you control the model and want logit-level guarantees without retries"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "vLLM guided decoding fits self-hosted serving with logit-level constraints; vendor APIs lock you to their stack."
     }
   ]

--- a/phases/05-nlp-foundations-to-advanced/21-nli-textual-entailment/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/21-nli-textual-entailment/quiz.json
@@ -6,33 +6,33 @@
       "stage": "pre",
       "question": "What three labels does NLI assign to a (premise, hypothesis) pair?",
       "options": [
+        "Positive / negative / neutral",
         "True / false / unknown",
         "Entailment / contradiction / neutral",
-        "Positive / negative / neutral",
         "Cause / effect / unrelated"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "NLI is a 3-way classification over entailment, contradiction, and neutral."
     },
     {
       "stage": "pre",
       "question": "How is NLI used as a zero-shot text classifier?",
       "options": [
-        "By prompting an LLM",
         "Verbalize each candidate label as a hypothesis (e.g. 'This text is about sports') and pick the label with the highest entailment score",
+        "By averaging embeddings",
         "By computing TF-IDF",
-        "By averaging embeddings"
+        "By prompting an LLM"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "NLI-as-classifier turns labels into hypotheses; the model picks the max-entailment label."
     },
     {
       "stage": "check",
       "question": "Why is NLI a faithfulness check for RAG outputs?",
       "options": [
-        "It is cheap",
-        "Checking whether the retrieved context entails each answer claim is exactly the formulation NLI was trained on",
         "It uses tokenizers",
+        "Checking whether the retrieved context entails each answer claim is exactly the formulation NLI was trained on",
+        "It is cheap",
         "It is multilingual"
       ],
       "correct": 1,
@@ -42,58 +42,58 @@
       "stage": "check",
       "question": "What does the hypothesis-only baseline expose?",
       "options": [
-        "Tokenizer drift",
-        "Datasets where the hypothesis alone (without the premise) is predictive of the label, signalling label leakage",
+        "Multilingual gaps",
         "Slow inference",
-        "Multilingual gaps"
+        "Datasets where the hypothesis alone (without the premise) is predictive of the label, signalling label leakage",
+        "Tokenizer drift"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "A high hypothesis-only score on SNLI revealed annotation artifacts; useful for debugging your data."
     },
     {
       "stage": "check",
       "question": "Which NLI model family tops 2026 leaderboards as the standard workhorse?",
       "options": [
-        "GPT-2",
-        "DeBERTa-v3 variants fine-tuned on MNLI/FEVER/ANLI",
+        "fastText",
         "Plain Word2Vec",
-        "fastText"
+        "DeBERTa-v3 variants fine-tuned on MNLI/FEVER/ANLI",
+        "GPT-2"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "DeBERTa-v3 fine-tuned on MNLI and related corpora is the open NLI workhorse in 2026."
     },
     {
       "stage": "post",
       "question": "Why do sentence-level NLI models drop accuracy on document-length premises?",
       "options": [
-        "Larger inputs run slower",
         "They were trained on short premises and fail at multi-sentence and multi-hop inference; DocNLI-tuned models handle longer inputs",
+        "Larger inputs run slower",
         "Documents trigger tokenizer drift",
         "Cosine similarity decays"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Training distribution mismatch: single-sentence NLI models lose 20+ F1 on document-length inputs."
     },
     {
       "stage": "post",
       "question": "Why can zero-shot accuracy swing 10+ points based on the hypothesis template?",
       "options": [
-        "Templates change tokenizer behavior",
         "Models are sensitive to phrasing; e.g. 'This text is about {label}' vs '{label}' alone shifts entailment probabilities",
+        "Templates change tokenizer behavior",
         "Templates affect model weights",
         "Templates change the label set"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Template wording materially shifts entailment scores; tune it on a small held-out set."
     },
     {
       "stage": "post",
       "question": "What is a safe limit to claim about NLI for hallucination detection?",
       "options": [
-        "It eliminates hallucination",
+        "It only works on English",
         "It reduces hallucination as a faithfulness signal but does not eliminate it; combine with retrieval recall and human review",
-        "It requires LLMs",
-        "It only works on English"
+        "It eliminates hallucination",
+        "It requires LLMs"
       ],
       "correct": 1,
       "explanation": "NLI is a useful signal but not a complete solution; pair with retrieval metrics and human spot-checks."

--- a/phases/05-nlp-foundations-to-advanced/21-nli-textual-entailment/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/21-nli-textual-entailment/quiz.json
@@ -1,0 +1,102 @@
+{
+  "lesson": "21-nli-textual-entailment",
+  "title": "Natural Language Inference — Textual Entailment",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "What three labels does NLI assign to a (premise, hypothesis) pair?",
+      "options": [
+        "True / false / unknown",
+        "Entailment / contradiction / neutral",
+        "Positive / negative / neutral",
+        "Cause / effect / unrelated"
+      ],
+      "correct": 1,
+      "explanation": "NLI is a 3-way classification over entailment, contradiction, and neutral."
+    },
+    {
+      "stage": "pre",
+      "question": "How is NLI used as a zero-shot text classifier?",
+      "options": [
+        "By prompting an LLM",
+        "Verbalize each candidate label as a hypothesis (e.g. 'This text is about sports') and pick the label with the highest entailment score",
+        "By computing TF-IDF",
+        "By averaging embeddings"
+      ],
+      "correct": 1,
+      "explanation": "NLI-as-classifier turns labels into hypotheses; the model picks the max-entailment label."
+    },
+    {
+      "stage": "check",
+      "question": "Why is NLI a faithfulness check for RAG outputs?",
+      "options": [
+        "It is cheap",
+        "Checking whether the retrieved context entails each answer claim is exactly the formulation NLI was trained on",
+        "It uses tokenizers",
+        "It is multilingual"
+      ],
+      "correct": 1,
+      "explanation": "Hallucination = answer claims not entailed by retrieved context; NLI directly measures entailment."
+    },
+    {
+      "stage": "check",
+      "question": "What does the hypothesis-only baseline expose?",
+      "options": [
+        "Tokenizer drift",
+        "Datasets where the hypothesis alone (without the premise) is predictive of the label, signalling label leakage",
+        "Slow inference",
+        "Multilingual gaps"
+      ],
+      "correct": 1,
+      "explanation": "A high hypothesis-only score on SNLI revealed annotation artifacts; useful for debugging your data."
+    },
+    {
+      "stage": "check",
+      "question": "Which NLI model family tops 2026 leaderboards as the standard workhorse?",
+      "options": [
+        "GPT-2",
+        "DeBERTa-v3 variants fine-tuned on MNLI/FEVER/ANLI",
+        "Plain Word2Vec",
+        "fastText"
+      ],
+      "correct": 1,
+      "explanation": "DeBERTa-v3 fine-tuned on MNLI and related corpora is the open NLI workhorse in 2026."
+    },
+    {
+      "stage": "post",
+      "question": "Why do sentence-level NLI models drop accuracy on document-length premises?",
+      "options": [
+        "Larger inputs run slower",
+        "They were trained on short premises and fail at multi-sentence and multi-hop inference; DocNLI-tuned models handle longer inputs",
+        "Documents trigger tokenizer drift",
+        "Cosine similarity decays"
+      ],
+      "correct": 1,
+      "explanation": "Training distribution mismatch: single-sentence NLI models lose 20+ F1 on document-length inputs."
+    },
+    {
+      "stage": "post",
+      "question": "Why can zero-shot accuracy swing 10+ points based on the hypothesis template?",
+      "options": [
+        "Templates change tokenizer behavior",
+        "Models are sensitive to phrasing; e.g. 'This text is about {label}' vs '{label}' alone shifts entailment probabilities",
+        "Templates affect model weights",
+        "Templates change the label set"
+      ],
+      "correct": 1,
+      "explanation": "Template wording materially shifts entailment scores; tune it on a small held-out set."
+    },
+    {
+      "stage": "post",
+      "question": "What is a safe limit to claim about NLI for hallucination detection?",
+      "options": [
+        "It eliminates hallucination",
+        "It reduces hallucination as a faithfulness signal but does not eliminate it; combine with retrieval recall and human review",
+        "It requires LLMs",
+        "It only works on English"
+      ],
+      "correct": 1,
+      "explanation": "NLI is a useful signal but not a complete solution; pair with retrieval metrics and human spot-checks."
+    }
+  ]
+}

--- a/phases/05-nlp-foundations-to-advanced/22-embedding-models-deep-dive/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/22-embedding-models-deep-dive/quiz.json
@@ -1,0 +1,102 @@
+{
+  "lesson": "22-embedding-models-deep-dive",
+  "title": "Embedding Models — The 2026 Deep Dive",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "What is a dense embedding?",
+      "options": [
+        "A sparse weight per vocab token",
+        "One fixed-size vector per text where cosine similarity ranks passages by semantic proximity",
+        "A graph over documents",
+        "A token-level alignment matrix"
+      ],
+      "correct": 1,
+      "explanation": "Dense embeddings give one vector per text (typically 384-3072 dim); cosine ranks similarity."
+    },
+    {
+      "stage": "pre",
+      "question": "What does Matryoshka Representation Learning enable?",
+      "options": [
+        "Faster softmax",
+        "Truncating a trained embedding to its first N dimensions and getting a still-useful smaller embedding",
+        "Multilingual training",
+        "Cross-encoder rescoring"
+      ],
+      "correct": 1,
+      "explanation": "Matryoshka training makes the first N dims of the vector standalone-useful, enabling cheap truncation."
+    },
+    {
+      "stage": "check",
+      "question": "How do multi-vector (ColBERT) embeddings score query-doc pairs?",
+      "options": [
+        "Cosine of mean-pooled token vectors",
+        "MaxSim: for each query token find the most similar document token, then sum the maxima",
+        "Cross-entropy",
+        "Earth-mover's distance"
+      ],
+      "correct": 1,
+      "explanation": "ColBERT-style late interaction uses MaxSim across per-token vectors."
+    },
+    {
+      "stage": "check",
+      "question": "What does BGE-M3 output simultaneously?",
+      "options": [
+        "Only a dense vector",
+        "Dense, sparse, and multi-vector (colbert) representations from one model in a single inference",
+        "Only a sparse vector",
+        "Only a colbert vector"
+      ],
+      "correct": 1,
+      "explanation": "BGE-M3 emits three retrieval modes from one model, useful for fused hybrid scoring."
+    },
+    {
+      "stage": "check",
+      "question": "Why must you re-normalize a Matryoshka-truncated vector before cosine similarity?",
+      "options": [
+        "Cosine ignores normalization",
+        "Truncation changes the vector norm; without re-normalizing, dot product no longer equals cosine",
+        "Required by FAISS only",
+        "Truncation breaks training"
+      ],
+      "correct": 1,
+      "explanation": "Re-normalizing after truncation restores unit norm so dot product equals cosine again."
+    },
+    {
+      "stage": "post",
+      "question": "Why do BGE models often need a query-side prefix string?",
+      "options": [
+        "To compress queries",
+        "BGE was trained with an explicit query prompt; omitting it costs 3-5 points recall",
+        "Required by FAISS",
+        "Prefixes change tokenizer behavior"
+      ],
+      "correct": 1,
+      "explanation": "BGE models expect a 'Represent this sentence for searching...' prefix on queries."
+    },
+    {
+      "stage": "post",
+      "question": "Why is MTEB necessary but not sufficient for picking an embedding model?",
+      "options": [
+        "MTEB only covers English",
+        "Leaderboard ranks are average across many tasks; your specific domain may differ, so always benchmark on your data",
+        "MTEB ignores latency",
+        "MTEB rewards bigger models"
+      ],
+      "correct": 1,
+      "explanation": "MTEB averages across tasks; domain-specific eval can flip the ranking."
+    },
+    {
+      "stage": "post",
+      "question": "When should you add SPLADE sparse retrieval alongside dense embeddings?",
+      "options": [
+        "On small corpora only",
+        "When queries are keyword-heavy or contain identifiers/codes that dense embeddings blur",
+        "Whenever the encoder is multilingual",
+        "Whenever Matryoshka is used"
+      ],
+      "correct": 1,
+      "explanation": "SPLADE captures lexical/keyword matches that dense models can miss; fuse with dense via RRF."
+    }
+  ]
+}

--- a/phases/05-nlp-foundations-to-advanced/22-embedding-models-deep-dive/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/22-embedding-models-deep-dive/quiz.json
@@ -6,24 +6,24 @@
       "stage": "pre",
       "question": "What is a dense embedding?",
       "options": [
-        "A sparse weight per vocab token",
-        "One fixed-size vector per text where cosine similarity ranks passages by semantic proximity",
         "A graph over documents",
-        "A token-level alignment matrix"
+        "A sparse weight per vocab token",
+        "A token-level alignment matrix",
+        "One fixed-size vector per text where cosine similarity ranks passages by semantic proximity"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "Dense embeddings give one vector per text (typically 384-3072 dim); cosine ranks similarity."
     },
     {
       "stage": "pre",
       "question": "What does Matryoshka Representation Learning enable?",
       "options": [
+        "Multilingual training",
         "Faster softmax",
         "Truncating a trained embedding to its first N dimensions and getting a still-useful smaller embedding",
-        "Multilingual training",
         "Cross-encoder rescoring"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Matryoshka training makes the first N dims of the vector standalone-useful, enabling cheap truncation."
     },
     {
@@ -31,33 +31,33 @@
       "question": "How do multi-vector (ColBERT) embeddings score query-doc pairs?",
       "options": [
         "Cosine of mean-pooled token vectors",
-        "MaxSim: for each query token find the most similar document token, then sum the maxima",
         "Cross-entropy",
-        "Earth-mover's distance"
+        "Earth-mover's distance",
+        "MaxSim: for each query token find the most similar document token, then sum the maxima"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "ColBERT-style late interaction uses MaxSim across per-token vectors."
     },
     {
       "stage": "check",
       "question": "What does BGE-M3 output simultaneously?",
       "options": [
+        "Only a sparse vector",
         "Only a dense vector",
         "Dense, sparse, and multi-vector (colbert) representations from one model in a single inference",
-        "Only a sparse vector",
         "Only a colbert vector"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "BGE-M3 emits three retrieval modes from one model, useful for fused hybrid scoring."
     },
     {
       "stage": "check",
       "question": "Why must you re-normalize a Matryoshka-truncated vector before cosine similarity?",
       "options": [
-        "Cosine ignores normalization",
+        "Truncation breaks training",
         "Truncation changes the vector norm; without re-normalizing, dot product no longer equals cosine",
-        "Required by FAISS only",
-        "Truncation breaks training"
+        "Cosine ignores normalization",
+        "Required by FAISS only"
       ],
       "correct": 1,
       "explanation": "Re-normalizing after truncation restores unit norm so dot product equals cosine again."
@@ -67,11 +67,11 @@
       "question": "Why do BGE models often need a query-side prefix string?",
       "options": [
         "To compress queries",
-        "BGE was trained with an explicit query prompt; omitting it costs 3-5 points recall",
         "Required by FAISS",
+        "BGE was trained with an explicit query prompt; omitting it costs 3-5 points recall",
         "Prefixes change tokenizer behavior"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "BGE models expect a 'Represent this sentence for searching...' prefix on queries."
     },
     {
@@ -79,23 +79,23 @@
       "question": "Why is MTEB necessary but not sufficient for picking an embedding model?",
       "options": [
         "MTEB only covers English",
-        "Leaderboard ranks are average across many tasks; your specific domain may differ, so always benchmark on your data",
         "MTEB ignores latency",
+        "Leaderboard ranks are average across many tasks; your specific domain may differ, so always benchmark on your data",
         "MTEB rewards bigger models"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "MTEB averages across tasks; domain-specific eval can flip the ranking."
     },
     {
       "stage": "post",
       "question": "When should you add SPLADE sparse retrieval alongside dense embeddings?",
       "options": [
-        "On small corpora only",
-        "When queries are keyword-heavy or contain identifiers/codes that dense embeddings blur",
         "Whenever the encoder is multilingual",
-        "Whenever Matryoshka is used"
+        "Whenever Matryoshka is used",
+        "When queries are keyword-heavy or contain identifiers/codes that dense embeddings blur",
+        "On small corpora only"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "SPLADE captures lexical/keyword matches that dense models can miss; fuse with dense via RRF."
     }
   ]

--- a/phases/05-nlp-foundations-to-advanced/23-chunking-strategies-rag/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/23-chunking-strategies-rag/quiz.json
@@ -1,0 +1,102 @@
+{
+  "lesson": "23-chunking-strategies-rag",
+  "title": "Chunking Strategies for RAG",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "Why is chunking strategy as important as the embedding model in RAG?",
+      "options": [
+        "Smaller chunks train faster",
+        "Chunk boundaries determine whether the answer is even retrievable; bad chunks defeat any embedding",
+        "Chunking shrinks the model",
+        "Chunking is required by FAISS"
+      ],
+      "correct": 1,
+      "explanation": "Vectara's 2025 study showed chunking quality matches or exceeds embedding-model impact on retrieval quality."
+    },
+    {
+      "stage": "pre",
+      "question": "What does LangChain's RecursiveCharacterTextSplitter try in order?",
+      "options": [
+        "Split on whitespace only",
+        "Try splitting on paragraph breaks, then newlines, then sentence boundaries, then spaces",
+        "Always split on character N",
+        "Split on token IDs"
+      ],
+      "correct": 1,
+      "explanation": "Recursive splitting falls back through paragraph -> newline -> sentence -> space to preserve structure."
+    },
+    {
+      "stage": "check",
+      "question": "Why does the parent-document pattern improve answer quality?",
+      "options": [
+        "It removes embeddings",
+        "Children give precise retrieval; returning the larger parent block preserves the surrounding context the reader needs",
+        "It avoids tokenization",
+        "It uses fewer GPU cycles"
+      ],
+      "correct": 1,
+      "explanation": "Retrieve by small child chunks for precision, then expand to the parent for context."
+    },
+    {
+      "stage": "check",
+      "question": "What does Anthropic's 'contextual retrieval' add to each chunk before indexing?",
+      "options": [
+        "Random noise",
+        "An LLM-generated 50-100 word summary placing the chunk in the document's overall context",
+        "A POS tag",
+        "A language code"
+      ],
+      "correct": 1,
+      "explanation": "Contextual retrieval prepends an LLM-written situating summary to each chunk; ~35-50% recall gain."
+    },
+    {
+      "stage": "check",
+      "question": "Which 2026 finding contradicts the conventional wisdom about chunk overlap?",
+      "options": [
+        "Overlap should be 50%",
+        "Empirical 2026 benchmarks show overlap often provides zero measurable benefit while doubling index cost",
+        "Overlap is required for BM25",
+        "Overlap improves contextual retrieval only"
+      ],
+      "correct": 1,
+      "explanation": "Newer studies (SPLADE+Mistral on NQ) show chunk overlap rarely helps and inflates index size."
+    },
+    {
+      "stage": "post",
+      "question": "Which chunk size does NVIDIA's 2026 benchmark associate with factoid queries?",
+      "options": [
+        "2048-4096 tokens",
+        "Roughly 256-512 tokens",
+        "8192 tokens",
+        "64 tokens"
+      ],
+      "correct": 1,
+      "explanation": "Factoid queries benefit from smaller chunks (256-512 tokens) that concentrate the answer signal."
+    },
+    {
+      "stage": "post",
+      "question": "Why is a min-token floor important when using semantic chunking?",
+      "options": [
+        "Required by BERT",
+        "Without a floor, semantic chunking can produce tiny 40-token fragments that hurt retrieval",
+        "Floors speed up inference",
+        "Floors prevent overlap"
+      ],
+      "correct": 1,
+      "explanation": "Semantic chunkers can over-segment; enforcing a min size prevents low-signal fragments."
+    },
+    {
+      "stage": "post",
+      "question": "What does 'late chunking' do differently from traditional chunking?",
+      "options": [
+        "Skips chunking entirely",
+        "Embeds the whole document at the token level first, then pools token embeddings into chunk vectors to preserve cross-chunk context",
+        "Chunks after retrieval",
+        "Uses BM25 instead"
+      ],
+      "correct": 1,
+      "explanation": "Late chunking embeds first and pools second, preserving contextual interactions across chunk boundaries."
+    }
+  ]
+}

--- a/phases/05-nlp-foundations-to-advanced/23-chunking-strategies-rag/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/23-chunking-strategies-rag/quiz.json
@@ -6,58 +6,58 @@
       "stage": "pre",
       "question": "Why is chunking strategy as important as the embedding model in RAG?",
       "options": [
-        "Smaller chunks train faster",
         "Chunk boundaries determine whether the answer is even retrievable; bad chunks defeat any embedding",
         "Chunking shrinks the model",
+        "Smaller chunks train faster",
         "Chunking is required by FAISS"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Vectara's 2025 study showed chunking quality matches or exceeds embedding-model impact on retrieval quality."
     },
     {
       "stage": "pre",
       "question": "What does LangChain's RecursiveCharacterTextSplitter try in order?",
       "options": [
-        "Split on whitespace only",
-        "Try splitting on paragraph breaks, then newlines, then sentence boundaries, then spaces",
         "Always split on character N",
-        "Split on token IDs"
+        "Split on token IDs",
+        "Try splitting on paragraph breaks, then newlines, then sentence boundaries, then spaces",
+        "Split on whitespace only"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Recursive splitting falls back through paragraph -> newline -> sentence -> space to preserve structure."
     },
     {
       "stage": "check",
       "question": "Why does the parent-document pattern improve answer quality?",
       "options": [
-        "It removes embeddings",
         "Children give precise retrieval; returning the larger parent block preserves the surrounding context the reader needs",
+        "It removes embeddings",
         "It avoids tokenization",
         "It uses fewer GPU cycles"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Retrieve by small child chunks for precision, then expand to the parent for context."
     },
     {
       "stage": "check",
       "question": "What does Anthropic's 'contextual retrieval' add to each chunk before indexing?",
       "options": [
-        "Random noise",
-        "An LLM-generated 50-100 word summary placing the chunk in the document's overall context",
         "A POS tag",
-        "A language code"
+        "A language code",
+        "An LLM-generated 50-100 word summary placing the chunk in the document's overall context",
+        "Random noise"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Contextual retrieval prepends an LLM-written situating summary to each chunk; ~35-50% recall gain."
     },
     {
       "stage": "check",
       "question": "Which 2026 finding contradicts the conventional wisdom about chunk overlap?",
       "options": [
-        "Overlap should be 50%",
-        "Empirical 2026 benchmarks show overlap often provides zero measurable benefit while doubling index cost",
         "Overlap is required for BM25",
-        "Overlap improves contextual retrieval only"
+        "Empirical 2026 benchmarks show overlap often provides zero measurable benefit while doubling index cost",
+        "Overlap improves contextual retrieval only",
+        "Overlap should be 50%"
       ],
       "correct": 1,
       "explanation": "Newer studies (SPLADE+Mistral on NQ) show chunk overlap rarely helps and inflates index size."
@@ -66,10 +66,10 @@
       "stage": "post",
       "question": "Which chunk size does NVIDIA's 2026 benchmark associate with factoid queries?",
       "options": [
-        "2048-4096 tokens",
+        "64 tokens",
         "Roughly 256-512 tokens",
-        "8192 tokens",
-        "64 tokens"
+        "2048-4096 tokens",
+        "8192 tokens"
       ],
       "correct": 1,
       "explanation": "Factoid queries benefit from smaller chunks (256-512 tokens) that concentrate the answer signal."

--- a/phases/05-nlp-foundations-to-advanced/24-coreference-resolution/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/24-coreference-resolution/quiz.json
@@ -1,0 +1,102 @@
+{
+  "lesson": "24-coreference-resolution",
+  "title": "Coreference Resolution",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "What is the goal of coreference resolution?",
+      "options": [
+        "Translate pronouns to nouns",
+        "Cluster all mentions (named, nominal, pronominal) that refer to the same real-world entity",
+        "Tag parts of speech",
+        "Extract relations"
+      ],
+      "correct": 1,
+      "explanation": "Coref clusters mention spans that all refer to the same entity."
+    },
+    {
+      "stage": "pre",
+      "question": "Which type of expression is a 'nominal' mention?",
+      "options": [
+        "A pronoun like 'she'",
+        "A noun phrase such as 'the CEO' or 'the company'",
+        "A proper noun only",
+        "A verb"
+      ],
+      "correct": 1,
+      "explanation": "Nominal mentions are noun phrases like 'the company'; pronominal mentions are pronouns."
+    },
+    {
+      "stage": "check",
+      "question": "What is the modern (Lee et al., 2017) coref architecture?",
+      "options": [
+        "Rule-based syntactic parsing only",
+        "End-to-end span-based: enumerate spans, score mentions, then score antecedent probabilities and cluster greedily",
+        "BM25 retrieval",
+        "Decision trees"
+      ],
+      "correct": 1,
+      "explanation": "End-to-end neural coref enumerates spans and learns mention + antecedent scoring jointly."
+    },
+    {
+      "stage": "check",
+      "question": "What does CoNLL F1 average?",
+      "options": [
+        "Precision and recall",
+        "MUC, B-cubed, and CEAF-phi4 F1 scores",
+        "F1 across languages",
+        "Token and span F1"
+      ],
+      "correct": 1,
+      "explanation": "CoNLL F1 is the mean of MUC, B-cubed, and CEAF-phi4 metrics."
+    },
+    {
+      "stage": "check",
+      "question": "What is bridging anaphora?",
+      "options": [
+        "A pronoun before its referent",
+        "An implicit reference like 'the wheels' implying the wheels of a previously mentioned car",
+        "A mistranslation",
+        "A pronoun without an antecedent"
+      ],
+      "correct": 1,
+      "explanation": "Bridging links a mention to a part-of or related entity that was implied but not explicitly stated."
+    },
+    {
+      "stage": "post",
+      "question": "Why is LLM-only coref unreliable on long documents?",
+      "options": [
+        "LLMs cannot read text",
+        "Single-call LLMs over-merge or silently drop mentions across 50+ paragraphs; require sliding-window plus merge",
+        "Tokenizers fail",
+        "Coref requires a CFG"
+      ],
+      "correct": 1,
+      "explanation": "Long-doc LLM coref degrades; sliding-window with cross-window merging mitigates."
+    },
+    {
+      "stage": "post",
+      "question": "Why merge coref clusters into NER results before downstream tasks?",
+      "options": [
+        "Lower latency",
+        "So downstream tasks see one entity per cluster rather than one per surface mention, dramatically improving coverage",
+        "To increase token count",
+        "Required by Wikidata"
+      ],
+      "correct": 1,
+      "explanation": "Without merging, NER counts each surface form separately and misses 60-80% of entity mentions."
+    },
+    {
+      "stage": "post",
+      "question": "Why are hard-coded gender rules a fragility in coref systems?",
+      "options": [
+        "They run too fast",
+        "They break on non-binary referents, organizations, and animals; learned scoring is more robust",
+        "They require GPU",
+        "They cannot use POS tags"
+      ],
+      "correct": 1,
+      "explanation": "Gender heuristics fail in demographically diverse text; learned models are preferred."
+    }
+  ]
+}

--- a/phases/05-nlp-foundations-to-advanced/24-coreference-resolution/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/24-coreference-resolution/quiz.json
@@ -6,21 +6,21 @@
       "stage": "pre",
       "question": "What is the goal of coreference resolution?",
       "options": [
-        "Translate pronouns to nouns",
         "Cluster all mentions (named, nominal, pronominal) that refer to the same real-world entity",
         "Tag parts of speech",
-        "Extract relations"
+        "Extract relations",
+        "Translate pronouns to nouns"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Coref clusters mention spans that all refer to the same entity."
     },
     {
       "stage": "pre",
       "question": "Which type of expression is a 'nominal' mention?",
       "options": [
-        "A pronoun like 'she'",
-        "A noun phrase such as 'the CEO' or 'the company'",
         "A proper noun only",
+        "A noun phrase such as 'the CEO' or 'the company'",
+        "A pronoun like 'she'",
         "A verb"
       ],
       "correct": 1,
@@ -30,22 +30,22 @@
       "stage": "check",
       "question": "What is the modern (Lee et al., 2017) coref architecture?",
       "options": [
-        "Rule-based syntactic parsing only",
-        "End-to-end span-based: enumerate spans, score mentions, then score antecedent probabilities and cluster greedily",
         "BM25 retrieval",
-        "Decision trees"
+        "Rule-based syntactic parsing only",
+        "Decision trees",
+        "End-to-end span-based: enumerate spans, score mentions, then score antecedent probabilities and cluster greedily"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "End-to-end neural coref enumerates spans and learns mention + antecedent scoring jointly."
     },
     {
       "stage": "check",
       "question": "What does CoNLL F1 average?",
       "options": [
-        "Precision and recall",
-        "MUC, B-cubed, and CEAF-phi4 F1 scores",
         "F1 across languages",
-        "Token and span F1"
+        "MUC, B-cubed, and CEAF-phi4 F1 scores",
+        "Token and span F1",
+        "Precision and recall"
       ],
       "correct": 1,
       "explanation": "CoNLL F1 is the mean of MUC, B-cubed, and CEAF-phi4 metrics."
@@ -54,9 +54,9 @@
       "stage": "check",
       "question": "What is bridging anaphora?",
       "options": [
-        "A pronoun before its referent",
-        "An implicit reference like 'the wheels' implying the wheels of a previously mentioned car",
         "A mistranslation",
+        "An implicit reference like 'the wheels' implying the wheels of a previously mentioned car",
+        "A pronoun before its referent",
         "A pronoun without an antecedent"
       ],
       "correct": 1,
@@ -67,35 +67,35 @@
       "question": "Why is LLM-only coref unreliable on long documents?",
       "options": [
         "LLMs cannot read text",
-        "Single-call LLMs over-merge or silently drop mentions across 50+ paragraphs; require sliding-window plus merge",
         "Tokenizers fail",
+        "Single-call LLMs over-merge or silently drop mentions across 50+ paragraphs; require sliding-window plus merge",
         "Coref requires a CFG"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Long-doc LLM coref degrades; sliding-window with cross-window merging mitigates."
     },
     {
       "stage": "post",
       "question": "Why merge coref clusters into NER results before downstream tasks?",
       "options": [
-        "Lower latency",
-        "So downstream tasks see one entity per cluster rather than one per surface mention, dramatically improving coverage",
+        "Required by Wikidata",
         "To increase token count",
-        "Required by Wikidata"
+        "Lower latency",
+        "So downstream tasks see one entity per cluster rather than one per surface mention, dramatically improving coverage"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "Without merging, NER counts each surface form separately and misses 60-80% of entity mentions."
     },
     {
       "stage": "post",
       "question": "Why are hard-coded gender rules a fragility in coref systems?",
       "options": [
-        "They run too fast",
         "They break on non-binary referents, organizations, and animals; learned scoring is more robust",
         "They require GPU",
+        "They run too fast",
         "They cannot use POS tags"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Gender heuristics fail in demographically diverse text; learned models are preferred."
     }
   ]

--- a/phases/05-nlp-foundations-to-advanced/25-entity-linking/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/25-entity-linking/quiz.json
@@ -1,0 +1,102 @@
+{
+  "lesson": "25-entity-linking",
+  "title": "Entity Linking & Disambiguation",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "What does entity linking add on top of NER?",
+      "options": [
+        "Part-of-speech tags",
+        "It maps each detected mention to a unique entry in a knowledge base (Wikidata, Wikipedia, or a domain KB)",
+        "Sentiment polarity",
+        "Translations"
+      ],
+      "correct": 1,
+      "explanation": "EL turns a mention into a canonical KB id, disambiguating between same-name entities."
+    },
+    {
+      "stage": "pre",
+      "question": "What are the two main subtasks in entity linking?",
+      "options": [
+        "Tokenization and parsing",
+        "Candidate generation (shortlist of plausible KB entries) and disambiguation (pick the right one given context)",
+        "POS tagging and lemmatization",
+        "Embedding and clustering"
+      ],
+      "correct": 1,
+      "explanation": "EL decomposes into proposing candidates then ranking them by contextual fit."
+    },
+    {
+      "stage": "check",
+      "question": "Why must mention recall be reported alongside disambiguation accuracy?",
+      "options": [
+        "Mention recall is mandatory by GDPR",
+        "Disambiguation cannot recover from missing candidates; the pipeline is bounded by candidate-generation recall",
+        "Recall is required by spaCy",
+        "Recall replaces precision"
+      ],
+      "correct": 1,
+      "explanation": "If candidates miss the gold entity, no disambiguator can fix it; recall floors pipeline quality."
+    },
+    {
+      "stage": "check",
+      "question": "How does GENRE perform entity linking?",
+      "options": [
+        "By computing TF-IDF",
+        "Decodes the entity's canonical name token-by-token under constrained decoding over a trie of valid KB ids",
+        "By BM25",
+        "By PageRank"
+      ],
+      "correct": 1,
+      "explanation": "GENRE generates the canonical KB name with constrained decoding to guarantee a valid id."
+    },
+    {
+      "stage": "check",
+      "question": "What is NIL handling in entity linking?",
+      "options": [
+        "Skipping every mention",
+        "Predicting a 'not in KB' label when no candidate is a real match (emerging entities, obscure people)",
+        "Returning the entire candidate list",
+        "Lowercasing the input"
+      ],
+      "correct": 1,
+      "explanation": "NIL prediction prevents guessing wrong KB ids for entities the KB does not cover."
+    },
+    {
+      "stage": "post",
+      "question": "Why does popularity bias hurt entity linking in specialized domains?",
+      "options": [
+        "It biases toward older entities only",
+        "Models trained on web data over-predict frequent entities (e.g. basketball Jordan over the ML researcher Michael I. Jordan)",
+        "Popularity helps recall",
+        "Popularity removes NIL"
+      ],
+      "correct": 1,
+      "explanation": "Popularity priors skew predictions away from less-common, domain-specific name-clashes."
+    },
+    {
+      "stage": "post",
+      "question": "What is a safe LLM-EL pattern in 2026?",
+      "options": [
+        "Free-form generation",
+        "Provide a candidate list and use constrained JSON output that the LLM can only choose from valid KB ids",
+        "Just prompt 'find the entity'",
+        "Skip candidate generation"
+      ],
+      "correct": 1,
+      "explanation": "Constraining the LLM to a valid candidate list prevents made-up KB ids and keeps output queryable."
+    },
+    {
+      "stage": "post",
+      "question": "Why must NER mention boundaries be exact for entity linking to work?",
+      "options": [
+        "Boundary errors propagate: 'Bank of America' clipped to 'Bank' surfaces wrong candidates and tanks EL recall",
+        "EL requires exact boundaries because partial mentions return wrong candidates",
+        "Boundaries change tokenization",
+        "Boundaries break Wikipedia lookups"
+      ],
+      "correct": 1,
+      "explanation": "Mis-bounded mentions retrieve the wrong alias set, propagating errors into disambiguation."
+    }
+  ]
+}

--- a/phases/05-nlp-foundations-to-advanced/25-entity-linking/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/25-entity-linking/quiz.json
@@ -6,12 +6,12 @@
       "stage": "pre",
       "question": "What does entity linking add on top of NER?",
       "options": [
-        "Part-of-speech tags",
-        "It maps each detected mention to a unique entry in a knowledge base (Wikidata, Wikipedia, or a domain KB)",
+        "Translations",
         "Sentiment polarity",
-        "Translations"
+        "Part-of-speech tags",
+        "It maps each detected mention to a unique entry in a knowledge base (Wikidata, Wikipedia, or a domain KB)"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "EL turns a mention into a canonical KB id, disambiguating between same-name entities."
     },
     {
@@ -19,11 +19,11 @@
       "question": "What are the two main subtasks in entity linking?",
       "options": [
         "Tokenization and parsing",
-        "Candidate generation (shortlist of plausible KB entries) and disambiguation (pick the right one given context)",
         "POS tagging and lemmatization",
-        "Embedding and clustering"
+        "Embedding and clustering",
+        "Candidate generation (shortlist of plausible KB entries) and disambiguation (pick the right one given context)"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "EL decomposes into proposing candidates then ranking them by contextual fit."
     },
     {
@@ -31,59 +31,59 @@
       "question": "Why must mention recall be reported alongside disambiguation accuracy?",
       "options": [
         "Mention recall is mandatory by GDPR",
+        "Recall replaces precision",
         "Disambiguation cannot recover from missing candidates; the pipeline is bounded by candidate-generation recall",
-        "Recall is required by spaCy",
-        "Recall replaces precision"
+        "Recall is required by spaCy"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "If candidates miss the gold entity, no disambiguator can fix it; recall floors pipeline quality."
     },
     {
       "stage": "check",
       "question": "How does GENRE perform entity linking?",
       "options": [
-        "By computing TF-IDF",
         "Decodes the entity's canonical name token-by-token under constrained decoding over a trie of valid KB ids",
         "By BM25",
+        "By computing TF-IDF",
         "By PageRank"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "GENRE generates the canonical KB name with constrained decoding to guarantee a valid id."
     },
     {
       "stage": "check",
       "question": "What is NIL handling in entity linking?",
       "options": [
-        "Skipping every mention",
         "Predicting a 'not in KB' label when no candidate is a real match (emerging entities, obscure people)",
         "Returning the entire candidate list",
-        "Lowercasing the input"
+        "Lowercasing the input",
+        "Skipping every mention"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "NIL prediction prevents guessing wrong KB ids for entities the KB does not cover."
     },
     {
       "stage": "post",
       "question": "Why does popularity bias hurt entity linking in specialized domains?",
       "options": [
-        "It biases toward older entities only",
         "Models trained on web data over-predict frequent entities (e.g. basketball Jordan over the ML researcher Michael I. Jordan)",
-        "Popularity helps recall",
-        "Popularity removes NIL"
+        "It biases toward older entities only",
+        "Popularity removes NIL",
+        "Popularity helps recall"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Popularity priors skew predictions away from less-common, domain-specific name-clashes."
     },
     {
       "stage": "post",
       "question": "What is a safe LLM-EL pattern in 2026?",
       "options": [
-        "Free-form generation",
         "Provide a candidate list and use constrained JSON output that the LLM can only choose from valid KB ids",
         "Just prompt 'find the entity'",
+        "Free-form generation",
         "Skip candidate generation"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Constraining the LLM to a valid candidate list prevents made-up KB ids and keeps output queryable."
     },
     {
@@ -91,11 +91,11 @@
       "question": "Why must NER mention boundaries be exact for entity linking to work?",
       "options": [
         "Boundary errors propagate: 'Bank of America' clipped to 'Bank' surfaces wrong candidates and tanks EL recall",
-        "EL requires exact boundaries because partial mentions return wrong candidates",
+        "Boundary precision only affects NER metrics, not entity-linking candidate quality",
         "Boundaries change tokenization",
         "Boundaries break Wikipedia lookups"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Mis-bounded mentions retrieve the wrong alias set, propagating errors into disambiguation."
     }
   ]

--- a/phases/05-nlp-foundations-to-advanced/26-relation-extraction-kg/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/26-relation-extraction-kg/quiz.json
@@ -1,0 +1,102 @@
+{
+  "lesson": "26-relation-extraction-kg",
+  "title": "Relation Extraction & Knowledge Graph Construction",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "What is the atomic unit of a knowledge graph?",
+      "options": [
+        "A token",
+        "A (subject, relation, object) triple",
+        "A POS tag",
+        "A sentence"
+      ],
+      "correct": 1,
+      "explanation": "KGs store information as (s, r, o) triples; aggregated triples form the graph."
+    },
+    {
+      "stage": "pre",
+      "question": "What does AEVS stand for in 2026 relation extraction?",
+      "options": [
+        "Async Entity Validation Service",
+        "Anchor-Extraction-Verification-Supplement: anchor spans, extract triples, verify against source, supplement coverage",
+        "Auto-Encoder Vector Search",
+        "Aggregated Entity-Value Schema"
+      ],
+      "correct": 1,
+      "explanation": "AEVS is the 2026 hallucination-mitigation framework for grounded RE."
+    },
+    {
+      "stage": "check",
+      "question": "Why must each triple carry source provenance (doc id + span)?",
+      "options": [
+        "It speeds up extraction",
+        "Provenance lets you audit triples and reject hallucinations whose spans do not match the source text",
+        "Provenance is required by SPARQL",
+        "Provenance changes the ontology"
+      ],
+      "correct": 1,
+      "explanation": "Provenance enables auditing and is the core of AEVS-style hallucination detection."
+    },
+    {
+      "stage": "check",
+      "question": "What does canonicalization of relations do?",
+      "options": [
+        "Removes triples",
+        "Maps surface verb phrases (e.g. 'was born in', 'is a native of') onto a fixed property id so the graph is queryable",
+        "Translates the document",
+        "Adds embeddings"
+      ],
+      "correct": 1,
+      "explanation": "Canonicalization collapses paraphrases into canonical KG property ids."
+    },
+    {
+      "stage": "check",
+      "question": "Why does relation extraction usually need coreference resolution first?",
+      "options": [
+        "Coref normalizes case",
+        "Pronouns like 'he founded Apple' must be resolved to a named entity before triple extraction",
+        "Coref adds embeddings",
+        "Coref provides positions"
+      ],
+      "correct": 1,
+      "explanation": "Without coref, RE attaches relations to pronouns instead of the underlying named entity."
+    },
+    {
+      "stage": "post",
+      "question": "Which choice trades open IE recall for graph queryability?",
+      "options": [
+        "Embedding-only graphs",
+        "Mapping open-IE relations onto a closed ontology (e.g. Wikidata properties) before merging into the KG",
+        "Random sampling of triples",
+        "Skipping NER"
+      ],
+      "correct": 1,
+      "explanation": "Closed ontologies make the graph queryable; the canonicalization step pays for itself downstream."
+    },
+    {
+      "stage": "post",
+      "question": "Why do many production KGs use temporal qualifiers (start/end time)?",
+      "options": [
+        "Faster SPARQL",
+        "Many relations are time-bounded (employer, spouse, role); qualifiers prevent 'forever true' claims that go stale",
+        "Required by RDF",
+        "To remove NIL entities"
+      ],
+      "correct": 1,
+      "explanation": "Time-bounded relations need qualifiers (e.g. Wikidata P580/P582) or facts go silently stale."
+    },
+    {
+      "stage": "post",
+      "question": "What is REBEL?",
+      "options": [
+        "A vector database",
+        "A seq2seq relation extractor that outputs triples already in Wikidata property ids",
+        "A coreference model",
+        "A tokenizer"
+      ],
+      "correct": 1,
+      "explanation": "REBEL (Babelscape) is a seq2seq RE model trained on distantly supervised Wikidata triples."
+    }
+  ]
+}

--- a/phases/05-nlp-foundations-to-advanced/26-relation-extraction-kg/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/26-relation-extraction-kg/quiz.json
@@ -6,9 +6,9 @@
       "stage": "pre",
       "question": "What is the atomic unit of a knowledge graph?",
       "options": [
-        "A token",
-        "A (subject, relation, object) triple",
         "A POS tag",
+        "A (subject, relation, object) triple",
+        "A token",
         "A sentence"
       ],
       "correct": 1,
@@ -18,60 +18,60 @@
       "stage": "pre",
       "question": "What does AEVS stand for in 2026 relation extraction?",
       "options": [
-        "Async Entity Validation Service",
         "Anchor-Extraction-Verification-Supplement: anchor spans, extract triples, verify against source, supplement coverage",
         "Auto-Encoder Vector Search",
+        "Async Entity Validation Service",
         "Aggregated Entity-Value Schema"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "AEVS is the 2026 hallucination-mitigation framework for grounded RE."
     },
     {
       "stage": "check",
       "question": "Why must each triple carry source provenance (doc id + span)?",
       "options": [
-        "It speeds up extraction",
         "Provenance lets you audit triples and reject hallucinations whose spans do not match the source text",
-        "Provenance is required by SPARQL",
-        "Provenance changes the ontology"
+        "It speeds up extraction",
+        "Provenance changes the ontology",
+        "Provenance is required by SPARQL"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Provenance enables auditing and is the core of AEVS-style hallucination detection."
     },
     {
       "stage": "check",
       "question": "What does canonicalization of relations do?",
       "options": [
-        "Removes triples",
         "Maps surface verb phrases (e.g. 'was born in', 'is a native of') onto a fixed property id so the graph is queryable",
-        "Translates the document",
-        "Adds embeddings"
+        "Removes triples",
+        "Adds embeddings",
+        "Translates the document"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Canonicalization collapses paraphrases into canonical KG property ids."
     },
     {
       "stage": "check",
       "question": "Why does relation extraction usually need coreference resolution first?",
       "options": [
-        "Coref normalizes case",
         "Pronouns like 'he founded Apple' must be resolved to a named entity before triple extraction",
         "Coref adds embeddings",
-        "Coref provides positions"
+        "Coref provides positions",
+        "Coref normalizes case"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Without coref, RE attaches relations to pronouns instead of the underlying named entity."
     },
     {
       "stage": "post",
       "question": "Which choice trades open IE recall for graph queryability?",
       "options": [
-        "Embedding-only graphs",
-        "Mapping open-IE relations onto a closed ontology (e.g. Wikidata properties) before merging into the KG",
+        "Skipping NER",
         "Random sampling of triples",
-        "Skipping NER"
+        "Embedding-only graphs",
+        "Mapping open-IE relations onto a closed ontology (e.g. Wikidata properties) before merging into the KG"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "Closed ontologies make the graph queryable; the canonicalization step pays for itself downstream."
     },
     {
@@ -79,11 +79,11 @@
       "question": "Why do many production KGs use temporal qualifiers (start/end time)?",
       "options": [
         "Faster SPARQL",
-        "Many relations are time-bounded (employer, spouse, role); qualifiers prevent 'forever true' claims that go stale",
         "Required by RDF",
+        "Many relations are time-bounded (employer, spouse, role); qualifiers prevent 'forever true' claims that go stale",
         "To remove NIL entities"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Time-bounded relations need qualifiers (e.g. Wikidata P580/P582) or facts go silently stale."
     },
     {
@@ -92,8 +92,8 @@
       "options": [
         "A vector database",
         "A seq2seq relation extractor that outputs triples already in Wikidata property ids",
-        "A coreference model",
-        "A tokenizer"
+        "A tokenizer",
+        "A coreference model"
       ],
       "correct": 1,
       "explanation": "REBEL (Babelscape) is a seq2seq RE model trained on distantly supervised Wikidata triples."

--- a/phases/05-nlp-foundations-to-advanced/27-llm-evaluation-frameworks/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/27-llm-evaluation-frameworks/quiz.json
@@ -7,21 +7,21 @@
       "question": "Why are Exact Match and token-F1 insufficient for evaluating modern LLM outputs?",
       "options": [
         "They are too slow",
-        "They miss semantic equivalence; 'June 29th, 2007' vs 'June 29, 2007' scores 0 EM despite being correct",
+        "They are not differentiable",
         "They require GPUs",
-        "They are not differentiable"
+        "They miss semantic equivalence; 'June 29th, 2007' vs 'June 29, 2007' scores 0 EM despite being correct"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "Exact-match/F1 cannot recognize paraphrases or formatting differences that humans would mark correct."
     },
     {
       "stage": "pre",
       "question": "What does the RAGAS faithfulness metric measure?",
       "options": [
-        "Latency",
+        "Retrieval recall",
         "Whether each claim in the answer is entailed by the retrieved context, via NLI",
-        "Tokens per second",
-        "Retrieval recall"
+        "Latency",
+        "Tokens per second"
       ],
       "correct": 1,
       "explanation": "Faithfulness checks each answer claim against retrieved context using NLI entailment."
@@ -30,9 +30,9 @@
       "stage": "check",
       "question": "Why is judge-model calibration against human labels required before trusting scores?",
       "options": [
-        "Calibration speeds up the judge",
-        "If Spearman correlation between judge and human labels is too low (e.g. below 0.7), the score is noise rather than signal",
         "Required by the GDPR",
+        "If Spearman correlation between judge and human labels is too low (e.g. below 0.7), the score is noise rather than signal",
+        "Calibration speeds up the judge",
         "Calibration is a tokenization issue"
       ],
       "correct": 1,
@@ -42,24 +42,24 @@
       "stage": "check",
       "question": "What is self-evaluation bias in LLM-as-judge setups?",
       "options": [
-        "Lower latency",
         "Using the same LLM family to generate and judge inflates scores by 10-20% versus an independent judge",
+        "Lower latency",
         "Judges run faster on cached outputs",
         "Judges ignore system prompts"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Same-family generator+judge biases scores upward; use a different model family for judging."
     },
     {
       "stage": "check",
       "question": "What does G-Eval specifically add over a naive 'score 0-1' prompt?",
       "options": [
-        "Lower cost",
-        "An explicit chain-of-thought rubric with named evaluation steps, which yields more stable scores",
         "Bigger context",
-        "Multilingual scoring"
+        "Lower cost",
+        "Multilingual scoring",
+        "An explicit chain-of-thought rubric with named evaluation steps, which yields more stable scores"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "G-Eval's structured eval-steps produce more reliable scores than freeform 'rate it' prompts."
     },
     {
@@ -67,35 +67,35 @@
       "question": "Why is reporting only the aggregate mean score dangerous?",
       "options": [
         "Aggregates are too large",
-        "An 0.85 mean can hide 5% catastrophic failures; always inspect the bottom quantile",
+        "Aggregates ignore the judge",
         "Aggregates need GPU",
-        "Aggregates ignore the judge"
+        "An 0.85 mean can hide 5% catastrophic failures; always inspect the bottom quantile"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "Means hide tail failures; surface bottom-10% to catch high-severity issues."
     },
     {
       "stage": "post",
       "question": "Why pin the judge model + version in CI?",
       "options": [
-        "Tokenizer drift",
-        "Upgrading the judge changes every metric; longitudinal comparison breaks without a frozen judge",
         "Required by Anthropic",
-        "Lower cost"
+        "Lower cost",
+        "Tokenizer drift",
+        "Upgrading the judge changes every metric; longitudinal comparison breaks without a frozen judge"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "A judge upgrade silently shifts the metric baseline; pinning preserves cross-run comparability."
     },
     {
       "stage": "post",
       "question": "Where does DeepEval fit relative to RAGAS?",
       "options": [
-        "Replaces RAGAS entirely",
         "DeepEval is pytest-for-LLMs (CI gates, G-Eval, hallucination metrics); RAGAS specializes in reference-free RAG monitoring",
         "DeepEval is hosted only",
-        "DeepEval is a tokenizer"
+        "DeepEval is a tokenizer",
+        "Replaces RAGAS entirely"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "DeepEval anchors CI/CD regression testing; RAGAS handles reference-free RAG monitoring."
     }
   ]

--- a/phases/05-nlp-foundations-to-advanced/27-llm-evaluation-frameworks/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/27-llm-evaluation-frameworks/quiz.json
@@ -1,0 +1,102 @@
+{
+  "lesson": "27-llm-evaluation-frameworks",
+  "title": "LLM Evaluation — RAGAS, DeepEval, G-Eval",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "Why are Exact Match and token-F1 insufficient for evaluating modern LLM outputs?",
+      "options": [
+        "They are too slow",
+        "They miss semantic equivalence; 'June 29th, 2007' vs 'June 29, 2007' scores 0 EM despite being correct",
+        "They require GPUs",
+        "They are not differentiable"
+      ],
+      "correct": 1,
+      "explanation": "Exact-match/F1 cannot recognize paraphrases or formatting differences that humans would mark correct."
+    },
+    {
+      "stage": "pre",
+      "question": "What does the RAGAS faithfulness metric measure?",
+      "options": [
+        "Latency",
+        "Whether each claim in the answer is entailed by the retrieved context, via NLI",
+        "Tokens per second",
+        "Retrieval recall"
+      ],
+      "correct": 1,
+      "explanation": "Faithfulness checks each answer claim against retrieved context using NLI entailment."
+    },
+    {
+      "stage": "check",
+      "question": "Why is judge-model calibration against human labels required before trusting scores?",
+      "options": [
+        "Calibration speeds up the judge",
+        "If Spearman correlation between judge and human labels is too low (e.g. below 0.7), the score is noise rather than signal",
+        "Required by the GDPR",
+        "Calibration is a tokenization issue"
+      ],
+      "correct": 1,
+      "explanation": "Without calibration, you cannot tell whether judge scores reflect quality or model bias."
+    },
+    {
+      "stage": "check",
+      "question": "What is self-evaluation bias in LLM-as-judge setups?",
+      "options": [
+        "Lower latency",
+        "Using the same LLM family to generate and judge inflates scores by 10-20% versus an independent judge",
+        "Judges run faster on cached outputs",
+        "Judges ignore system prompts"
+      ],
+      "correct": 1,
+      "explanation": "Same-family generator+judge biases scores upward; use a different model family for judging."
+    },
+    {
+      "stage": "check",
+      "question": "What does G-Eval specifically add over a naive 'score 0-1' prompt?",
+      "options": [
+        "Lower cost",
+        "An explicit chain-of-thought rubric with named evaluation steps, which yields more stable scores",
+        "Bigger context",
+        "Multilingual scoring"
+      ],
+      "correct": 1,
+      "explanation": "G-Eval's structured eval-steps produce more reliable scores than freeform 'rate it' prompts."
+    },
+    {
+      "stage": "post",
+      "question": "Why is reporting only the aggregate mean score dangerous?",
+      "options": [
+        "Aggregates are too large",
+        "An 0.85 mean can hide 5% catastrophic failures; always inspect the bottom quantile",
+        "Aggregates need GPU",
+        "Aggregates ignore the judge"
+      ],
+      "correct": 1,
+      "explanation": "Means hide tail failures; surface bottom-10% to catch high-severity issues."
+    },
+    {
+      "stage": "post",
+      "question": "Why pin the judge model + version in CI?",
+      "options": [
+        "Tokenizer drift",
+        "Upgrading the judge changes every metric; longitudinal comparison breaks without a frozen judge",
+        "Required by Anthropic",
+        "Lower cost"
+      ],
+      "correct": 1,
+      "explanation": "A judge upgrade silently shifts the metric baseline; pinning preserves cross-run comparability."
+    },
+    {
+      "stage": "post",
+      "question": "Where does DeepEval fit relative to RAGAS?",
+      "options": [
+        "Replaces RAGAS entirely",
+        "DeepEval is pytest-for-LLMs (CI gates, G-Eval, hallucination metrics); RAGAS specializes in reference-free RAG monitoring",
+        "DeepEval is hosted only",
+        "DeepEval is a tokenizer"
+      ],
+      "correct": 1,
+      "explanation": "DeepEval anchors CI/CD regression testing; RAGAS handles reference-free RAG monitoring."
+    }
+  ]
+}

--- a/phases/05-nlp-foundations-to-advanced/28-long-context-evaluation/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/28-long-context-evaluation/quiz.json
@@ -1,0 +1,102 @@
+{
+  "lesson": "28-long-context-evaluation",
+  "title": "Long-Context Evaluation — NIAH, RULER, LongBench, MRCR",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "What does the original NIAH benchmark measure?",
+      "options": [
+        "Tokenizer fertility",
+        "Whether the model can retrieve a planted fact at controlled depths across a long context",
+        "Multi-hop reasoning only",
+        "Embedding cosine drift"
+      ],
+      "correct": 1,
+      "explanation": "NIAH = needle in a haystack: plant a fact, ask the model to retrieve it, sweep depth and length."
+    },
+    {
+      "stage": "pre",
+      "question": "Why is the advertised context window often very different from the usable context?",
+      "options": [
+        "Tokenizers truncate",
+        "Attention degrades with length and task; spec-sheet maximums rarely hold under multi-hop or reasoning loads",
+        "Beam search slows",
+        "Embeddings overflow"
+      ],
+      "correct": 1,
+      "explanation": "Effective context for reasoning is usually 25-50% of the advertised max."
+    },
+    {
+      "stage": "check",
+      "question": "What does RULER add over NIAH?",
+      "options": [
+        "Faster inference",
+        "Thirteen task types across retrieval, multi-hop tracing, aggregation, and QA at multiple context lengths",
+        "Translation tasks",
+        "Per-token logprobs"
+      ],
+      "correct": 1,
+      "explanation": "RULER expands NIAH into a multi-task long-context benchmark catching models that saturate NIAH but fail elsewhere."
+    },
+    {
+      "stage": "check",
+      "question": "What is the 'lost in the middle' effect?",
+      "options": [
+        "Models forget the first token",
+        "Models under-attend to content placed in the middle of long inputs; depth=0.5 often performs worse than depth=0 or 1",
+        "Models lose punctuation",
+        "Models reorder tokens"
+      ],
+      "correct": 1,
+      "explanation": "Mid-context content is least attended; sweeping depth exposes the U-shaped accuracy curve."
+    },
+    {
+      "stage": "check",
+      "question": "Why must NIAH-only evaluation be supplemented with multi-hop tests?",
+      "options": [
+        "NIAH cannot run on long context",
+        "Frontier models can ace single-needle retrieval but still fail multi-hop variable-tracing or aggregation tasks",
+        "NIAH lacks ground truth",
+        "Multi-hop is faster"
+      ],
+      "correct": 1,
+      "explanation": "Retrieval pass does not imply reasoning pass; multi-hop benchmarks expose the real ceiling."
+    },
+    {
+      "stage": "post",
+      "question": "What does NoLiMa stress?",
+      "options": [
+        "Latency",
+        "Needles that share no literal tokens with the query, so retrieval requires a semantic reasoning step",
+        "Tokenization",
+        "Streaming output"
+      ],
+      "correct": 1,
+      "explanation": "NoLiMa removes lexical overlap so the model must reason rather than match keywords."
+    },
+    {
+      "stage": "post",
+      "question": "What two numbers should a long-context spec sheet report?",
+      "options": [
+        "Only the advertised max",
+        "Effective retrieval length (e.g. 90% NIAH pass) and effective reasoning length (e.g. 70% multi-hop pass)",
+        "Tokens per second only",
+        "GPU memory and latency only"
+      ],
+      "correct": 1,
+      "explanation": "Distinguishing retrieval-effective from reasoning-effective length is essential for real-world claims."
+    },
+    {
+      "stage": "post",
+      "question": "Why measure time-to-first-token at long context lengths?",
+      "options": [
+        "Tokenization is slow",
+        "1M-token prefills can take tens of seconds; accuracy alone hides product-impacting latency",
+        "Required by RAG",
+        "Beam search depends on it"
+      ],
+      "correct": 1,
+      "explanation": "Long prompts have huge prefill costs; latency must be tracked alongside accuracy."
+    }
+  ]
+}

--- a/phases/05-nlp-foundations-to-advanced/28-long-context-evaluation/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/28-long-context-evaluation/quiz.json
@@ -8,8 +8,8 @@
       "options": [
         "Tokenizer fertility",
         "Whether the model can retrieve a planted fact at controlled depths across a long context",
-        "Multi-hop reasoning only",
-        "Embedding cosine drift"
+        "Embedding cosine drift",
+        "Multi-hop reasoning only"
       ],
       "correct": 1,
       "explanation": "NIAH = needle in a haystack: plant a fact, ask the model to retrieve it, sweep depth and length."
@@ -18,84 +18,84 @@
       "stage": "pre",
       "question": "Why is the advertised context window often very different from the usable context?",
       "options": [
-        "Tokenizers truncate",
         "Attention degrades with length and task; spec-sheet maximums rarely hold under multi-hop or reasoning loads",
-        "Beam search slows",
-        "Embeddings overflow"
+        "Tokenizers truncate",
+        "Embeddings overflow",
+        "Beam search slows"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Effective context for reasoning is usually 25-50% of the advertised max."
     },
     {
       "stage": "check",
       "question": "What does RULER add over NIAH?",
       "options": [
-        "Faster inference",
-        "Thirteen task types across retrieval, multi-hop tracing, aggregation, and QA at multiple context lengths",
         "Translation tasks",
-        "Per-token logprobs"
+        "Faster inference",
+        "Per-token logprobs",
+        "Thirteen task types across retrieval, multi-hop tracing, aggregation, and QA at multiple context lengths"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "RULER expands NIAH into a multi-task long-context benchmark catching models that saturate NIAH but fail elsewhere."
     },
     {
       "stage": "check",
       "question": "What is the 'lost in the middle' effect?",
       "options": [
-        "Models forget the first token",
         "Models under-attend to content placed in the middle of long inputs; depth=0.5 often performs worse than depth=0 or 1",
-        "Models lose punctuation",
-        "Models reorder tokens"
+        "Models reorder tokens",
+        "Models forget the first token",
+        "Models lose punctuation"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Mid-context content is least attended; sweeping depth exposes the U-shaped accuracy curve."
     },
     {
       "stage": "check",
       "question": "Why must NIAH-only evaluation be supplemented with multi-hop tests?",
       "options": [
-        "NIAH cannot run on long context",
-        "Frontier models can ace single-needle retrieval but still fail multi-hop variable-tracing or aggregation tasks",
+        "Multi-hop is faster",
         "NIAH lacks ground truth",
-        "Multi-hop is faster"
+        "NIAH cannot run on long context",
+        "Frontier models can ace single-needle retrieval but still fail multi-hop variable-tracing or aggregation tasks"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "Retrieval pass does not imply reasoning pass; multi-hop benchmarks expose the real ceiling."
     },
     {
       "stage": "post",
       "question": "What does NoLiMa stress?",
       "options": [
+        "Streaming output",
         "Latency",
-        "Needles that share no literal tokens with the query, so retrieval requires a semantic reasoning step",
         "Tokenization",
-        "Streaming output"
+        "Needles that share no literal tokens with the query, so retrieval requires a semantic reasoning step"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "NoLiMa removes lexical overlap so the model must reason rather than match keywords."
     },
     {
       "stage": "post",
       "question": "What two numbers should a long-context spec sheet report?",
       "options": [
-        "Only the advertised max",
         "Effective retrieval length (e.g. 90% NIAH pass) and effective reasoning length (e.g. 70% multi-hop pass)",
-        "Tokens per second only",
-        "GPU memory and latency only"
+        "GPU memory and latency only",
+        "Only the advertised max",
+        "Tokens per second only"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Distinguishing retrieval-effective from reasoning-effective length is essential for real-world claims."
     },
     {
       "stage": "post",
       "question": "Why measure time-to-first-token at long context lengths?",
       "options": [
-        "Tokenization is slow",
         "1M-token prefills can take tens of seconds; accuracy alone hides product-impacting latency",
+        "Tokenization is slow",
         "Required by RAG",
         "Beam search depends on it"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Long prompts have huge prefill costs; latency must be tracked alongside accuracy."
     }
   ]

--- a/phases/05-nlp-foundations-to-advanced/29-dialogue-state-tracking/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/29-dialogue-state-tracking/quiz.json
@@ -18,24 +18,24 @@
       "stage": "pre",
       "question": "What does Joint Goal Accuracy (JGA) measure?",
       "options": [
-        "Average slot accuracy",
         "Fraction of turns where every slot is exactly correct (all-or-nothing)",
+        "Average slot accuracy",
         "Latency per turn",
         "Cosine similarity"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "JGA is the strict per-turn match across all slots; per-slot accuracy is more lenient."
     },
     {
       "stage": "check",
       "question": "Why does regenerating the whole state from history each turn handle user corrections naturally?",
       "options": [
+        "It uses fewer tokens",
         "It runs on GPU",
-        "Reading the full history lets the model re-derive the final state including 'actually...' corrections without explicit rollback logic",
         "It avoids embeddings",
-        "It uses fewer tokens"
+        "Reading the full history lets the model re-derive the final state including 'actually...' corrections without explicit rollback logic"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "Full-history regeneration absorbs corrections by recomputing the final state from the entire conversation."
     },
     {
@@ -43,32 +43,32 @@
       "question": "Which 2026 pattern gives a guaranteed-valid slot dict in 5 lines of code?",
       "options": [
         "Hand-written regex",
-        "LLM + Instructor + Pydantic schema with constrained or validated output",
         "BM25 retrieval",
+        "LLM + Instructor + Pydantic schema with constrained or validated output",
         "TF-IDF classifier"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Pydantic schema + Instructor validates the LLM's state output against the slot ontology automatically."
     },
     {
       "stage": "check",
       "question": "Why version your DST schema?",
       "options": [
-        "Required by JSON",
         "Adding new slots post-hoc invalidates older training data and breaks longitudinal evaluation",
-        "Speed gains",
-        "Reduce token count"
+        "Required by JSON",
+        "Reduce token count",
+        "Speed gains"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Unversioned schema changes silently break training data alignment and eval comparability."
     },
     {
       "stage": "post",
       "question": "Why must DST for compliance-sensitive domains include a rule-based check alongside LLM extraction?",
       "options": [
-        "LLMs are slower",
-        "LLM-only DST can mis-extract destructive parameters (amount, account, date); a rules layer enforces deterministic constraints",
         "Rules avoid embeddings",
+        "LLM-only DST can mis-extract destructive parameters (amount, account, date); a rules layer enforces deterministic constraints",
+        "LLMs are slower",
         "Rules are multilingual"
       ],
       "correct": 1,
@@ -78,12 +78,12 @@
       "stage": "post",
       "question": "What is the cost concern with regenerating state on every turn via LLM?",
       "options": [
-        "More embeddings",
         "Re-reading the full history each turn yields O(n^2) total token usage; cap or summarize older turns",
-        "Embedding drift",
-        "Cosine costs"
+        "More embeddings",
+        "Cosine costs",
+        "Embedding drift"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Full-history regeneration is quadratic in turns; cap history or use rolling summaries."
     },
     {
@@ -91,11 +91,11 @@
       "question": "Why are explicit confirmation flows required before destructive backend actions?",
       "options": [
         "Latency",
-        "Even good DST has nonzero slot-error rates; a deterministic confirmation prevents wrong-account or wrong-amount actions",
+        "Confirmation increases JGA",
         "Required by tokenizers",
-        "Confirmation increases JGA"
+        "Even good DST has nonzero slot-error rates; a deterministic confirmation prevents wrong-account or wrong-amount actions"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "Destructive actions need user confirmation because DST is never error-free."
     }
   ]

--- a/phases/05-nlp-foundations-to-advanced/29-dialogue-state-tracking/quiz.json
+++ b/phases/05-nlp-foundations-to-advanced/29-dialogue-state-tracking/quiz.json
@@ -1,0 +1,102 @@
+{
+  "lesson": "29-dialogue-state-tracking",
+  "title": "Dialogue State Tracking",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "What does dialogue state tracking maintain across turns?",
+      "options": [
+        "A free-text history only",
+        "A slot-value dictionary representing the user's current goal, updated after every turn",
+        "An embedding of the conversation",
+        "A POS-tagged transcript"
+      ],
+      "correct": 1,
+      "explanation": "DST keeps a structured slot-value map that the backend can act on."
+    },
+    {
+      "stage": "pre",
+      "question": "What does Joint Goal Accuracy (JGA) measure?",
+      "options": [
+        "Average slot accuracy",
+        "Fraction of turns where every slot is exactly correct (all-or-nothing)",
+        "Latency per turn",
+        "Cosine similarity"
+      ],
+      "correct": 1,
+      "explanation": "JGA is the strict per-turn match across all slots; per-slot accuracy is more lenient."
+    },
+    {
+      "stage": "check",
+      "question": "Why does regenerating the whole state from history each turn handle user corrections naturally?",
+      "options": [
+        "It runs on GPU",
+        "Reading the full history lets the model re-derive the final state including 'actually...' corrections without explicit rollback logic",
+        "It avoids embeddings",
+        "It uses fewer tokens"
+      ],
+      "correct": 1,
+      "explanation": "Full-history regeneration absorbs corrections by recomputing the final state from the entire conversation."
+    },
+    {
+      "stage": "check",
+      "question": "Which 2026 pattern gives a guaranteed-valid slot dict in 5 lines of code?",
+      "options": [
+        "Hand-written regex",
+        "LLM + Instructor + Pydantic schema with constrained or validated output",
+        "BM25 retrieval",
+        "TF-IDF classifier"
+      ],
+      "correct": 1,
+      "explanation": "Pydantic schema + Instructor validates the LLM's state output against the slot ontology automatically."
+    },
+    {
+      "stage": "check",
+      "question": "Why version your DST schema?",
+      "options": [
+        "Required by JSON",
+        "Adding new slots post-hoc invalidates older training data and breaks longitudinal evaluation",
+        "Speed gains",
+        "Reduce token count"
+      ],
+      "correct": 1,
+      "explanation": "Unversioned schema changes silently break training data alignment and eval comparability."
+    },
+    {
+      "stage": "post",
+      "question": "Why must DST for compliance-sensitive domains include a rule-based check alongside LLM extraction?",
+      "options": [
+        "LLMs are slower",
+        "LLM-only DST can mis-extract destructive parameters (amount, account, date); a rules layer enforces deterministic constraints",
+        "Rules avoid embeddings",
+        "Rules are multilingual"
+      ],
+      "correct": 1,
+      "explanation": "Compliance domains require deterministic enforcement; rules catch slot errors that LLMs introduce."
+    },
+    {
+      "stage": "post",
+      "question": "What is the cost concern with regenerating state on every turn via LLM?",
+      "options": [
+        "More embeddings",
+        "Re-reading the full history each turn yields O(n^2) total token usage; cap or summarize older turns",
+        "Embedding drift",
+        "Cosine costs"
+      ],
+      "correct": 1,
+      "explanation": "Full-history regeneration is quadratic in turns; cap history or use rolling summaries."
+    },
+    {
+      "stage": "post",
+      "question": "Why are explicit confirmation flows required before destructive backend actions?",
+      "options": [
+        "Latency",
+        "Even good DST has nonzero slot-error rates; a deterministic confirmation prevents wrong-account or wrong-amount actions",
+        "Required by tokenizers",
+        "Confirmation increases JGA"
+      ],
+      "correct": 1,
+      "explanation": "Destructive actions need user confirmation because DST is never error-free."
+    }
+  ]
+}


### PR DESCRIPTION
Backfills `quiz.json` for every Phase 5 lesson (NLP foundations to advanced). Each quiz has 8 questions distributed across pre/check/post stages, grounded in the lesson's `docs/en.md`, and validates against the canonical schema (`stage/question/options/correct/explanation`).

| stage | total questions |
|-------|-----------------|
| pre   | 58 (2 per lesson) |
| check | 87 (3 per lesson) |
| post  | 87 (3 per lesson) |
| **total** | **232 (8 per lesson * 29 lessons)** |

`python3 scripts/audit_lessons.py --phase 5` exits 0. Catalog rebuilt: phase 5 now reports 29/29 `has_quiz=true`.