### PR TITLE
feat(phase-17): quiz backfill, 0/28 -> 28/28

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -10501,7 +10501,7 @@
           "path": "phases/17-infrastructure-and-production/01-managed-llm-platforms",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -10531,7 +10531,7 @@
           "path": "phases/17-infrastructure-and-production/02-inference-platform-economics",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -10563,7 +10563,7 @@
           "path": "phases/17-infrastructure-and-production/03-gpu-autoscaling-kubernetes",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -10595,7 +10595,7 @@
           "path": "phases/17-infrastructure-and-production/04-vllm-serving-internals",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -10625,7 +10625,7 @@
           "path": "phases/17-infrastructure-and-production/05-eagle3-speculative-decoding",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -10654,7 +10654,7 @@
           "path": "phases/17-infrastructure-and-production/06-sglang-radixattention",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -10683,7 +10683,7 @@
           "path": "phases/17-infrastructure-and-production/07-tensorrt-llm-blackwell",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -10714,7 +10714,7 @@
           "path": "phases/17-infrastructure-and-production/08-inference-metrics-goodput",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -10745,7 +10745,7 @@
           "path": "phases/17-infrastructure-and-production/09-production-quantization",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -10776,7 +10776,7 @@
           "path": "phases/17-infrastructure-and-production/10-cold-start-mitigation",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -10807,7 +10807,7 @@
           "path": "phases/17-infrastructure-and-production/11-multi-region-kv-locality",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -10839,7 +10839,7 @@
           "path": "phases/17-infrastructure-and-production/12-edge-inference",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -10872,7 +10872,7 @@
           "path": "phases/17-infrastructure-and-production/13-llm-observability",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -10905,7 +10905,7 @@
           "path": "phases/17-infrastructure-and-production/14-prompt-semantic-caching",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -10936,7 +10936,7 @@
           "path": "phases/17-infrastructure-and-production/15-batch-apis",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -10966,7 +10966,7 @@
           "path": "phases/17-infrastructure-and-production/16-model-routing",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -10996,7 +10996,7 @@
           "path": "phases/17-infrastructure-and-production/17-disaggregated-prefill-decode",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -11026,7 +11026,7 @@
           "path": "phases/17-infrastructure-and-production/18-vllm-production-stack-lmcache",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -11055,7 +11055,7 @@
           "path": "phases/17-infrastructure-and-production/19-ai-gateways",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -11089,7 +11089,7 @@
           "path": "phases/17-infrastructure-and-production/20-shadow-canary-progressive",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -11121,7 +11121,7 @@
           "path": "phases/17-infrastructure-and-production/21-ab-testing-llm-features",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -11152,7 +11152,7 @@
           "path": "phases/17-infrastructure-and-production/22-load-testing-llm-apis",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -11183,7 +11183,7 @@
           "path": "phases/17-infrastructure-and-production/23-sre-for-ai",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -11215,7 +11215,7 @@
           "path": "phases/17-infrastructure-and-production/24-chaos-engineering-llm",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -11245,7 +11245,7 @@
           "path": "phases/17-infrastructure-and-production/25-security-secrets-audit",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -11279,7 +11279,7 @@
           "path": "phases/17-infrastructure-and-production/26-compliance-frameworks",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -11312,7 +11312,7 @@
           "path": "phases/17-infrastructure-and-production/27-finops-llms",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"
@@ -11342,7 +11342,7 @@
           "path": "phases/17-infrastructure-and-production/28-self-hosted-serving-selection",
           "has_docs": true,
           "has_code": true,
-          "has_quiz": false,
+          "has_quiz": true,
           "has_notebook": true,
           "code_files": [
             "main.py"

--- a/phases/17-infrastructure-and-production/01-managed-llm-platforms/quiz.json
+++ b/phases/17-infrastructure-and-production/01-managed-llm-platforms/quiz.json
@@ -1,0 +1,90 @@
+{
+  "lesson": "01-managed-llm-platforms",
+  "title": "Managed LLM Platforms — Bedrock, Vertex AI, Azure OpenAI",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "Before this lesson, which platform would you reach for first if a customer needed Claude, Llama, and Cohere behind one API?",
+      "options": [
+        "Azure OpenAI Service",
+        "AWS Bedrock",
+        "Vertex AI",
+        "Direct Anthropic API"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "pre",
+      "question": "Which hyperscaler's bet is described as exclusive partnership rather than marketplace?",
+      "options": [
+        "AWS Bedrock",
+        "Vertex AI",
+        "Azure OpenAI",
+        "OCI Generative AI"
+      ],
+      "correct": 2,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Roughly what is the measured median TTFT gap between Azure OpenAI (with PTUs) and Bedrock on-demand on Llama 3.1 405B equivalents?",
+      "options": [
+        "~5 ms",
+        "~25 ms",
+        "~100 ms",
+        "~250 ms"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Which Bedrock 2025 feature gives the cleanest per-product cost attribution natively in CloudWatch?",
+      "options": [
+        "Bedrock Knowledge Bases",
+        "Application Inference Profiles",
+        "Bedrock Guardrails",
+        "Bedrock Agents"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Azure PTUs typically break even versus on-demand at what sustained utilization band?",
+      "options": [
+        "5-10%",
+        "20-30%",
+        "40-60%",
+        "80-95%"
+      ],
+      "correct": 2,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Why is the lesson's recommended 2026 policy a two-provider minimum for product-critical LLM calls?",
+      "options": [
+        "It is required by SOC 2 Type II",
+        "Frontier model leadership rotates monthly, so single-vendor lock-in shuts you out of two-thirds of the frontier",
+        "Single-vendor pricing is always more expensive",
+        "Hyperscalers refuse to sign BAAs unless you also use a competitor"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Which statement best describes the FinOps surface across the three platforms?",
+      "options": [
+        "All three expose identical per-request attribution",
+        "Bedrock is cleanest native, Vertex is most flexible via BigQuery, Azure is most opaque without instrumentation",
+        "Azure is cleanest native, Bedrock is opaque",
+        "Vertex has no attribution surface at all"
+      ],
+      "correct": 1,
+      "explanation": ""
+    }
+  ]
+}

--- a/phases/17-infrastructure-and-production/01-managed-llm-platforms/quiz.json
+++ b/phases/17-infrastructure-and-production/01-managed-llm-platforms/quiz.json
@@ -6,9 +6,9 @@
       "stage": "pre",
       "question": "Before this lesson, which platform would you reach for first if a customer needed Claude, Llama, and Cohere behind one API?",
       "options": [
-        "Azure OpenAI Service",
-        "AWS Bedrock",
         "Vertex AI",
+        "AWS Bedrock",
+        "Azure OpenAI Service",
         "Direct Anthropic API"
       ],
       "correct": 1,
@@ -18,24 +18,24 @@
       "stage": "pre",
       "question": "Which hyperscaler's bet is described as exclusive partnership rather than marketplace?",
       "options": [
-        "AWS Bedrock",
-        "Vertex AI",
         "Azure OpenAI",
+        "Vertex AI",
+        "AWS Bedrock",
         "OCI Generative AI"
       ],
-      "correct": 2,
+      "correct": 0,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "Roughly what is the measured median TTFT gap between Azure OpenAI (with PTUs) and Bedrock on-demand on Llama 3.1 405B equivalents?",
       "options": [
-        "~5 ms",
-        "~25 ms",
         "~100 ms",
-        "~250 ms"
+        "~5 ms",
+        "~250 ms",
+        "~25 ms"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
@@ -55,11 +55,11 @@
       "question": "Azure PTUs typically break even versus on-demand at what sustained utilization band?",
       "options": [
         "5-10%",
+        "80-95%",
         "20-30%",
-        "40-60%",
-        "80-95%"
+        "40-60%"
       ],
-      "correct": 2,
+      "correct": 3,
       "explanation": ""
     },
     {
@@ -68,8 +68,8 @@
       "options": [
         "It is required by SOC 2 Type II",
         "Frontier model leadership rotates monthly, so single-vendor lock-in shuts you out of two-thirds of the frontier",
-        "Single-vendor pricing is always more expensive",
-        "Hyperscalers refuse to sign BAAs unless you also use a competitor"
+        "Hyperscalers refuse to sign BAAs unless you also use a competitor",
+        "Single-vendor pricing is always more expensive"
       ],
       "correct": 1,
       "explanation": ""
@@ -78,12 +78,12 @@
       "stage": "post",
       "question": "Which statement best describes the FinOps surface across the three platforms?",
       "options": [
-        "All three expose identical per-request attribution",
-        "Bedrock is cleanest native, Vertex is most flexible via BigQuery, Azure is most opaque without instrumentation",
         "Azure is cleanest native, Bedrock is opaque",
-        "Vertex has no attribution surface at all"
+        "Vertex has no attribution surface at all",
+        "All three expose identical per-request attribution",
+        "Bedrock is cleanest native, Vertex is most flexible via BigQuery, Azure is most opaque without instrumentation"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     }
   ]

--- a/phases/17-infrastructure-and-production/02-inference-platform-economics/quiz.json
+++ b/phases/17-infrastructure-and-production/02-inference-platform-economics/quiz.json
@@ -1,0 +1,78 @@
+{
+  "lesson": "02-inference-platform-economics",
+  "title": "Inference Platform Economics — Fireworks, Together, Baseten, Modal, Replicate, Anyscale",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "Which three market segments does the lesson use to organize 2026 inference vendors?",
+      "options": [
+        "Free, paid, enterprise",
+        "Custom silicon, GPU platforms, API-first marketplaces",
+        "Single-tenant, multi-tenant, on-prem",
+        "Open-source, commercial, hybrid"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Around what sustained GPU utilization does per-minute billing (Baseten, Modal) start to beat per-token billing (Fireworks, Together)?",
+      "options": [
+        "5%",
+        "30%",
+        "60%",
+        "90%"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Which platform is described as Python-native serverless with per-second billing and 2-4s cold starts after pre-warming?",
+      "options": [
+        "Fireworks",
+        "Baseten",
+        "Modal",
+        "Anyscale"
+      ],
+      "correct": 2,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "What is Fireworks's notable LoRA pricing differentiator?",
+      "options": [
+        "LoRA-served requests cost more than base model",
+        "LoRA-served requests are charged at the base model's per-token rate",
+        "LoRA is not supported at all",
+        "LoRA requests require a separate dedicated GPU contract"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Which platform fits a regulated healthcare customer that needs SOC 2 Type II, HIPAA-ready posture, and dedicated GPUs?",
+      "options": [
+        "Replicate",
+        "Together",
+        "Baseten",
+        "Anyscale"
+      ],
+      "correct": 2,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Why does the lesson argue that custom-engine claims are mostly marketing shade at the platform layer?",
+      "options": [
+        "Custom engines never outperform vLLM",
+        "vLLM and SGLang represent roughly 80% of production open-source inference, so platform differentiation comes more from DX, attribution, and SLAs than engine",
+        "All custom engines are forks of TensorRT-LLM",
+        "Per-token pricing is the only real differentiator"
+      ],
+      "correct": 1,
+      "explanation": ""
+    }
+  ]
+}

--- a/phases/17-infrastructure-and-production/02-inference-platform-economics/quiz.json
+++ b/phases/17-infrastructure-and-production/02-inference-platform-economics/quiz.json
@@ -7,35 +7,35 @@
       "question": "Which three market segments does the lesson use to organize 2026 inference vendors?",
       "options": [
         "Free, paid, enterprise",
-        "Custom silicon, GPU platforms, API-first marketplaces",
         "Single-tenant, multi-tenant, on-prem",
+        "Custom silicon, GPU platforms, API-first marketplaces",
         "Open-source, commercial, hybrid"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "Around what sustained GPU utilization does per-minute billing (Baseten, Modal) start to beat per-token billing (Fireworks, Together)?",
       "options": [
-        "5%",
-        "30%",
         "60%",
-        "90%"
+        "90%",
+        "30%",
+        "5%"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "Which platform is described as Python-native serverless with per-second billing and 2-4s cold starts after pre-warming?",
       "options": [
-        "Fireworks",
         "Baseten",
         "Modal",
+        "Fireworks",
         "Anyscale"
       ],
-      "correct": 2,
+      "correct": 1,
       "explanation": ""
     },
     {
@@ -43,33 +43,33 @@
       "question": "What is Fireworks's notable LoRA pricing differentiator?",
       "options": [
         "LoRA-served requests cost more than base model",
-        "LoRA-served requests are charged at the base model's per-token rate",
         "LoRA is not supported at all",
-        "LoRA requests require a separate dedicated GPU contract"
+        "LoRA requests require a separate dedicated GPU contract",
+        "LoRA-served requests are charged at the base model's per-token rate"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
       "stage": "post",
       "question": "Which platform fits a regulated healthcare customer that needs SOC 2 Type II, HIPAA-ready posture, and dedicated GPUs?",
       "options": [
-        "Replicate",
-        "Together",
         "Baseten",
-        "Anyscale"
+        "Together",
+        "Anyscale",
+        "Replicate"
       ],
-      "correct": 2,
+      "correct": 0,
       "explanation": ""
     },
     {
       "stage": "post",
       "question": "Why does the lesson argue that custom-engine claims are mostly marketing shade at the platform layer?",
       "options": [
-        "Custom engines never outperform vLLM",
+        "Per-token pricing is the only real differentiator",
         "vLLM and SGLang represent roughly 80% of production open-source inference, so platform differentiation comes more from DX, attribution, and SLAs than engine",
         "All custom engines are forks of TensorRT-LLM",
-        "Per-token pricing is the only real differentiator"
+        "Custom engines never outperform vLLM"
       ],
       "correct": 1,
       "explanation": ""

--- a/phases/17-infrastructure-and-production/03-gpu-autoscaling-kubernetes/quiz.json
+++ b/phases/17-infrastructure-and-production/03-gpu-autoscaling-kubernetes/quiz.json
@@ -1,0 +1,78 @@
+{
+  "lesson": "03-gpu-autoscaling-kubernetes",
+  "title": "GPU Autoscaling on Kubernetes — Karpenter, KAI Scheduler, Gang Scheduling",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "Which signal does HPA typically scale on by default that the lesson calls broken for vLLM-style serving?",
+      "options": [
+        "Queue depth",
+        "KV cache utilization",
+        "DCGM_FI_DEV_GPU_UTIL duty cycle",
+        "P99 TTFT"
+      ],
+      "correct": 2,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Which problem does gang scheduling in KAI Scheduler primarily prevent?",
+      "options": [
+        "GPU memory fragmentation",
+        "The partial-allocation trap where 7 of 8 GPUs sit idle waiting on the eighth",
+        "Cold-start latency",
+        "Tokenizer GIL contention"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Why is Karpenter's default consolidationPolicy WhenEmptyOrUnderutilized dangerous for inference GPU pools?",
+      "options": [
+        "It refuses to scale up under burst",
+        "It terminates running GPU nodes to migrate pods, which evicts running requests and reloads weights",
+        "It only consolidates spot instances",
+        "It prevents Karpenter from provisioning new nodes"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Roughly how much faster is Karpenter at provisioning a GPU node compared to Cluster Autoscaler?",
+      "options": [
+        "About 5% faster",
+        "Roughly 40% faster (~45-60s vs ~90-120s)",
+        "About 10x slower",
+        "The same"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "For disaggregated prefill / decode pods (Phase 17 · 17), which scaling signals does the lesson recommend?",
+      "options": [
+        "A single HPA on duty cycle covering both pod classes",
+        "Queue depth for prefill pods and KV cache pressure for decode pods, as separate per-role HPAs",
+        "Manual scaling only",
+        "Cluster Autoscaler for both"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Which Karpenter disruption setting does the lesson recommend for an inference GPU pool to avoid evicting running jobs?",
+      "options": [
+        "consolidationPolicy: WhenEmptyOrUnderutilized with consolidateAfter: 0s",
+        "consolidationPolicy: WhenEmpty with consolidateAfter: 1h",
+        "Disable Karpenter entirely",
+        "Always run with spot instances and no consolidation"
+      ],
+      "correct": 1,
+      "explanation": ""
+    }
+  ]
+}

--- a/phases/17-infrastructure-and-production/03-gpu-autoscaling-kubernetes/quiz.json
+++ b/phases/17-infrastructure-and-production/03-gpu-autoscaling-kubernetes/quiz.json
@@ -7,11 +7,11 @@
       "question": "Which signal does HPA typically scale on by default that the lesson calls broken for vLLM-style serving?",
       "options": [
         "Queue depth",
+        "P99 TTFT",
         "KV cache utilization",
-        "DCGM_FI_DEV_GPU_UTIL duty cycle",
-        "P99 TTFT"
+        "DCGM_FI_DEV_GPU_UTIL duty cycle"
       ],
-      "correct": 2,
+      "correct": 3,
       "explanation": ""
     },
     {
@@ -19,11 +19,11 @@
       "question": "Which problem does gang scheduling in KAI Scheduler primarily prevent?",
       "options": [
         "GPU memory fragmentation",
+        "Tokenizer GIL contention",
         "The partial-allocation trap where 7 of 8 GPUs sit idle waiting on the eighth",
-        "Cold-start latency",
-        "Tokenizer GIL contention"
+        "Cold-start latency"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     },
     {
@@ -31,35 +31,35 @@
       "question": "Why is Karpenter's default consolidationPolicy WhenEmptyOrUnderutilized dangerous for inference GPU pools?",
       "options": [
         "It refuses to scale up under burst",
-        "It terminates running GPU nodes to migrate pods, which evicts running requests and reloads weights",
         "It only consolidates spot instances",
+        "It terminates running GPU nodes to migrate pods, which evicts running requests and reloads weights",
         "It prevents Karpenter from provisioning new nodes"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "Roughly how much faster is Karpenter at provisioning a GPU node compared to Cluster Autoscaler?",
       "options": [
-        "About 5% faster",
         "Roughly 40% faster (~45-60s vs ~90-120s)",
         "About 10x slower",
-        "The same"
+        "The same",
+        "About 5% faster"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     },
     {
       "stage": "post",
       "question": "For disaggregated prefill / decode pods (Phase 17 · 17), which scaling signals does the lesson recommend?",
       "options": [
+        "Manual scaling only",
         "A single HPA on duty cycle covering both pod classes",
         "Queue depth for prefill pods and KV cache pressure for decode pods, as separate per-role HPAs",
-        "Manual scaling only",
         "Cluster Autoscaler for both"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     },
     {
@@ -68,8 +68,8 @@
       "options": [
         "consolidationPolicy: WhenEmptyOrUnderutilized with consolidateAfter: 0s",
         "consolidationPolicy: WhenEmpty with consolidateAfter: 1h",
-        "Disable Karpenter entirely",
-        "Always run with spot instances and no consolidation"
+        "Always run with spot instances and no consolidation",
+        "Disable Karpenter entirely"
       ],
       "correct": 1,
       "explanation": ""

--- a/phases/17-infrastructure-and-production/04-vllm-serving-internals/quiz.json
+++ b/phases/17-infrastructure-and-production/04-vllm-serving-internals/quiz.json
@@ -1,0 +1,78 @@
+{
+  "lesson": "04-vllm-serving-internals",
+  "title": "vLLM Serving Internals: PagedAttention, Continuous Batching, Chunked Prefill",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "What is the main problem classic static batching has with mixed-length requests?",
+      "options": [
+        "It cannot use GPUs at all",
+        "Padding to the longest prompt and longest output wastes memory and stalls the whole batch on the slowest sequence",
+        "It only works with FP4",
+        "It requires NVLink between every GPU"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "How does PagedAttention reduce KV cache fragmentation from 60-80% to under 4%?",
+      "options": [
+        "By compressing weights to INT4",
+        "By allocating KV cache in fixed-size blocks (default 16 tokens) referenced through a per-sequence block table",
+        "By disabling KV cache entirely",
+        "By holding the full prompt in CPU RAM"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "What invariant defines continuous batching in vLLM's V1 scheduler?",
+      "options": [
+        "The scheduler runs once per request and the batch never changes",
+        "The scheduler runs once per decode iteration, admitting finished sequences out and waiting ones in",
+        "The scheduler waits 10 ms windows to fill a batch before running",
+        "Each request gets its own dedicated GPU stream"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Which latency metric does chunked prefill primarily protect under mixed load?",
+      "options": [
+        "Mean throughput",
+        "P99 inter-token latency (ITL)",
+        "Cold-start time",
+        "Network RTT"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "In vLLM v0.18.0, which speculative-decoding variant remains compatible with --enable-chunked-prefill?",
+      "options": [
+        "Draft-model speculative decoding",
+        "N-gram GPU speculative decoding in the V1 scheduler",
+        "EAGLE-1 only",
+        "No speculative decoding is compatible"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Why does chunked prefill not in isolation increase mean throughput?",
+      "options": [
+        "It only reduces decode-time jitter; the throughput win in practice comes from keeping decode sequences alive during long prefills, not from changing the work done",
+        "It compresses weights more aggressively",
+        "It runs on a different GPU than decode",
+        "It uses speculative decoding under the hood"
+      ],
+      "correct": 0,
+      "explanation": ""
+    }
+  ]
+}

--- a/phases/17-infrastructure-and-production/04-vllm-serving-internals/quiz.json
+++ b/phases/17-infrastructure-and-production/04-vllm-serving-internals/quiz.json
@@ -6,24 +6,24 @@
       "stage": "pre",
       "question": "What is the main problem classic static batching has with mixed-length requests?",
       "options": [
-        "It cannot use GPUs at all",
-        "Padding to the longest prompt and longest output wastes memory and stalls the whole batch on the slowest sequence",
         "It only works with FP4",
-        "It requires NVLink between every GPU"
+        "It requires NVLink between every GPU",
+        "It cannot use GPUs at all",
+        "Padding to the longest prompt and longest output wastes memory and stalls the whole batch on the slowest sequence"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "How does PagedAttention reduce KV cache fragmentation from 60-80% to under 4%?",
       "options": [
+        "By disabling KV cache entirely",
         "By compressing weights to INT4",
         "By allocating KV cache in fixed-size blocks (default 16 tokens) referenced through a per-sequence block table",
-        "By disabling KV cache entirely",
         "By holding the full prompt in CPU RAM"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     },
     {
@@ -31,11 +31,11 @@
       "question": "What invariant defines continuous batching in vLLM's V1 scheduler?",
       "options": [
         "The scheduler runs once per request and the batch never changes",
-        "The scheduler runs once per decode iteration, admitting finished sequences out and waiting ones in",
+        "Each request gets its own dedicated GPU stream",
         "The scheduler waits 10 ms windows to fill a batch before running",
-        "Each request gets its own dedicated GPU stream"
+        "The scheduler runs once per decode iteration, admitting finished sequences out and waiting ones in"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
@@ -43,21 +43,21 @@
       "question": "Which latency metric does chunked prefill primarily protect under mixed load?",
       "options": [
         "Mean throughput",
-        "P99 inter-token latency (ITL)",
         "Cold-start time",
-        "Network RTT"
+        "Network RTT",
+        "P99 inter-token latency (ITL)"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
       "stage": "post",
       "question": "In vLLM v0.18.0, which speculative-decoding variant remains compatible with --enable-chunked-prefill?",
       "options": [
-        "Draft-model speculative decoding",
-        "N-gram GPU speculative decoding in the V1 scheduler",
         "EAGLE-1 only",
-        "No speculative decoding is compatible"
+        "N-gram GPU speculative decoding in the V1 scheduler",
+        "No speculative decoding is compatible",
+        "Draft-model speculative decoding"
       ],
       "correct": 1,
       "explanation": ""
@@ -66,12 +66,12 @@
       "stage": "post",
       "question": "Why does chunked prefill not in isolation increase mean throughput?",
       "options": [
-        "It only reduces decode-time jitter; the throughput win in practice comes from keeping decode sequences alive during long prefills, not from changing the work done",
-        "It compresses weights more aggressively",
         "It runs on a different GPU than decode",
-        "It uses speculative decoding under the hood"
+        "It uses speculative decoding under the hood",
+        "It compresses weights more aggressively",
+        "It only reduces decode-time jitter; the throughput win in practice comes from keeping decode sequences alive during long prefills, not from changing the work done"
       ],
-      "correct": 0,
+      "correct": 3,
       "explanation": ""
     }
   ]

--- a/phases/17-infrastructure-and-production/05-eagle3-speculative-decoding/quiz.json
+++ b/phases/17-infrastructure-and-production/05-eagle3-speculative-decoding/quiz.json
@@ -7,11 +7,11 @@
       "question": "Why does speculative decoding exploit a gap that exists in plain decode?",
       "options": [
         "Decode is compute-bound, so adding more compute is free",
-        "Decode is memory-bound, so the GPU is mostly idle waiting on HBM reads of weights",
+        "Decode does not benefit from batching",
         "Decode requires more network bandwidth than prefill",
-        "Decode does not benefit from batching"
+        "Decode is memory-bound, so the GPU is mostly idle waiting on HBM reads of weights"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
@@ -31,47 +31,47 @@
       "question": "What changes in EAGLE-3 compared to EAGLE-2 that pushes alpha to roughly 0.6-0.8 on general chat?",
       "options": [
         "It uses a full-sized draft model of the same family",
-        "The draft head is trained on multiple target layers rather than just the last layer",
+        "It runs on CPU instead of GPU",
         "It removes the verify step entirely",
-        "It runs on CPU instead of GPU"
+        "The draft head is trained on multiple target layers rather than just the last layer"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "Below roughly what alpha does the lesson say speculative decoding becomes net negative at high concurrency on most 2026 hardware?",
       "options": [
+        "0.95",
         "0.05",
         "0.55",
-        "0.85",
-        "0.95"
+        "0.85"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     },
     {
       "stage": "post",
       "question": "Which metric should you watch most closely after flipping EAGLE-3 on, even if mean ITL drops?",
       "options": [
-        "Mean E2E latency",
-        "P99 ITL, because rejected-draft two-passes can serialize under full batch",
         "Cold-start time",
-        "GPU memory utilization"
+        "GPU memory utilization",
+        "P99 ITL, because rejected-draft two-passes can serialize under full batch",
+        "Mean E2E latency"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     },
     {
       "stage": "post",
       "question": "Why is speculative decoding opt-in (not default) in vLLM 2026 per the lesson?",
       "options": [
-        "It is incompatible with PagedAttention",
         "Acceptance rate depends on workload, and turning it on without measuring alpha is a production anti-pattern",
         "It only works on Blackwell GPUs",
+        "It is incompatible with PagedAttention",
         "It requires a separate license"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     }
   ]

--- a/phases/17-infrastructure-and-production/05-eagle3-speculative-decoding/quiz.json
+++ b/phases/17-infrastructure-and-production/05-eagle3-speculative-decoding/quiz.json
@@ -1,0 +1,78 @@
+{
+  "lesson": "05-eagle3-speculative-decoding",
+  "title": "EAGLE-3 Speculative Decoding in Production",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "Why does speculative decoding exploit a gap that exists in plain decode?",
+      "options": [
+        "Decode is compute-bound, so adding more compute is free",
+        "Decode is memory-bound, so the GPU is mostly idle waiting on HBM reads of weights",
+        "Decode requires more network bandwidth than prefill",
+        "Decode does not benefit from batching"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "What does the acceptance rate alpha measure?",
+      "options": [
+        "Fraction of GPU memory used during decode",
+        "Fraction of draft-proposed tokens accepted by the target model",
+        "Latency overhead of the draft model",
+        "Cache hit rate of the KV cache"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "What changes in EAGLE-3 compared to EAGLE-2 that pushes alpha to roughly 0.6-0.8 on general chat?",
+      "options": [
+        "It uses a full-sized draft model of the same family",
+        "The draft head is trained on multiple target layers rather than just the last layer",
+        "It removes the verify step entirely",
+        "It runs on CPU instead of GPU"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Below roughly what alpha does the lesson say speculative decoding becomes net negative at high concurrency on most 2026 hardware?",
+      "options": [
+        "0.05",
+        "0.55",
+        "0.85",
+        "0.95"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Which metric should you watch most closely after flipping EAGLE-3 on, even if mean ITL drops?",
+      "options": [
+        "Mean E2E latency",
+        "P99 ITL, because rejected-draft two-passes can serialize under full batch",
+        "Cold-start time",
+        "GPU memory utilization"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Why is speculative decoding opt-in (not default) in vLLM 2026 per the lesson?",
+      "options": [
+        "It is incompatible with PagedAttention",
+        "Acceptance rate depends on workload, and turning it on without measuring alpha is a production anti-pattern",
+        "It only works on Blackwell GPUs",
+        "It requires a separate license"
+      ],
+      "correct": 1,
+      "explanation": ""
+    }
+  ]
+}

--- a/phases/17-infrastructure-and-production/06-sglang-radixattention/quiz.json
+++ b/phases/17-infrastructure-and-production/06-sglang-radixattention/quiz.json
@@ -1,0 +1,78 @@
+{
+  "lesson": "06-sglang-radixattention",
+  "title": "SGLang and RadixAttention for Prefix-Heavy Workloads",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "What core data structure backs SGLang's KV cache reuse?",
+      "options": [
+        "A skip list keyed by request id",
+        "A radix tree where each node owns a token range and its KV blocks",
+        "A hash table keyed by full prompt",
+        "A B-tree of attention scores"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Why is FCFS scheduling wrong for prefix-heavy traffic on SGLang?",
+      "options": [
+        "FCFS is the recommended SGLang policy",
+        "FCFS can evict a hot prefix branch before the next long-prefix request hits, breaking radix-tree reuse",
+        "FCFS only works on AMD GPUs",
+        "FCFS is incompatible with PagedAttention"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "What eviction granularity does SGLang's cache-aware scheduler use to match radix shape?",
+      "options": [
+        "Single tokens",
+        "Whole branches, starting from shortest-used leaves",
+        "Random eviction",
+        "Per-request only"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "What is the most direct engineer's lever for keeping the radix-tree shared prefix discoverable?",
+      "options": [
+        "Lower the GPU memory utilization knob",
+        "Fix prompt-template ordering so immutable content (system, tools, schemas) is always first",
+        "Always use static batching",
+        "Disable continuous batching"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Which workload pattern does the lesson NOT expect RadixAttention to win on?",
+      "options": [
+        "Agents with shared tool schemas",
+        "Single-shot generation with unique prompts and no shared system prompt",
+        "RAG with a shared retrieval preamble",
+        "Voice workloads with repeated preambles"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "ProjectDiscovery's deployment moved from 7% to 74% prefix-cache hit rate by doing what?",
+      "options": [
+        "Switching from vLLM to SGLang without any prompt changes",
+        "Moving dynamic content out of the cacheable prefix",
+        "Increasing GPU count from 8 to 16",
+        "Disabling continuous batching"
+      ],
+      "correct": 1,
+      "explanation": ""
+    }
+  ]
+}

--- a/phases/17-infrastructure-and-production/06-sglang-radixattention/quiz.json
+++ b/phases/17-infrastructure-and-production/06-sglang-radixattention/quiz.json
@@ -6,34 +6,34 @@
       "stage": "pre",
       "question": "What core data structure backs SGLang's KV cache reuse?",
       "options": [
-        "A skip list keyed by request id",
         "A radix tree where each node owns a token range and its KV blocks",
         "A hash table keyed by full prompt",
+        "A skip list keyed by request id",
         "A B-tree of attention scores"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "Why is FCFS scheduling wrong for prefix-heavy traffic on SGLang?",
       "options": [
-        "FCFS is the recommended SGLang policy",
-        "FCFS can evict a hot prefix branch before the next long-prefix request hits, breaking radix-tree reuse",
         "FCFS only works on AMD GPUs",
-        "FCFS is incompatible with PagedAttention"
+        "FCFS is the recommended SGLang policy",
+        "FCFS is incompatible with PagedAttention",
+        "FCFS can evict a hot prefix branch before the next long-prefix request hits, breaking radix-tree reuse"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "What eviction granularity does SGLang's cache-aware scheduler use to match radix shape?",
       "options": [
-        "Single tokens",
+        "Per-request only",
         "Whole branches, starting from shortest-used leaves",
-        "Random eviction",
-        "Per-request only"
+        "Single tokens",
+        "Random eviction"
       ],
       "correct": 1,
       "explanation": ""
@@ -55,23 +55,23 @@
       "question": "Which workload pattern does the lesson NOT expect RadixAttention to win on?",
       "options": [
         "Agents with shared tool schemas",
-        "Single-shot generation with unique prompts and no shared system prompt",
+        "Voice workloads with repeated preambles",
         "RAG with a shared retrieval preamble",
-        "Voice workloads with repeated preambles"
+        "Single-shot generation with unique prompts and no shared system prompt"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
       "stage": "post",
       "question": "ProjectDiscovery's deployment moved from 7% to 74% prefix-cache hit rate by doing what?",
       "options": [
-        "Switching from vLLM to SGLang without any prompt changes",
         "Moving dynamic content out of the cacheable prefix",
         "Increasing GPU count from 8 to 16",
+        "Switching from vLLM to SGLang without any prompt changes",
         "Disabling continuous batching"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     }
   ]

--- a/phases/17-infrastructure-and-production/07-tensorrt-llm-blackwell/quiz.json
+++ b/phases/17-infrastructure-and-production/07-tensorrt-llm-blackwell/quiz.json
@@ -1,0 +1,78 @@
+{
+  "lesson": "07-tensorrt-llm-blackwell",
+  "title": "TensorRT-LLM on Blackwell with FP8 and NVFP4",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "Roughly what is the per-million-tokens cost gap the lesson reports between Blackwell + TRT-LLM + Dynamo and H100 + vLLM on a comparable 120B-class workload?",
+      "options": [
+        "About 1.1x",
+        "About 2x",
+        "About 7x",
+        "About 100x"
+      ],
+      "correct": 2,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Why does the lesson recommend keeping KV cache in FP8 rather than NVFP4 on Blackwell?",
+      "options": [
+        "FP8 is the only precision NVLink 5 supports",
+        "KV cache spans a wide dynamic range; FP4 quantization causes catastrophic accuracy loss in attention scores",
+        "FP8 uses less memory than FP4",
+        "NVFP4 KV cache is not yet supported in any engine"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Which Blackwell feature does TRT-LLM exploit so models can be loaded without a post-training conversion step?",
+      "options": [
+        "Day-0 FP4 weights shipped by model providers",
+        "INT2 weights via bitsandbytes",
+        "FP64 attention",
+        "BF16 KV cache"
+      ],
+      "correct": 0,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "What is the dominant tradeoff of choosing the TRT-LLM stack per the lesson?",
+      "options": [
+        "It only works at small scale",
+        "It locks you into NVIDIA hardware — no AMD, no Intel, no ARM",
+        "It requires fully autonomous remediation",
+        "It cannot serve MoE models"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Which precision combination does the lesson describe as the typical Blackwell config?",
+      "options": [
+        "Weights NVFP4, activations NVFP4, KV cache FP8, attention accumulator FP32",
+        "Everything in BF16",
+        "Weights INT8, activations FP32, KV cache INT4",
+        "Weights FP4, KV cache FP4, attention in INT8"
+      ],
+      "correct": 0,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "For reasoning-heavy workloads where NVFP4 weight conversion drops MATH accuracy a few points, what does the lesson advise?",
+      "options": [
+        "Ship NVFP4 anyway because the cost win dominates",
+        "Validate task quality on your eval set per model; teams often use FP8 weights + FP4 activations or stay on H200 with FP8 throughout",
+        "Switch to AMD MI300X",
+        "Disable speculative decoding"
+      ],
+      "correct": 1,
+      "explanation": ""
+    }
+  ]
+}

--- a/phases/17-infrastructure-and-production/07-tensorrt-llm-blackwell/quiz.json
+++ b/phases/17-infrastructure-and-production/07-tensorrt-llm-blackwell/quiz.json
@@ -6,24 +6,24 @@
       "stage": "pre",
       "question": "Roughly what is the per-million-tokens cost gap the lesson reports between Blackwell + TRT-LLM + Dynamo and H100 + vLLM on a comparable 120B-class workload?",
       "options": [
-        "About 1.1x",
-        "About 2x",
+        "About 100x",
         "About 7x",
-        "About 100x"
+        "About 2x",
+        "About 1.1x"
       ],
-      "correct": 2,
+      "correct": 1,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "Why does the lesson recommend keeping KV cache in FP8 rather than NVFP4 on Blackwell?",
       "options": [
+        "NVFP4 KV cache is not yet supported in any engine",
         "FP8 is the only precision NVLink 5 supports",
         "KV cache spans a wide dynamic range; FP4 quantization causes catastrophic accuracy loss in attention scores",
-        "FP8 uses less memory than FP4",
-        "NVFP4 KV cache is not yet supported in any engine"
+        "FP8 uses less memory than FP4"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     },
     {
@@ -42,36 +42,36 @@
       "stage": "check",
       "question": "What is the dominant tradeoff of choosing the TRT-LLM stack per the lesson?",
       "options": [
-        "It only works at small scale",
-        "It locks you into NVIDIA hardware — no AMD, no Intel, no ARM",
+        "It cannot serve MoE models",
         "It requires fully autonomous remediation",
-        "It cannot serve MoE models"
+        "It locks you into NVIDIA hardware — no AMD, no Intel, no ARM",
+        "It only works at small scale"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     },
     {
       "stage": "post",
       "question": "Which precision combination does the lesson describe as the typical Blackwell config?",
       "options": [
-        "Weights NVFP4, activations NVFP4, KV cache FP8, attention accumulator FP32",
+        "Weights FP4, KV cache FP4, attention in INT8",
         "Everything in BF16",
-        "Weights INT8, activations FP32, KV cache INT4",
-        "Weights FP4, KV cache FP4, attention in INT8"
+        "Weights NVFP4, activations NVFP4, KV cache FP8, attention accumulator FP32",
+        "Weights INT8, activations FP32, KV cache INT4"
       ],
-      "correct": 0,
+      "correct": 2,
       "explanation": ""
     },
     {
       "stage": "post",
       "question": "For reasoning-heavy workloads where NVFP4 weight conversion drops MATH accuracy a few points, what does the lesson advise?",
       "options": [
-        "Ship NVFP4 anyway because the cost win dominates",
-        "Validate task quality on your eval set per model; teams often use FP8 weights + FP4 activations or stay on H200 with FP8 throughout",
         "Switch to AMD MI300X",
-        "Disable speculative decoding"
+        "Disable speculative decoding",
+        "Validate task quality on your eval set per model; teams often use FP8 weights + FP4 activations or stay on H200 with FP8 throughout",
+        "Ship NVFP4 anyway because the cost win dominates"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     }
   ]

--- a/phases/17-infrastructure-and-production/08-inference-metrics-goodput/quiz.json
+++ b/phases/17-infrastructure-and-production/08-inference-metrics-goodput/quiz.json
@@ -1,0 +1,78 @@
+{
+  "lesson": "08-inference-metrics-goodput",
+  "title": "Inference Metrics — TTFT, TPOT, ITL, Goodput, P99",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "Which components dominate TTFT (time to first token)?",
+      "options": [
+        "Decode-only forward time",
+        "Queue time, network request time, and prefill time",
+        "Tokenizer GIL overhead",
+        "Disk I/O for weights"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Which metric does the lesson call the one that actually matters for product?",
+      "options": [
+        "Aggregate throughput in tokens per second",
+        "Goodput — fraction of requests meeting every SLO constraint simultaneously",
+        "Mean ITL",
+        "GPU duty cycle"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Why is mean the wrong statistic to report for LLM latency?",
+      "options": [
+        "LLM latency distributions are right-skewed; users routinely hit P99 outliers that mean hides",
+        "Mean is never computable on streaming responses",
+        "Mean is not supported by GenAI-Perf",
+        "Mean only works for prefill, not decode"
+      ],
+      "correct": 0,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Why do GenAI-Perf and LLMPerf disagree on TPOT for the same run?",
+      "options": [
+        "GenAI-Perf only runs on Blackwell",
+        "GenAI-Perf excludes TTFT from the ITL calculation; LLMPerf includes it, so tool choice changes the number",
+        "LLMPerf uses microseconds and GenAI-Perf uses milliseconds",
+        "They sample different requests"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "For long-output requests (>500 tokens), which metric dominates end-to-end latency?",
+      "options": [
+        "TTFT",
+        "TPOT times output length",
+        "Network response time",
+        "Cold-start time"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Which set best captures the lesson's reasonable consumer-facing SLO for a 70B chat model in 2026?",
+      "options": [
+        "TTFT P99 8s, TPOT P99 200ms, goodput 50%",
+        "TTFT P99 800 ms, TPOT P99 25 ms, E2E P99 3 s for <300-token outputs, goodput >= 99%",
+        "Mean TTFT 10 ms, mean TPOT 1 ms",
+        "P50 only, no percentiles above"
+      ],
+      "correct": 1,
+      "explanation": ""
+    }
+  ]
+}

--- a/phases/17-infrastructure-and-production/08-inference-metrics-goodput/quiz.json
+++ b/phases/17-infrastructure-and-production/08-inference-metrics-goodput/quiz.json
@@ -7,35 +7,35 @@
       "question": "Which components dominate TTFT (time to first token)?",
       "options": [
         "Decode-only forward time",
-        "Queue time, network request time, and prefill time",
+        "Disk I/O for weights",
         "Tokenizer GIL overhead",
-        "Disk I/O for weights"
+        "Queue time, network request time, and prefill time"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "Which metric does the lesson call the one that actually matters for product?",
       "options": [
+        "GPU duty cycle",
         "Aggregate throughput in tokens per second",
         "Goodput — fraction of requests meeting every SLO constraint simultaneously",
-        "Mean ITL",
-        "GPU duty cycle"
+        "Mean ITL"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "Why is mean the wrong statistic to report for LLM latency?",
       "options": [
-        "LLM latency distributions are right-skewed; users routinely hit P99 outliers that mean hides",
         "Mean is never computable on streaming responses",
-        "Mean is not supported by GenAI-Perf",
-        "Mean only works for prefill, not decode"
+        "Mean only works for prefill, not decode",
+        "LLM latency distributions are right-skewed; users routinely hit P99 outliers that mean hides",
+        "Mean is not supported by GenAI-Perf"
       ],
-      "correct": 0,
+      "correct": 2,
       "explanation": ""
     },
     {
@@ -54,22 +54,22 @@
       "stage": "post",
       "question": "For long-output requests (>500 tokens), which metric dominates end-to-end latency?",
       "options": [
-        "TTFT",
         "TPOT times output length",
-        "Network response time",
-        "Cold-start time"
+        "Cold-start time",
+        "TTFT",
+        "Network response time"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     },
     {
       "stage": "post",
       "question": "Which set best captures the lesson's reasonable consumer-facing SLO for a 70B chat model in 2026?",
       "options": [
-        "TTFT P99 8s, TPOT P99 200ms, goodput 50%",
+        "P50 only, no percentiles above",
         "TTFT P99 800 ms, TPOT P99 25 ms, E2E P99 3 s for <300-token outputs, goodput >= 99%",
-        "Mean TTFT 10 ms, mean TPOT 1 ms",
-        "P50 only, no percentiles above"
+        "TTFT P99 8s, TPOT P99 200ms, goodput 50%",
+        "Mean TTFT 10 ms, mean TPOT 1 ms"
       ],
       "correct": 1,
       "explanation": ""

--- a/phases/17-infrastructure-and-production/09-production-quantization/quiz.json
+++ b/phases/17-infrastructure-and-production/09-production-quantization/quiz.json
@@ -6,10 +6,10 @@
       "stage": "pre",
       "question": "Which quantization format does the lesson call the production default for CPU and edge serving?",
       "options": [
-        "AWQ INT4",
+        "FP8",
         "GGUF Q4_K_M / Q5_K_M",
-        "NVFP4",
-        "FP8"
+        "AWQ INT4",
+        "NVFP4"
       ],
       "correct": 1,
       "explanation": ""
@@ -18,34 +18,34 @@
       "stage": "check",
       "question": "Which format is the lesson's pick for datacenter GPU serving when multi-LoRA is required in vLLM?",
       "options": [
+        "GGUF Q4_K_M",
         "AWQ",
         "GPTQ with Marlin kernels",
-        "GGUF Q4_K_M",
         "NVFP4"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "What is the \"my model is 4 GB now\" trap with AWQ?",
       "options": [
-        "AWQ does not actually shrink weights",
-        "AWQ only shrinks weights; KV cache and activations are separate and can add 30-50 GB at production batch sizes",
+        "AWQ is incompatible with vLLM",
         "AWQ requires INT8 KV cache",
-        "AWQ is incompatible with vLLM"
+        "AWQ does not actually shrink weights",
+        "AWQ only shrinks weights; KV cache and activations are separate and can add 30-50 GB at production batch sizes"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "Why does calibrating AWQ on generic web text hurt domain models?",
       "options": [
-        "It increases model size",
+        "It disables Marlin kernels",
         "The algorithm makes wrong decisions about which weights to protect, dropping domain accuracy (for example several Pass@1 points on HumanEval)",
         "It only works on AMD GPUs",
-        "It disables Marlin kernels"
+        "It increases model size"
       ],
       "correct": 1,
       "explanation": ""
@@ -54,12 +54,12 @@
       "stage": "post",
       "question": "For a reasoning-heavy workload where quality is non-negotiable, which precision does the lesson recommend by default?",
       "options": [
-        "NVFP4 weights",
-        "FP8 weights",
+        "GPTQ INT4",
         "INT2 GGUF",
-        "GPTQ INT4"
+        "NVFP4 weights",
+        "FP8 weights"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {

--- a/phases/17-infrastructure-and-production/09-production-quantization/quiz.json
+++ b/phases/17-infrastructure-and-production/09-production-quantization/quiz.json
@@ -1,0 +1,78 @@
+{
+  "lesson": "09-production-quantization",
+  "title": "Production Quantization — AWQ, GPTQ, GGUF K-quants, FP8, MXFP4/NVFP4",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "Which quantization format does the lesson call the production default for CPU and edge serving?",
+      "options": [
+        "AWQ INT4",
+        "GGUF Q4_K_M / Q5_K_M",
+        "NVFP4",
+        "FP8"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Which format is the lesson's pick for datacenter GPU serving when multi-LoRA is required in vLLM?",
+      "options": [
+        "AWQ",
+        "GPTQ with Marlin kernels",
+        "GGUF Q4_K_M",
+        "NVFP4"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "What is the \"my model is 4 GB now\" trap with AWQ?",
+      "options": [
+        "AWQ does not actually shrink weights",
+        "AWQ only shrinks weights; KV cache and activations are separate and can add 30-50 GB at production batch sizes",
+        "AWQ requires INT8 KV cache",
+        "AWQ is incompatible with vLLM"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Why does calibrating AWQ on generic web text hurt domain models?",
+      "options": [
+        "It increases model size",
+        "The algorithm makes wrong decisions about which weights to protect, dropping domain accuracy (for example several Pass@1 points on HumanEval)",
+        "It only works on AMD GPUs",
+        "It disables Marlin kernels"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "For a reasoning-heavy workload where quality is non-negotiable, which precision does the lesson recommend by default?",
+      "options": [
+        "NVFP4 weights",
+        "FP8 weights",
+        "INT2 GGUF",
+        "GPTQ INT4"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Which 2026 quantization limitation does the lesson call out for NVFP4 in early 2026?",
+      "options": [
+        "No LoRA support yet",
+        "Not supported on H100",
+        "Only runs on CPU",
+        "Cannot be combined with FP8 KV cache"
+      ],
+      "correct": 0,
+      "explanation": ""
+    }
+  ]
+}

--- a/phases/17-infrastructure-and-production/10-cold-start-mitigation/quiz.json
+++ b/phases/17-infrastructure-and-production/10-cold-start-mitigation/quiz.json
@@ -1,0 +1,78 @@
+{
+  "lesson": "10-cold-start-mitigation",
+  "title": "Cold Start Mitigation for Serverless LLMs",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "Roughly how long does a cold start typically take for a 70B model on a fresh node without mitigations?",
+      "options": [
+        "Under 10 seconds",
+        "30-60 seconds",
+        "3-8 minutes",
+        "Over 1 hour"
+      ],
+      "correct": 2,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Which AWS-side feature does the lesson recommend for pre-seeding container images so step-2 image pull disappears?",
+      "options": [
+        "EBS volume snapshots only",
+        "Bottlerocket dual-volume architecture referenced from EC2NodeClass",
+        "ECS task definitions",
+        "Spot fleet placement"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Which Modal feature provides the closest thing to a \"warm GPU boot in seconds\" by deserializing post-load state directly into HBM?",
+      "options": [
+        "Live migration",
+        "GPU memory snapshots (checkpoints)",
+        "Tiered NVMe-to-DRAM loading",
+        "Run:ai Model Streamer"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Why does live migration transfer input tokens rather than KV cache between nodes?",
+      "options": [
+        "Recomputing KV on the destination is cheaper than transferring GB of KV cache over the network",
+        "KV cache is encrypted and cannot move",
+        "Input tokens have larger entropy",
+        "Live migration is required by GDPR"
+      ],
+      "correct": 0,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Which serverless layer trades direct GPU cost for predictable readiness by keeping at least one replica live?",
+      "options": [
+        "Tiered loading",
+        "Warm pool with min_workers >= 1",
+        "Bottlerocket pre-seeding",
+        "Live migration"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Why does the lesson say cold-start mitigation must be stacked across layers rather than picked as a single tool?",
+      "options": [
+        "No single layer eliminates every step (node provision, image pull, weights load, engine init); stacking layers compresses each step",
+        "Modal owns the entire stack",
+        "All five layers are bundled in vLLM",
+        "It is a regulatory requirement"
+      ],
+      "correct": 0,
+      "explanation": ""
+    }
+  ]
+}

--- a/phases/17-infrastructure-and-production/10-cold-start-mitigation/quiz.json
+++ b/phases/17-infrastructure-and-production/10-cold-start-mitigation/quiz.json
@@ -6,10 +6,10 @@
       "stage": "pre",
       "question": "Roughly how long does a cold start typically take for a 70B model on a fresh node without mitigations?",
       "options": [
-        "Under 10 seconds",
+        "Over 1 hour",
         "30-60 seconds",
         "3-8 minutes",
-        "Over 1 hour"
+        "Under 10 seconds"
       ],
       "correct": 2,
       "explanation": ""
@@ -18,48 +18,48 @@
       "stage": "check",
       "question": "Which AWS-side feature does the lesson recommend for pre-seeding container images so step-2 image pull disappears?",
       "options": [
-        "EBS volume snapshots only",
         "Bottlerocket dual-volume architecture referenced from EC2NodeClass",
         "ECS task definitions",
-        "Spot fleet placement"
+        "Spot fleet placement",
+        "EBS volume snapshots only"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "Which Modal feature provides the closest thing to a \"warm GPU boot in seconds\" by deserializing post-load state directly into HBM?",
       "options": [
+        "Tiered NVMe-to-DRAM loading",
         "Live migration",
         "GPU memory snapshots (checkpoints)",
-        "Tiered NVMe-to-DRAM loading",
         "Run:ai Model Streamer"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "Why does live migration transfer input tokens rather than KV cache between nodes?",
       "options": [
-        "Recomputing KV on the destination is cheaper than transferring GB of KV cache over the network",
-        "KV cache is encrypted and cannot move",
+        "Live migration is required by GDPR",
         "Input tokens have larger entropy",
-        "Live migration is required by GDPR"
+        "KV cache is encrypted and cannot move",
+        "Recomputing KV on the destination is cheaper than transferring GB of KV cache over the network"
       ],
-      "correct": 0,
+      "correct": 3,
       "explanation": ""
     },
     {
       "stage": "post",
       "question": "Which serverless layer trades direct GPU cost for predictable readiness by keeping at least one replica live?",
       "options": [
-        "Tiered loading",
         "Warm pool with min_workers >= 1",
+        "Tiered loading",
         "Bottlerocket pre-seeding",
         "Live migration"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     },
     {
@@ -67,9 +67,9 @@
       "question": "Why does the lesson say cold-start mitigation must be stacked across layers rather than picked as a single tool?",
       "options": [
         "No single layer eliminates every step (node provision, image pull, weights load, engine init); stacking layers compresses each step",
+        "It is a regulatory requirement",
         "Modal owns the entire stack",
-        "All five layers are bundled in vLLM",
-        "It is a regulatory requirement"
+        "All five layers are bundled in vLLM"
       ],
       "correct": 0,
       "explanation": ""

--- a/phases/17-infrastructure-and-production/11-multi-region-kv-locality/quiz.json
+++ b/phases/17-infrastructure-and-production/11-multi-region-kv-locality/quiz.json
@@ -1,0 +1,78 @@
+{
+  "lesson": "11-multi-region-kv-locality",
+  "title": "Multi-Region LLM Serving and KV Cache Locality",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "Why is round-robin load balancing actively harmful for cached LLM inference?",
+      "options": [
+        "Round-robin requires sticky sessions",
+        "A request that does not land on the node holding its prefix pays full prefill cost instead of a cache hit",
+        "Round-robin breaks TLS",
+        "Round-robin is only valid for stateful databases"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "What two inputs does a cache-aware router consume?",
+      "options": [
+        "Random shuffles and request size",
+        "KV-cache events from replicas and a prefix hash on the incoming request",
+        "Round-robin counters and TLS keys",
+        "Only the user_id and tenant_id"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Roughly what is the TTFT gap between a cache hit and a cold prefill on a 2K-token prompt for Llama 3.3 70B FP8?",
+      "options": [
+        "About 1.1x",
+        "About 10x (~80 ms vs ~800 ms)",
+        "About 1000x",
+        "Identical"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Why does cross-region routing not always beat regional routing for cache hits?",
+      "options": [
+        "Inter-region routing is forbidden by all hyperscalers",
+        "Saved prefill can be dwarfed by network RTT, e.g. 440 ms round-trip can dwarf an 800-to-80 ms prefill saving",
+        "Cache-aware routing is impossible across regions",
+        "GORGO research found cache hits do not help latency"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "What does the lesson cite as the 32% LLM DR failure driver?",
+      "options": [
+        "Misconfigured load balancers",
+        "Backups that include weights but miss tokenizer files or quantization configs",
+        "Unencrypted backups",
+        "Region quota exhaustion"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "What does the lesson say about commercial cross-region inference offerings such as Bedrock CRI?",
+      "options": [
+        "They are KV-cache-aware and replace app-layer routing",
+        "They optimize availability, not TTFT, and treat inference as opaque — you still need an app-layer cache-aware router",
+        "They are forbidden under GDPR",
+        "They only work in us-east-1"
+      ],
+      "correct": 1,
+      "explanation": ""
+    }
+  ]
+}

--- a/phases/17-infrastructure-and-production/11-multi-region-kv-locality/quiz.json
+++ b/phases/17-infrastructure-and-production/11-multi-region-kv-locality/quiz.json
@@ -6,12 +6,12 @@
       "stage": "pre",
       "question": "Why is round-robin load balancing actively harmful for cached LLM inference?",
       "options": [
-        "Round-robin requires sticky sessions",
         "A request that does not land on the node holding its prefix pays full prefill cost instead of a cache hit",
+        "Round-robin requires sticky sessions",
         "Round-robin breaks TLS",
         "Round-robin is only valid for stateful databases"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     },
     {
@@ -19,21 +19,21 @@
       "question": "What two inputs does a cache-aware router consume?",
       "options": [
         "Random shuffles and request size",
-        "KV-cache events from replicas and a prefix hash on the incoming request",
+        "Only the user_id and tenant_id",
         "Round-robin counters and TLS keys",
-        "Only the user_id and tenant_id"
+        "KV-cache events from replicas and a prefix hash on the incoming request"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "Roughly what is the TTFT gap between a cache hit and a cold prefill on a 2K-token prompt for Llama 3.3 70B FP8?",
       "options": [
-        "About 1.1x",
+        "Identical",
         "About 10x (~80 ms vs ~800 ms)",
-        "About 1000x",
-        "Identical"
+        "About 1.1x",
+        "About 1000x"
       ],
       "correct": 1,
       "explanation": ""
@@ -42,24 +42,24 @@
       "stage": "check",
       "question": "Why does cross-region routing not always beat regional routing for cache hits?",
       "options": [
-        "Inter-region routing is forbidden by all hyperscalers",
-        "Saved prefill can be dwarfed by network RTT, e.g. 440 ms round-trip can dwarf an 800-to-80 ms prefill saving",
         "Cache-aware routing is impossible across regions",
-        "GORGO research found cache hits do not help latency"
+        "GORGO research found cache hits do not help latency",
+        "Inter-region routing is forbidden by all hyperscalers",
+        "Saved prefill can be dwarfed by network RTT, e.g. 440 ms round-trip can dwarf an 800-to-80 ms prefill saving"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
       "stage": "post",
       "question": "What does the lesson cite as the 32% LLM DR failure driver?",
       "options": [
-        "Misconfigured load balancers",
         "Backups that include weights but miss tokenizer files or quantization configs",
-        "Unencrypted backups",
-        "Region quota exhaustion"
+        "Region quota exhaustion",
+        "Misconfigured load balancers",
+        "Unencrypted backups"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     },
     {
@@ -67,11 +67,11 @@
       "question": "What does the lesson say about commercial cross-region inference offerings such as Bedrock CRI?",
       "options": [
         "They are KV-cache-aware and replace app-layer routing",
+        "They only work in us-east-1",
         "They optimize availability, not TTFT, and treat inference as opaque — you still need an app-layer cache-aware router",
-        "They are forbidden under GDPR",
-        "They only work in us-east-1"
+        "They are forbidden under GDPR"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     }
   ]

--- a/phases/17-infrastructure-and-production/12-edge-inference/quiz.json
+++ b/phases/17-infrastructure-and-production/12-edge-inference/quiz.json
@@ -6,12 +6,12 @@
       "stage": "pre",
       "question": "What is the core constraint that makes mobile LLM inference slower than datacenter, per the lesson?",
       "options": [
+        "Wi-Fi latency",
         "Compute throughput",
         "Memory bandwidth (mobile DRAM at 50-90 GB/s vs HBM3 at 2-3 TB/s)",
-        "Storage capacity",
-        "Wi-Fi latency"
+        "Storage capacity"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     },
     {
@@ -19,45 +19,45 @@
       "question": "Why does Apple's Neural Engine avoid CPU-NPU copy overhead?",
       "options": [
         "It uses PCIe 5.0",
-        "Apple Silicon ships unified memory — CPU and ANE share the same pool",
         "Core ML disables KV cache",
-        "It transcodes weights to FP4 before copy"
+        "It transcodes weights to FP4 before copy",
+        "Apple Silicon ships unified memory — CPU and ANE share the same pool"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "Which quantization format does the lesson recommend for WebGPU + WebLLM in the browser?",
       "options": [
-        "GGUF Q4_K_M",
-        "Q4 MLC (q4f16_1) compiled via mlc_llm convert_weight",
         "NVFP4",
-        "FP8"
+        "FP8",
+        "Q4 MLC (q4f16_1) compiled via mlc_llm convert_weight",
+        "GGUF Q4_K_M"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "Roughly what WebGPU mobile coverage does the lesson report for 2026?",
       "options": [
-        "Under 10%",
-        "About 70-75%, with Firefox Android still catching up",
         "100% across all browsers",
-        "Only iOS Safari"
+        "Only iOS Safari",
+        "Under 10%",
+        "About 70-75%, with Firefox Android still catching up"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
       "stage": "post",
       "question": "Why is keeping 128K context impractical on a typical phone?",
       "options": [
-        "WebGPU caps context at 4K",
+        "Tokenizers fail above 8K",
         "Model weights plus KV cache for 32K tokens plus OS overhead easily exceed the 8 GB RAM budget",
-        "iOS forbids long context",
-        "Tokenizers fail above 8K"
+        "WebGPU caps context at 4K",
+        "iOS forbids long context"
       ],
       "correct": 1,
       "explanation": ""
@@ -66,12 +66,12 @@
       "stage": "post",
       "question": "Why is voice highlighted as the killer app for edge inference?",
       "options": [
-        "Voice models do not need KV cache",
         "Voice agents are latency-sensitive (first token < 500 ms) and local inference eliminates network latency entirely",
-        "Voice runs in WebAssembly only",
-        "Voice models always fit in 50 MB"
+        "Voice models do not need KV cache",
+        "Voice models always fit in 50 MB",
+        "Voice runs in WebAssembly only"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     }
   ]

--- a/phases/17-infrastructure-and-production/12-edge-inference/quiz.json
+++ b/phases/17-infrastructure-and-production/12-edge-inference/quiz.json
@@ -1,0 +1,78 @@
+{
+  "lesson": "12-edge-inference",
+  "title": "Edge Inference — Apple Neural Engine, Qualcomm Hexagon, WebGPU/WebLLM, Jetson",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "What is the core constraint that makes mobile LLM inference slower than datacenter, per the lesson?",
+      "options": [
+        "Compute throughput",
+        "Memory bandwidth (mobile DRAM at 50-90 GB/s vs HBM3 at 2-3 TB/s)",
+        "Storage capacity",
+        "Wi-Fi latency"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Why does Apple's Neural Engine avoid CPU-NPU copy overhead?",
+      "options": [
+        "It uses PCIe 5.0",
+        "Apple Silicon ships unified memory — CPU and ANE share the same pool",
+        "Core ML disables KV cache",
+        "It transcodes weights to FP4 before copy"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Which quantization format does the lesson recommend for WebGPU + WebLLM in the browser?",
+      "options": [
+        "GGUF Q4_K_M",
+        "Q4 MLC (q4f16_1) compiled via mlc_llm convert_weight",
+        "NVFP4",
+        "FP8"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Roughly what WebGPU mobile coverage does the lesson report for 2026?",
+      "options": [
+        "Under 10%",
+        "About 70-75%, with Firefox Android still catching up",
+        "100% across all browsers",
+        "Only iOS Safari"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Why is keeping 128K context impractical on a typical phone?",
+      "options": [
+        "WebGPU caps context at 4K",
+        "Model weights plus KV cache for 32K tokens plus OS overhead easily exceed the 8 GB RAM budget",
+        "iOS forbids long context",
+        "Tokenizers fail above 8K"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Why is voice highlighted as the killer app for edge inference?",
+      "options": [
+        "Voice models do not need KV cache",
+        "Voice agents are latency-sensitive (first token < 500 ms) and local inference eliminates network latency entirely",
+        "Voice runs in WebAssembly only",
+        "Voice models always fit in 50 MB"
+      ],
+      "correct": 1,
+      "explanation": ""
+    }
+  ]
+}

--- a/phases/17-infrastructure-and-production/13-llm-observability/quiz.json
+++ b/phases/17-infrastructure-and-production/13-llm-observability/quiz.json
@@ -1,0 +1,78 @@
+{
+  "lesson": "13-llm-observability",
+  "title": "LLM Observability Stack Selection",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "How does the lesson split the 2026 LLM observability market?",
+      "options": [
+        "Vendor versus open source",
+        "Development platforms (bundled with evals/prompts/sessions) versus gateway/telemetry tools",
+        "On-prem versus cloud",
+        "Python versus TypeScript"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Which tool does the lesson position as MIT-licensed core with strong self-host story and 50K events/month free cloud tier?",
+      "options": [
+        "Phoenix",
+        "Arize AX",
+        "Langfuse",
+        "LangSmith"
+      ],
+      "correct": 2,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "What is Arize AX's main scale claim relative to monolithic observability stacks like Datadog?",
+      "options": [
+        "10% cheaper",
+        "Roughly 100x cheaper at scale via zero-copy Iceberg/Parquet integration",
+        "Always more expensive",
+        "Free under 1M events/day"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "What does the lesson call the wrong instrumentation layer for portability?",
+      "options": [
+        "Instrumenting at the HTTP/OpenAI-SDK layer",
+        "Instrumenting inside your agent framework, since it couples you to that framework",
+        "Using OpenTelemetry GenAI semantic conventions",
+        "Sampling at 5% on successes"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Which OpenTelemetry conventions does the lesson identify as the 2026 interop layer between observability tools?",
+      "options": [
+        "OTel HTTP semantic conventions",
+        "GenAI semantic conventions (gen_ai.system, gen_ai.request.model, gen_ai.usage.input_tokens)",
+        "OTel database semantic conventions",
+        "OTel messaging semantic conventions"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Why does the lesson argue full-trace retention does not scale past 1M requests/day?",
+      "options": [
+        "Vendors block it",
+        "Retention storage costs more than the LLM calls themselves; teams must sample (e.g. 100% errors, 100% high-cost, 5% successes)",
+        "OpenTelemetry caps trace volume",
+        "Phoenix only supports 1M traces"
+      ],
+      "correct": 1,
+      "explanation": ""
+    }
+  ]
+}

--- a/phases/17-infrastructure-and-production/13-llm-observability/quiz.json
+++ b/phases/17-infrastructure-and-production/13-llm-observability/quiz.json
@@ -6,34 +6,34 @@
       "stage": "pre",
       "question": "How does the lesson split the 2026 LLM observability market?",
       "options": [
-        "Vendor versus open source",
         "Development platforms (bundled with evals/prompts/sessions) versus gateway/telemetry tools",
         "On-prem versus cloud",
+        "Vendor versus open source",
         "Python versus TypeScript"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "Which tool does the lesson position as MIT-licensed core with strong self-host story and 50K events/month free cloud tier?",
       "options": [
+        "LangSmith",
         "Phoenix",
         "Arize AX",
-        "Langfuse",
-        "LangSmith"
+        "Langfuse"
       ],
-      "correct": 2,
+      "correct": 3,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "What is Arize AX's main scale claim relative to monolithic observability stacks like Datadog?",
       "options": [
-        "10% cheaper",
-        "Roughly 100x cheaper at scale via zero-copy Iceberg/Parquet integration",
         "Always more expensive",
-        "Free under 1M events/day"
+        "Roughly 100x cheaper at scale via zero-copy Iceberg/Parquet integration",
+        "Free under 1M events/day",
+        "10% cheaper"
       ],
       "correct": 1,
       "explanation": ""
@@ -42,36 +42,36 @@
       "stage": "check",
       "question": "What does the lesson call the wrong instrumentation layer for portability?",
       "options": [
-        "Instrumenting at the HTTP/OpenAI-SDK layer",
         "Instrumenting inside your agent framework, since it couples you to that framework",
+        "Sampling at 5% on successes",
         "Using OpenTelemetry GenAI semantic conventions",
-        "Sampling at 5% on successes"
+        "Instrumenting at the HTTP/OpenAI-SDK layer"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     },
     {
       "stage": "post",
       "question": "Which OpenTelemetry conventions does the lesson identify as the 2026 interop layer between observability tools?",
       "options": [
-        "OTel HTTP semantic conventions",
-        "GenAI semantic conventions (gen_ai.system, gen_ai.request.model, gen_ai.usage.input_tokens)",
+        "OTel messaging semantic conventions",
         "OTel database semantic conventions",
-        "OTel messaging semantic conventions"
+        "GenAI semantic conventions (gen_ai.system, gen_ai.request.model, gen_ai.usage.input_tokens)",
+        "OTel HTTP semantic conventions"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     },
     {
       "stage": "post",
       "question": "Why does the lesson argue full-trace retention does not scale past 1M requests/day?",
       "options": [
-        "Vendors block it",
         "Retention storage costs more than the LLM calls themselves; teams must sample (e.g. 100% errors, 100% high-cost, 5% successes)",
         "OpenTelemetry caps trace volume",
+        "Vendors block it",
         "Phoenix only supports 1M traces"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     }
   ]

--- a/phases/17-infrastructure-and-production/14-prompt-semantic-caching/quiz.json
+++ b/phases/17-infrastructure-and-production/14-prompt-semantic-caching/quiz.json
@@ -1,0 +1,78 @@
+{
+  "lesson": "14-prompt-semantic-caching",
+  "title": "Prompt Caching and Semantic Caching Economics",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "What is the difference between L1 semantic caching and L2 prompt/prefix caching?",
+      "options": [
+        "L1 and L2 are the same",
+        "L1 skips the LLM entirely on embedding similarity hits; L2 reuses attention KV at the provider for repeated prefixes",
+        "L1 is provider-side and L2 is client-side",
+        "L2 stores embeddings; L1 stores attention KV"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Which Anthropic mechanism marks blocks as cacheable for L2 prompt caching?",
+      "options": [
+        "An implicit prompt-length threshold",
+        "Explicit cache_control attribute on the request blocks",
+        "A separate /caches endpoint",
+        "Filename suffixes in tool definitions"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "How does the parallelization anti-pattern inflate the bill?",
+      "options": [
+        "All parallel requests share one cache entry automatically",
+        "N parallel requests with the same prefix arrive before the first cache write completes, so each pays a write premium and gets zero discount",
+        "Parallelization triggers a per-request guardrail charge",
+        "Parallel requests bypass batching"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "What is the dynamic-content anti-pattern in cacheable prefixes?",
+      "options": [
+        "Putting tool schemas in the prefix",
+        "Including content that changes every request (current time to the minute, request ID, randomized example order) inside the cacheable prefix, killing hit rate",
+        "Using too short a system prompt",
+        "Always streaming responses"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "How can batch + cached input stack overnight to cut cost?",
+      "options": [
+        "Batch is incompatible with caching",
+        "Batch APIs give 50% off; cached input adds another ~10x; combined, overnight pipelines drop to ~10% of synchronous-uncached cost",
+        "Batch only saves output cost",
+        "Caching disables batch eligibility"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "What does the lesson say about semantic cache \"95% accuracy\" claims?",
+      "options": [
+        "95% refers to match correctness, not hit rate; reported production hit rates range from ~10% (open chat) up to ~70% (structured FAQ)",
+        "95% means you should expect 95% cache hits",
+        "95% is the OpenAI default cache hit rate",
+        "95% is a vendor-documented hit-rate baseline"
+      ],
+      "correct": 0,
+      "explanation": ""
+    }
+  ]
+}

--- a/phases/17-infrastructure-and-production/14-prompt-semantic-caching/quiz.json
+++ b/phases/17-infrastructure-and-production/14-prompt-semantic-caching/quiz.json
@@ -6,36 +6,36 @@
       "stage": "pre",
       "question": "What is the difference between L1 semantic caching and L2 prompt/prefix caching?",
       "options": [
-        "L1 and L2 are the same",
         "L1 skips the LLM entirely on embedding similarity hits; L2 reuses attention KV at the provider for repeated prefixes",
         "L1 is provider-side and L2 is client-side",
-        "L2 stores embeddings; L1 stores attention KV"
+        "L2 stores embeddings; L1 stores attention KV",
+        "L1 and L2 are the same"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "Which Anthropic mechanism marks blocks as cacheable for L2 prompt caching?",
       "options": [
-        "An implicit prompt-length threshold",
         "Explicit cache_control attribute on the request blocks",
         "A separate /caches endpoint",
-        "Filename suffixes in tool definitions"
+        "Filename suffixes in tool definitions",
+        "An implicit prompt-length threshold"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "How does the parallelization anti-pattern inflate the bill?",
       "options": [
-        "All parallel requests share one cache entry automatically",
-        "N parallel requests with the same prefix arrive before the first cache write completes, so each pays a write premium and gets zero discount",
+        "Parallel requests bypass batching",
         "Parallelization triggers a per-request guardrail charge",
-        "Parallel requests bypass batching"
+        "All parallel requests share one cache entry automatically",
+        "N parallel requests with the same prefix arrive before the first cache write completes, so each pays a write premium and gets zero discount"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
@@ -43,20 +43,20 @@
       "question": "What is the dynamic-content anti-pattern in cacheable prefixes?",
       "options": [
         "Putting tool schemas in the prefix",
+        "Always streaming responses",
         "Including content that changes every request (current time to the minute, request ID, randomized example order) inside the cacheable prefix, killing hit rate",
-        "Using too short a system prompt",
-        "Always streaming responses"
+        "Using too short a system prompt"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     },
     {
       "stage": "post",
       "question": "How can batch + cached input stack overnight to cut cost?",
       "options": [
-        "Batch is incompatible with caching",
-        "Batch APIs give 50% off; cached input adds another ~10x; combined, overnight pipelines drop to ~10% of synchronous-uncached cost",
         "Batch only saves output cost",
+        "Batch APIs give 50% off; cached input adds another ~10x; combined, overnight pipelines drop to ~10% of synchronous-uncached cost",
+        "Batch is incompatible with caching",
         "Caching disables batch eligibility"
       ],
       "correct": 1,
@@ -66,12 +66,12 @@
       "stage": "post",
       "question": "What does the lesson say about semantic cache \"95% accuracy\" claims?",
       "options": [
-        "95% refers to match correctness, not hit rate; reported production hit rates range from ~10% (open chat) up to ~70% (structured FAQ)",
-        "95% means you should expect 95% cache hits",
         "95% is the OpenAI default cache hit rate",
-        "95% is a vendor-documented hit-rate baseline"
+        "95% refers to match correctness, not hit rate; reported production hit rates range from ~10% (open chat) up to ~70% (structured FAQ)",
+        "95% is a vendor-documented hit-rate baseline",
+        "95% means you should expect 95% cache hits"
       ],
-      "correct": 0,
+      "correct": 1,
       "explanation": ""
     }
   ]

--- a/phases/17-infrastructure-and-production/15-batch-apis/quiz.json
+++ b/phases/17-infrastructure-and-production/15-batch-apis/quiz.json
@@ -7,35 +7,35 @@
       "question": "What is the common batch-API offer across OpenAI, Anthropic, and Google in 2026?",
       "options": [
         "10% discount with 1-hour turnaround",
-        "50% discount with 24-hour turnaround",
         "90% discount with 7-day turnaround",
-        "Free if under 1k tokens"
+        "Free if under 1k tokens",
+        "50% discount with 24-hour turnaround"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "What does \"24-hour turnaround\" actually guarantee in the lesson's framing?",
       "options": [
+        "24h is the cache TTL",
         "The batch always takes 24 hours",
         "The provider promises to return within 24 hours, with typical P50 around 2-6 hours",
-        "Only batches under 1k requests qualify",
-        "24h is the cache TTL"
+        "Only batches under 1k requests qualify"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "How does stacking batch with cached input change the bill versus synchronous uncached on a shared-system-prompt workload?",
       "options": [
-        "It increases cost by 50%",
-        "It can drop to roughly 10% of the synchronous-uncached baseline",
         "It has no effect because caching is automatic",
-        "It only helps if the model is on Vertex"
+        "It only helps if the model is on Vertex",
+        "It can drop to roughly 10% of the synchronous-uncached baseline",
+        "It increases cost by 50%"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     },
     {
@@ -43,9 +43,9 @@
       "question": "Which workload-triage lane is wrong to default to in 2026 for content pipelines and offline labeling?",
       "options": [
         "Interactive, because it sounds urgent",
-        "Semi-interactive with async queue",
         "Batch, because the user does not see a 24h delay",
-        "Hybrid batch-and-cache"
+        "Hybrid batch-and-cache",
+        "Semi-interactive with async queue"
       ],
       "correct": 0,
       "explanation": ""
@@ -54,24 +54,24 @@
       "stage": "post",
       "question": "What is the output-schema trap across providers?",
       "options": [
-        "All providers use the same OpenAI JSONL format",
-        "Batch file formats differ per provider (OpenAI JSONL, Anthropic JSONL, Vertex BigQuery/GCS), so a portable client needs per-provider adapters",
         "JSONL is unsupported by Anthropic",
-        "Vertex requires Parquet only"
+        "All providers use the same OpenAI JSONL format",
+        "Vertex requires Parquet only",
+        "Batch file formats differ per provider (OpenAI JSONL, Anthropic JSONL, Vertex BigQuery/GCS), so a portable client needs per-provider adapters"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
       "stage": "post",
       "question": "Per the lesson, what is the simplest decision rule for triaging a workload to batch?",
       "options": [
-        "If it uses tools, batch it",
-        "If the user wouldn't notice a 24-hour delivery, always batch (and stack caching)",
         "If the prompt is under 1k tokens, batch it",
-        "Batch only when the gateway requires it"
+        "If it uses tools, batch it",
+        "Batch only when the gateway requires it",
+        "If the user wouldn't notice a 24-hour delivery, always batch (and stack caching)"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     }
   ]

--- a/phases/17-infrastructure-and-production/15-batch-apis/quiz.json
+++ b/phases/17-infrastructure-and-production/15-batch-apis/quiz.json
@@ -1,0 +1,78 @@
+{
+  "lesson": "15-batch-apis",
+  "title": "Batch APIs — the 50% Discount as Industry Standard",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "What is the common batch-API offer across OpenAI, Anthropic, and Google in 2026?",
+      "options": [
+        "10% discount with 1-hour turnaround",
+        "50% discount with 24-hour turnaround",
+        "90% discount with 7-day turnaround",
+        "Free if under 1k tokens"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "What does \"24-hour turnaround\" actually guarantee in the lesson's framing?",
+      "options": [
+        "The batch always takes 24 hours",
+        "The provider promises to return within 24 hours, with typical P50 around 2-6 hours",
+        "Only batches under 1k requests qualify",
+        "24h is the cache TTL"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "How does stacking batch with cached input change the bill versus synchronous uncached on a shared-system-prompt workload?",
+      "options": [
+        "It increases cost by 50%",
+        "It can drop to roughly 10% of the synchronous-uncached baseline",
+        "It has no effect because caching is automatic",
+        "It only helps if the model is on Vertex"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Which workload-triage lane is wrong to default to in 2026 for content pipelines and offline labeling?",
+      "options": [
+        "Interactive, because it sounds urgent",
+        "Semi-interactive with async queue",
+        "Batch, because the user does not see a 24h delay",
+        "Hybrid batch-and-cache"
+      ],
+      "correct": 0,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "What is the output-schema trap across providers?",
+      "options": [
+        "All providers use the same OpenAI JSONL format",
+        "Batch file formats differ per provider (OpenAI JSONL, Anthropic JSONL, Vertex BigQuery/GCS), so a portable client needs per-provider adapters",
+        "JSONL is unsupported by Anthropic",
+        "Vertex requires Parquet only"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Per the lesson, what is the simplest decision rule for triaging a workload to batch?",
+      "options": [
+        "If it uses tools, batch it",
+        "If the user wouldn't notice a 24-hour delivery, always batch (and stack caching)",
+        "If the prompt is under 1k tokens, batch it",
+        "Batch only when the gateway requires it"
+      ],
+      "correct": 1,
+      "explanation": ""
+    }
+  ]
+}

--- a/phases/17-infrastructure-and-production/16-model-routing/quiz.json
+++ b/phases/17-infrastructure-and-production/16-model-routing/quiz.json
@@ -1,0 +1,78 @@
+{
+  "lesson": "16-model-routing",
+  "title": "Model Routing as a Cost-Reduction Primitive",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "What is the core idea of model cascading?",
+      "options": [
+        "Run every request on the most expensive model first",
+        "Run a cheap model first, escalate to a frontier model only on low confidence or refusal",
+        "Run two models in parallel and average the outputs",
+        "Always route by random weight"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Which four signals does the lesson list for routing decisions?",
+      "options": [
+        "GPU temperature, fan speed, room humidity, time of day",
+        "Task classification, prompt length, embedding similarity to known-hard set, and self-confidence from a first-pass",
+        "Token count only",
+        "User tier only"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "What is the expected latency profile of a cascade router?",
+      "options": [
+        "Identical to the frontier model",
+        "About 1.2x median latency (cheap run plus verify), about 2x on escalated requests (~10% of traffic)",
+        "Always slower by 10x",
+        "Always faster than pre-route"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Which routing pattern adds 5-10ms latency up front and is fastest overall?",
+      "options": [
+        "Cascade",
+        "Ensemble route",
+        "Pre-route with a classifier",
+        "Random round-robin"
+      ],
+      "correct": 2,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "What is cheap-model drift in routing?",
+      "options": [
+        "A latency drift in the cheap model",
+        "Task distribution shifts but the trained router keeps sending requests to the cheap model, silently degrading quality",
+        "The cheap model becomes more expensive",
+        "Cascade falls through to frontier 100% of the time"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Which guard does the lesson recommend to catch routing drift?",
+      "options": [
+        "Disable routing in production",
+        "Online quality metrics — thumbs-up/down per route, LLM-judge on held-out samples, escalation rate, refusal rate",
+        "Only offline eval sets",
+        "Quarterly engineering review only"
+      ],
+      "correct": 1,
+      "explanation": ""
+    }
+  ]
+}

--- a/phases/17-infrastructure-and-production/16-model-routing/quiz.json
+++ b/phases/17-infrastructure-and-production/16-model-routing/quiz.json
@@ -6,72 +6,72 @@
       "stage": "pre",
       "question": "What is the core idea of model cascading?",
       "options": [
-        "Run every request on the most expensive model first",
-        "Run a cheap model first, escalate to a frontier model only on low confidence or refusal",
         "Run two models in parallel and average the outputs",
-        "Always route by random weight"
+        "Always route by random weight",
+        "Run every request on the most expensive model first",
+        "Run a cheap model first, escalate to a frontier model only on low confidence or refusal"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "Which four signals does the lesson list for routing decisions?",
       "options": [
-        "GPU temperature, fan speed, room humidity, time of day",
         "Task classification, prompt length, embedding similarity to known-hard set, and self-confidence from a first-pass",
         "Token count only",
-        "User tier only"
+        "User tier only",
+        "GPU temperature, fan speed, room humidity, time of day"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "What is the expected latency profile of a cascade router?",
       "options": [
+        "Always slower by 10x",
         "Identical to the frontier model",
         "About 1.2x median latency (cheap run plus verify), about 2x on escalated requests (~10% of traffic)",
-        "Always slower by 10x",
         "Always faster than pre-route"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "Which routing pattern adds 5-10ms latency up front and is fastest overall?",
       "options": [
-        "Cascade",
-        "Ensemble route",
         "Pre-route with a classifier",
+        "Ensemble route",
+        "Cascade",
         "Random round-robin"
       ],
-      "correct": 2,
+      "correct": 0,
       "explanation": ""
     },
     {
       "stage": "post",
       "question": "What is cheap-model drift in routing?",
       "options": [
-        "A latency drift in the cheap model",
-        "Task distribution shifts but the trained router keeps sending requests to the cheap model, silently degrading quality",
         "The cheap model becomes more expensive",
-        "Cascade falls through to frontier 100% of the time"
+        "Cascade falls through to frontier 100% of the time",
+        "Task distribution shifts but the trained router keeps sending requests to the cheap model, silently degrading quality",
+        "A latency drift in the cheap model"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     },
     {
       "stage": "post",
       "question": "Which guard does the lesson recommend to catch routing drift?",
       "options": [
-        "Disable routing in production",
-        "Online quality metrics — thumbs-up/down per route, LLM-judge on held-out samples, escalation rate, refusal rate",
         "Only offline eval sets",
-        "Quarterly engineering review only"
+        "Disable routing in production",
+        "Quarterly engineering review only",
+        "Online quality metrics — thumbs-up/down per route, LLM-judge on held-out samples, escalation rate, refusal rate"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     }
   ]

--- a/phases/17-infrastructure-and-production/17-disaggregated-prefill-decode/quiz.json
+++ b/phases/17-infrastructure-and-production/17-disaggregated-prefill-decode/quiz.json
@@ -1,0 +1,78 @@
+{
+  "lesson": "17-disaggregated-prefill-decode",
+  "title": "Disaggregated Prefill/Decode — NVIDIA Dynamo and llm-d",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "Why do prefill and decode want different optimal GPU configurations?",
+      "options": [
+        "They use different model weights",
+        "Prefill is compute-bound on matmul throughput; decode is memory-bound on HBM bandwidth, so colocating them wastes one resource",
+        "Prefill must run on AMD and decode on NVIDIA",
+        "Decode requires more network bandwidth"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "What transport does NVIDIA Dynamo use to move KV cache between the prefill and decode pools?",
+      "options": [
+        "Plain HTTP",
+        "NIXL (RDMA/InfiniBand when available, TCP fallback)",
+        "gRPC bidi only",
+        "Shared filesystem on NFS"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "When does disaggregation NOT pay off according to the lesson?",
+      "options": [
+        "RAG with 8K+ prefixes",
+        "Prompts under 512 tokens and outputs under 200 tokens, where the KV transfer tax dominates the gain",
+        "MoE workloads on Blackwell",
+        "Multi-tenant serving with shared system prompts"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "What is the core architectural difference between Dynamo and llm-d?",
+      "options": [
+        "Dynamo is open source; llm-d is closed",
+        "Dynamo is a stack-above orchestrator over vLLM/SGLang/TRT-LLM; llm-d is Kubernetes-native with prefill/decode/router as independent Services",
+        "Dynamo requires AMD; llm-d requires NVIDIA",
+        "Dynamo runs on CPU; llm-d on GPU"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Which Dynamo components automatically tune the prefill:decode ratio for an SLO?",
+      "options": [
+        "Sidecar proxy and Envoy filter",
+        "Planner Profiler and SLA Planner",
+        "Marlin kernels",
+        "Cluster Autoscaler"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "How does disaggregation interact with cache-aware routing from Phase 17 · 11?",
+      "options": [
+        "They are mutually exclusive",
+        "The cache-aware router can land a request on the decode pool already holding its prefix; on miss it flows prefill -> decode, so the two compound",
+        "Cache-aware routing is only for colocated serving",
+        "Disaggregation disables KV cache reuse entirely"
+      ],
+      "correct": 1,
+      "explanation": ""
+    }
+  ]
+}

--- a/phases/17-infrastructure-and-production/17-disaggregated-prefill-decode/quiz.json
+++ b/phases/17-infrastructure-and-production/17-disaggregated-prefill-decode/quiz.json
@@ -6,9 +6,9 @@
       "stage": "pre",
       "question": "Why do prefill and decode want different optimal GPU configurations?",
       "options": [
-        "They use different model weights",
-        "Prefill is compute-bound on matmul throughput; decode is memory-bound on HBM bandwidth, so colocating them wastes one resource",
         "Prefill must run on AMD and decode on NVIDIA",
+        "Prefill is compute-bound on matmul throughput; decode is memory-bound on HBM bandwidth, so colocating them wastes one resource",
+        "They use different model weights",
         "Decode requires more network bandwidth"
       ],
       "correct": 1,
@@ -19,23 +19,23 @@
       "question": "What transport does NVIDIA Dynamo use to move KV cache between the prefill and decode pools?",
       "options": [
         "Plain HTTP",
-        "NIXL (RDMA/InfiniBand when available, TCP fallback)",
         "gRPC bidi only",
-        "Shared filesystem on NFS"
+        "Shared filesystem on NFS",
+        "NIXL (RDMA/InfiniBand when available, TCP fallback)"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "When does disaggregation NOT pay off according to the lesson?",
       "options": [
-        "RAG with 8K+ prefixes",
-        "Prompts under 512 tokens and outputs under 200 tokens, where the KV transfer tax dominates the gain",
         "MoE workloads on Blackwell",
-        "Multi-tenant serving with shared system prompts"
+        "Multi-tenant serving with shared system prompts",
+        "RAG with 8K+ prefixes",
+        "Prompts under 512 tokens and outputs under 200 tokens, where the KV transfer tax dominates the gain"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
@@ -43,11 +43,11 @@
       "question": "What is the core architectural difference between Dynamo and llm-d?",
       "options": [
         "Dynamo is open source; llm-d is closed",
+        "Dynamo runs on CPU; llm-d on GPU",
         "Dynamo is a stack-above orchestrator over vLLM/SGLang/TRT-LLM; llm-d is Kubernetes-native with prefill/decode/router as independent Services",
-        "Dynamo requires AMD; llm-d requires NVIDIA",
-        "Dynamo runs on CPU; llm-d on GPU"
+        "Dynamo requires AMD; llm-d requires NVIDIA"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     },
     {
@@ -56,8 +56,8 @@
       "options": [
         "Sidecar proxy and Envoy filter",
         "Planner Profiler and SLA Planner",
-        "Marlin kernels",
-        "Cluster Autoscaler"
+        "Cluster Autoscaler",
+        "Marlin kernels"
       ],
       "correct": 1,
       "explanation": ""
@@ -66,10 +66,10 @@
       "stage": "post",
       "question": "How does disaggregation interact with cache-aware routing from Phase 17 · 11?",
       "options": [
-        "They are mutually exclusive",
+        "Disaggregation disables KV cache reuse entirely",
         "The cache-aware router can land a request on the decode pool already holding its prefix; on miss it flows prefill -> decode, so the two compound",
-        "Cache-aware routing is only for colocated serving",
-        "Disaggregation disables KV cache reuse entirely"
+        "They are mutually exclusive",
+        "Cache-aware routing is only for colocated serving"
       ],
       "correct": 1,
       "explanation": ""

--- a/phases/17-infrastructure-and-production/18-vllm-production-stack-lmcache/quiz.json
+++ b/phases/17-infrastructure-and-production/18-vllm-production-stack-lmcache/quiz.json
@@ -1,0 +1,78 @@
+{
+  "lesson": "18-vllm-production-stack-lmcache",
+  "title": "vLLM Production Stack with LMCache KV Offloading",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "What problem does LMCache primarily address in a vLLM deployment?",
+      "options": [
+        "Tokenizer GIL contention",
+        "KV cache pressure in HBM causing preemption and re-prefill of the same prefixes",
+        "Network egress filtering",
+        "Cold-start image pull"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "What vLLM API introduced pluggable KV cache backends?",
+      "options": [
+        "Connector API in vLLM v0.9.0",
+        "PagedAttention v2",
+        "Prefix-caching flag",
+        "ChunkedPrefill API"
+      ],
+      "correct": 0,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "What does the vLLM 0.11.0 (January 2026) release add to the KV offload path?",
+      "options": [
+        "Synchronous-only offload",
+        "An asynchronous offload path so the engine does not block on offload in the common case",
+        "Removal of LMCache support",
+        "Mandatory FP8 KV cache"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "When should you pick LMCache over native CPU offload?",
+      "options": [
+        "When a single engine has HBM pressure and no prefix sharing",
+        "When multiple engines share prefixes across tenants, LoRA variants, or repeated RAG context, so cross-engine reuse pays",
+        "When you want to disable KV caching entirely",
+        "When you are running on CPU only"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "What happens to LMCache benefit when KV footprint stays well below HBM?",
+      "options": [
+        "It still doubles throughput",
+        "Configs match baseline with roughly 3-5% overhead and no real benefit",
+        "Engine crashes",
+        "LMCache automatically disables"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Why does LMCache compose with disaggregated serving (Phase 17 · 17)?",
+      "options": [
+        "It does not — they are mutually exclusive",
+        "KV transferred from prefill to decode lands in LMCache; later queries can pull from LMCache and skip prefill, so the cache-aware router can pick an engine whose local or LMCache-shared cache matches",
+        "Because LMCache replaces NIXL",
+        "Because LMCache runs on the same GPU as the engine"
+      ],
+      "correct": 1,
+      "explanation": ""
+    }
+  ]
+}

--- a/phases/17-infrastructure-and-production/18-vllm-production-stack-lmcache/quiz.json
+++ b/phases/17-infrastructure-and-production/18-vllm-production-stack-lmcache/quiz.json
@@ -6,70 +6,70 @@
       "stage": "pre",
       "question": "What problem does LMCache primarily address in a vLLM deployment?",
       "options": [
-        "Tokenizer GIL contention",
         "KV cache pressure in HBM causing preemption and re-prefill of the same prefixes",
+        "Tokenizer GIL contention",
         "Network egress filtering",
         "Cold-start image pull"
-      ],
-      "correct": 1,
-      "explanation": ""
-    },
-    {
-      "stage": "check",
-      "question": "What vLLM API introduced pluggable KV cache backends?",
-      "options": [
-        "Connector API in vLLM v0.9.0",
-        "PagedAttention v2",
-        "Prefix-caching flag",
-        "ChunkedPrefill API"
       ],
       "correct": 0,
       "explanation": ""
     },
     {
       "stage": "check",
+      "question": "What vLLM API introduced pluggable KV cache backends?",
+      "options": [
+        "Prefix-caching flag",
+        "PagedAttention v2",
+        "Connector API in vLLM v0.9.0",
+        "ChunkedPrefill API"
+      ],
+      "correct": 2,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
       "question": "What does the vLLM 0.11.0 (January 2026) release add to the KV offload path?",
       "options": [
-        "Synchronous-only offload",
         "An asynchronous offload path so the engine does not block on offload in the common case",
-        "Removal of LMCache support",
-        "Mandatory FP8 KV cache"
+        "Synchronous-only offload",
+        "Mandatory FP8 KV cache",
+        "Removal of LMCache support"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "When should you pick LMCache over native CPU offload?",
       "options": [
-        "When a single engine has HBM pressure and no prefix sharing",
         "When multiple engines share prefixes across tenants, LoRA variants, or repeated RAG context, so cross-engine reuse pays",
         "When you want to disable KV caching entirely",
+        "When a single engine has HBM pressure and no prefix sharing",
         "When you are running on CPU only"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     },
     {
       "stage": "post",
       "question": "What happens to LMCache benefit when KV footprint stays well below HBM?",
       "options": [
+        "LMCache automatically disables",
         "It still doubles throughput",
         "Configs match baseline with roughly 3-5% overhead and no real benefit",
-        "Engine crashes",
-        "LMCache automatically disables"
+        "Engine crashes"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     },
     {
       "stage": "post",
       "question": "Why does LMCache compose with disaggregated serving (Phase 17 · 17)?",
       "options": [
-        "It does not — they are mutually exclusive",
-        "KV transferred from prefill to decode lands in LMCache; later queries can pull from LMCache and skip prefill, so the cache-aware router can pick an engine whose local or LMCache-shared cache matches",
         "Because LMCache replaces NIXL",
-        "Because LMCache runs on the same GPU as the engine"
+        "KV transferred from prefill to decode lands in LMCache; later queries can pull from LMCache and skip prefill, so the cache-aware router can pick an engine whose local or LMCache-shared cache matches",
+        "Because LMCache runs on the same GPU as the engine",
+        "It does not — they are mutually exclusive"
       ],
       "correct": 1,
       "explanation": ""

--- a/phases/17-infrastructure-and-production/19-ai-gateways/quiz.json
+++ b/phases/17-infrastructure-and-production/19-ai-gateways/quiz.json
@@ -6,21 +6,21 @@
       "stage": "pre",
       "question": "What is the core role of an AI gateway in the lesson?",
       "options": [
-        "A vector database for retrieval",
-        "A process sitting between apps and model providers that consolidates routing, fallback, retries, rate limits, secret references, observability, and guardrails behind one API",
         "A model fine-tuning service",
-        "A logging-only sidecar"
+        "A vector database for retrieval",
+        "A logging-only sidecar",
+        "A process sitting between apps and model providers that consolidates routing, fallback, retries, rate limits, secret references, observability, and guardrails behind one API"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "What scale ceiling does Kong's benchmark report for LiteLLM?",
       "options": [
-        "It scales linearly past 10k RPS",
-        "It breaks down around ~2000 RPS with 8 GB memory and cascading failures under sustained load",
         "It tops out at 50 RPS",
+        "It breaks down around ~2000 RPS with 8 GB memory and cascading failures under sustained load",
+        "It scales linearly past 10k RPS",
         "LiteLLM cannot be benchmarked"
       ],
       "correct": 1,
@@ -30,48 +30,48 @@
       "stage": "check",
       "question": "Per the Kong benchmark on equivalent CPU, how much faster is Kong AI Gateway than Portkey and LiteLLM?",
       "options": [
-        "About 10% and 20% faster",
         "228% faster than Portkey and 859% faster than LiteLLM",
+        "About 10% and 20% faster",
         "Identical",
         "Slower than both"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "Which gateway does the lesson position with 20-40 ms latency overhead and guardrails / PII redaction / jailbreak detection focus?",
       "options": [
-        "LiteLLM",
-        "Portkey",
         "Kong AI Gateway",
-        "Cloudflare AI Gateway"
+        "LiteLLM",
+        "Cloudflare AI Gateway",
+        "Portkey"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
       "stage": "post",
       "question": "What does the lesson say is the forcing function for self-hosted vs managed gateway decisions?",
       "options": [
-        "Cost per request",
-        "Data residency requirements",
+        "Whether the gateway is open source",
         "Number of supported providers",
-        "Whether the gateway is open source"
+        "Cost per request",
+        "Data residency requirements"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
       "stage": "post",
       "question": "Which gateways stay within budget when the SLA is TTFT P99 < 100 ms?",
       "options": [
-        "Only LiteLLM",
-        "Kong (~3-8 ms) or Cloudflare/Vercel edge gateways (~1-3 ms); Portkey at 20-40 ms is too heavy",
         "Any gateway",
-        "Only Portkey"
+        "Only Portkey",
+        "Only LiteLLM",
+        "Kong (~3-8 ms) or Cloudflare/Vercel edge gateways (~1-3 ms); Portkey at 20-40 ms is too heavy"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     }
   ]

--- a/phases/17-infrastructure-and-production/19-ai-gateways/quiz.json
+++ b/phases/17-infrastructure-and-production/19-ai-gateways/quiz.json
@@ -1,0 +1,78 @@
+{
+  "lesson": "19-ai-gateways",
+  "title": "AI Gateways — LiteLLM, Portkey, Kong AI Gateway, Bifrost",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "What is the core role of an AI gateway in the lesson?",
+      "options": [
+        "A vector database for retrieval",
+        "A process sitting between apps and model providers that consolidates routing, fallback, retries, rate limits, secret references, observability, and guardrails behind one API",
+        "A model fine-tuning service",
+        "A logging-only sidecar"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "What scale ceiling does Kong's benchmark report for LiteLLM?",
+      "options": [
+        "It scales linearly past 10k RPS",
+        "It breaks down around ~2000 RPS with 8 GB memory and cascading failures under sustained load",
+        "It tops out at 50 RPS",
+        "LiteLLM cannot be benchmarked"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Per the Kong benchmark on equivalent CPU, how much faster is Kong AI Gateway than Portkey and LiteLLM?",
+      "options": [
+        "About 10% and 20% faster",
+        "228% faster than Portkey and 859% faster than LiteLLM",
+        "Identical",
+        "Slower than both"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Which gateway does the lesson position with 20-40 ms latency overhead and guardrails / PII redaction / jailbreak detection focus?",
+      "options": [
+        "LiteLLM",
+        "Portkey",
+        "Kong AI Gateway",
+        "Cloudflare AI Gateway"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "What does the lesson say is the forcing function for self-hosted vs managed gateway decisions?",
+      "options": [
+        "Cost per request",
+        "Data residency requirements",
+        "Number of supported providers",
+        "Whether the gateway is open source"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Which gateways stay within budget when the SLA is TTFT P99 < 100 ms?",
+      "options": [
+        "Only LiteLLM",
+        "Kong (~3-8 ms) or Cloudflare/Vercel edge gateways (~1-3 ms); Portkey at 20-40 ms is too heavy",
+        "Any gateway",
+        "Only Portkey"
+      ],
+      "correct": 1,
+      "explanation": ""
+    }
+  ]
+}

--- a/phases/17-infrastructure-and-production/20-shadow-canary-progressive/quiz.json
+++ b/phases/17-infrastructure-and-production/20-shadow-canary-progressive/quiz.json
@@ -6,12 +6,12 @@
       "stage": "pre",
       "question": "What is the right way to order shadow, canary, and A/B testing for an LLM rollout?",
       "options": [
-        "A/B first, then shadow, then canary",
         "Shadow (zero-impact compare), then canary (live traffic progressive with gates), then A/B for distinct alternatives once stability is confirmed",
+        "Skip shadow entirely",
         "Canary first, then shadow, then A/B",
-        "Skip shadow entirely"
+        "A/B first, then shadow, then canary"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     },
     {
@@ -19,11 +19,11 @@
       "question": "Which set of five metrics does the lesson gate canary progressions on?",
       "options": [
         "GPU temp, fan speed, queue depth, cost, latency",
-        "Latency percentiles, cost per request, error/refusal rate, output length distribution, user-feedback rate",
         "Accuracy on offline eval only",
+        "Latency percentiles, cost per request, error/refusal rate, output length distribution, user-feedback rate",
         "Just throughput"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     },
     {
@@ -31,47 +31,47 @@
       "question": "Roughly how much run-to-run accuracy variance does the lesson cite for identical inputs on LLMs?",
       "options": [
         "Under 0.1%",
-        "Up to about 15%, due to GPU FP non-associativity plus batch-size variance",
+        "Identical outputs run-to-run",
         "Always 50%",
-        "Identical outputs run-to-run"
+        "Up to about 15%, due to GPU FP non-associativity plus batch-size variance"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "What is shadow mode for, in the lesson's framing?",
       "options": [
+        "Replacement for rollback",
         "A complete quality test that replaces evals",
-        "A smoke test catching cost blow-ups, length regressions, refusal changes, and hard errors — not a quality guarantee",
         "Final production rollout step",
-        "Replacement for rollback"
+        "A smoke test catching cost blow-ups, length regressions, refusal changes, and hard errors — not a quality guarantee"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
       "stage": "post",
       "question": "What is the correct rollback design per the lesson?",
       "options": [
+        "Wait for the next release window",
         "Redeploy with new model digest, taking hours",
         "Flip a policy flag and revert the pinned model digest in seconds — no redeploy",
-        "Wait for the next release window",
         "Manual SSH to each pod"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     },
     {
       "stage": "post",
       "question": "Why is cost listed as a gate alongside latency and quality?",
       "options": [
-        "Cost is a vanity metric",
         "A 20% better model can be 3x more expensive per call; shipping that without a cost gate breaks unit economics",
         "Cost is automatically capped by every provider",
+        "Cost is a vanity metric",
         "Cost is the same across providers"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     }
   ]

--- a/phases/17-infrastructure-and-production/20-shadow-canary-progressive/quiz.json
+++ b/phases/17-infrastructure-and-production/20-shadow-canary-progressive/quiz.json
@@ -1,0 +1,78 @@
+{
+  "lesson": "20-shadow-canary-progressive",
+  "title": "Shadow Traffic, Canary Rollout, and Progressive Deployment for LLMs",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "What is the right way to order shadow, canary, and A/B testing for an LLM rollout?",
+      "options": [
+        "A/B first, then shadow, then canary",
+        "Shadow (zero-impact compare), then canary (live traffic progressive with gates), then A/B for distinct alternatives once stability is confirmed",
+        "Canary first, then shadow, then A/B",
+        "Skip shadow entirely"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Which set of five metrics does the lesson gate canary progressions on?",
+      "options": [
+        "GPU temp, fan speed, queue depth, cost, latency",
+        "Latency percentiles, cost per request, error/refusal rate, output length distribution, user-feedback rate",
+        "Accuracy on offline eval only",
+        "Just throughput"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Roughly how much run-to-run accuracy variance does the lesson cite for identical inputs on LLMs?",
+      "options": [
+        "Under 0.1%",
+        "Up to about 15%, due to GPU FP non-associativity plus batch-size variance",
+        "Always 50%",
+        "Identical outputs run-to-run"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "What is shadow mode for, in the lesson's framing?",
+      "options": [
+        "A complete quality test that replaces evals",
+        "A smoke test catching cost blow-ups, length regressions, refusal changes, and hard errors — not a quality guarantee",
+        "Final production rollout step",
+        "Replacement for rollback"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "What is the correct rollback design per the lesson?",
+      "options": [
+        "Redeploy with new model digest, taking hours",
+        "Flip a policy flag and revert the pinned model digest in seconds — no redeploy",
+        "Wait for the next release window",
+        "Manual SSH to each pod"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Why is cost listed as a gate alongside latency and quality?",
+      "options": [
+        "Cost is a vanity metric",
+        "A 20% better model can be 3x more expensive per call; shipping that without a cost gate breaks unit economics",
+        "Cost is automatically capped by every provider",
+        "Cost is the same across providers"
+      ],
+      "correct": 1,
+      "explanation": ""
+    }
+  ]
+}

--- a/phases/17-infrastructure-and-production/21-ab-testing-llm-features/quiz.json
+++ b/phases/17-infrastructure-and-production/21-ab-testing-llm-features/quiz.json
@@ -6,45 +6,45 @@
       "stage": "pre",
       "question": "What is the precise distinction between evals and A/B tests in the lesson?",
       "options": [
-        "Evals are user-facing; A/B tests are offline",
         "Evals answer \"can the model do the job?\" on a labeled set; A/B tests answer \"do users care?\" with live randomized traffic",
-        "They are interchangeable",
-        "Only A/B tests are required"
+        "Only A/B tests are required",
+        "Evals are user-facing; A/B tests are offline",
+        "They are interchangeable"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "What does CUPED do for an experiment?",
       "options": [
-        "Increases sample size by hiring more users",
-        "Regresses out pre-period variance before comparing post-period, typically reducing variance 30-70% and boosting effective sample size",
+        "Disables multiple-comparison correction",
         "Replaces sequential testing entirely",
-        "Disables multiple-comparison correction"
+        "Regresses out pre-period variance before comparing post-period, typically reducing variance 30-70% and boosting effective sample size",
+        "Increases sample size by hiring more users"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "Why do you need multiple-comparison corrections (Bonferroni or Benjamini-Hochberg) when running many A/Bs?",
       "options": [
-        "They speed up experiments",
-        "Running 20 tests at 95% confidence produces one false positive by chance; corrections control family-wise error or false discovery rate",
         "They are required by GDPR",
-        "They are only needed for sequential tests"
+        "They are only needed for sequential tests",
+        "Running 20 tests at 95% confidence produces one false positive by chance; corrections control family-wise error or false discovery rate",
+        "They speed up experiments"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "What does SRM (sample ratio mismatch) detect?",
       "options": [
-        "Memory leaks in the experiment platform",
-        "An assignment-hash bug producing a delivered split that diverges from the intended (e.g. 47/53 when targeting 50/50)",
         "Slow tokenizer performance",
+        "An assignment-hash bug producing a delivered split that diverges from the intended (e.g. 47/53 when targeting 50/50)",
+        "Memory leaks in the experiment platform",
         "PII leakage"
       ],
       "correct": 1,
@@ -54,12 +54,12 @@
       "stage": "post",
       "question": "Why does LLM non-determinism require buffering sample size?",
       "options": [
-        "Non-determinism reduces required samples",
         "It violates IID assumptions; effective sample size drops, so multiply required size by roughly 1.3-1.5x as a safety margin",
-        "It only matters offline",
-        "It is irrelevant to power calculations"
+        "It is irrelevant to power calculations",
+        "Non-determinism reduces required samples",
+        "It only matters offline"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     },
     {
@@ -67,11 +67,11 @@
       "question": "How does the lesson contrast Statsig and GrowthBook?",
       "options": [
         "Identical feature sets",
-        "Statsig is all-in-one SaaS (acquired by OpenAI Sept 2025, $1.1B); GrowthBook is open-source MIT, warehouse-native, with Bayesian/Frequentist/Sequential engines and CUPED/SRM/BH",
+        "Statsig is warehouse-native only",
         "GrowthBook is closed source",
-        "Statsig is warehouse-native only"
+        "Statsig is all-in-one SaaS (acquired by OpenAI Sept 2025, $1.1B); GrowthBook is open-source MIT, warehouse-native, with Bayesian/Frequentist/Sequential engines and CUPED/SRM/BH"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     }
   ]

--- a/phases/17-infrastructure-and-production/21-ab-testing-llm-features/quiz.json
+++ b/phases/17-infrastructure-and-production/21-ab-testing-llm-features/quiz.json
@@ -1,0 +1,78 @@
+{
+  "lesson": "21-ab-testing-llm-features",
+  "title": "A/B Testing LLM Features — GrowthBook, Statsig, and the Vibes Problem",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "What is the precise distinction between evals and A/B tests in the lesson?",
+      "options": [
+        "Evals are user-facing; A/B tests are offline",
+        "Evals answer \"can the model do the job?\" on a labeled set; A/B tests answer \"do users care?\" with live randomized traffic",
+        "They are interchangeable",
+        "Only A/B tests are required"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "What does CUPED do for an experiment?",
+      "options": [
+        "Increases sample size by hiring more users",
+        "Regresses out pre-period variance before comparing post-period, typically reducing variance 30-70% and boosting effective sample size",
+        "Replaces sequential testing entirely",
+        "Disables multiple-comparison correction"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Why do you need multiple-comparison corrections (Bonferroni or Benjamini-Hochberg) when running many A/Bs?",
+      "options": [
+        "They speed up experiments",
+        "Running 20 tests at 95% confidence produces one false positive by chance; corrections control family-wise error or false discovery rate",
+        "They are required by GDPR",
+        "They are only needed for sequential tests"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "What does SRM (sample ratio mismatch) detect?",
+      "options": [
+        "Memory leaks in the experiment platform",
+        "An assignment-hash bug producing a delivered split that diverges from the intended (e.g. 47/53 when targeting 50/50)",
+        "Slow tokenizer performance",
+        "PII leakage"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Why does LLM non-determinism require buffering sample size?",
+      "options": [
+        "Non-determinism reduces required samples",
+        "It violates IID assumptions; effective sample size drops, so multiply required size by roughly 1.3-1.5x as a safety margin",
+        "It only matters offline",
+        "It is irrelevant to power calculations"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "How does the lesson contrast Statsig and GrowthBook?",
+      "options": [
+        "Identical feature sets",
+        "Statsig is all-in-one SaaS (acquired by OpenAI Sept 2025, $1.1B); GrowthBook is open-source MIT, warehouse-native, with Bayesian/Frequentist/Sequential engines and CUPED/SRM/BH",
+        "GrowthBook is closed source",
+        "Statsig is warehouse-native only"
+      ],
+      "correct": 1,
+      "explanation": ""
+    }
+  ]
+}

--- a/phases/17-infrastructure-and-production/22-load-testing-llm-apis/quiz.json
+++ b/phases/17-infrastructure-and-production/22-load-testing-llm-apis/quiz.json
@@ -1,0 +1,78 @@
+{
+  "lesson": "22-load-testing-llm-apis",
+  "title": "Load Testing LLM APIs — Why k6 and Locust Lie",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "What is the GIL trap in Locust-based LLM load testing?",
+      "options": [
+        "Locust does not support HTTP",
+        "Client-side tokenization runs under the Python GIL and queues behind request generation, inflating reported inter-token latency",
+        "Locust only works on Windows",
+        "Locust requires CUDA"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "What is the prompt-uniformity trap?",
+      "options": [
+        "Sampling from a real distribution under-represents long prompts",
+        "Looping the same prompt makes prefix caching look like full concurrent decode, inflating reported throughput",
+        "Uniform prompts always slow the server down",
+        "Uniform prompts require streaming"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Which four load patterns does the lesson recommend?",
+      "options": [
+        "Steady-state, ramp, spike, soak",
+        "Burst only",
+        "Constant 1 RPS for 10 days",
+        "Manual click tests"
+      ],
+      "correct": 0,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "How does the lesson recommend building a realistic prompt distribution?",
+      "options": [
+        "Hand-write 5 prompts and shuffle",
+        "Sample from a real distribution using mean and stddev (for example LLMPerf's --mean-input-tokens / --stddev-input-tokens) or replay real traffic",
+        "Always use the same prompt to maximize cache hits",
+        "Random characters per request"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Which 2026 tool combination is positioned as best for CI/CD SLA gates and Kubernetes-native distributed runs?",
+      "options": [
+        "Locust 2.43.3 stock",
+        "k6 v2026.1.0 with the k6 Operator 1.0 GA (TestRun / PrivateLoadZone CRDs)",
+        "Vegeta only",
+        "guidellm only"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Which failure mode does the soak load pattern catch?",
+      "options": [
+        "Cold-start tail",
+        "Memory leaks, connection-pool drift, and observability overflow over hours",
+        "Tokenizer GIL contention",
+        "Cache eviction storms"
+      ],
+      "correct": 1,
+      "explanation": ""
+    }
+  ]
+}

--- a/phases/17-infrastructure-and-production/22-load-testing-llm-apis/quiz.json
+++ b/phases/17-infrastructure-and-production/22-load-testing-llm-apis/quiz.json
@@ -6,72 +6,72 @@
       "stage": "pre",
       "question": "What is the GIL trap in Locust-based LLM load testing?",
       "options": [
+        "Locust only works on Windows",
         "Locust does not support HTTP",
         "Client-side tokenization runs under the Python GIL and queues behind request generation, inflating reported inter-token latency",
-        "Locust only works on Windows",
         "Locust requires CUDA"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "What is the prompt-uniformity trap?",
       "options": [
-        "Sampling from a real distribution under-represents long prompts",
-        "Looping the same prompt makes prefix caching look like full concurrent decode, inflating reported throughput",
         "Uniform prompts always slow the server down",
-        "Uniform prompts require streaming"
+        "Sampling from a real distribution under-represents long prompts",
+        "Uniform prompts require streaming",
+        "Looping the same prompt makes prefix caching look like full concurrent decode, inflating reported throughput"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "Which four load patterns does the lesson recommend?",
       "options": [
-        "Steady-state, ramp, spike, soak",
-        "Burst only",
         "Constant 1 RPS for 10 days",
-        "Manual click tests"
+        "Manual click tests",
+        "Steady-state, ramp, spike, soak",
+        "Burst only"
       ],
-      "correct": 0,
+      "correct": 2,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "How does the lesson recommend building a realistic prompt distribution?",
       "options": [
-        "Hand-write 5 prompts and shuffle",
         "Sample from a real distribution using mean and stddev (for example LLMPerf's --mean-input-tokens / --stddev-input-tokens) or replay real traffic",
-        "Always use the same prompt to maximize cache hits",
-        "Random characters per request"
+        "Random characters per request",
+        "Hand-write 5 prompts and shuffle",
+        "Always use the same prompt to maximize cache hits"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     },
     {
       "stage": "post",
       "question": "Which 2026 tool combination is positioned as best for CI/CD SLA gates and Kubernetes-native distributed runs?",
       "options": [
-        "Locust 2.43.3 stock",
         "k6 v2026.1.0 with the k6 Operator 1.0 GA (TestRun / PrivateLoadZone CRDs)",
+        "guidellm only",
         "Vegeta only",
-        "guidellm only"
+        "Locust 2.43.3 stock"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     },
     {
       "stage": "post",
       "question": "Which failure mode does the soak load pattern catch?",
       "options": [
-        "Cold-start tail",
         "Memory leaks, connection-pool drift, and observability overflow over hours",
+        "Cold-start tail",
         "Tokenizer GIL contention",
         "Cache eviction storms"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     }
   ]

--- a/phases/17-infrastructure-and-production/23-sre-for-ai/quiz.json
+++ b/phases/17-infrastructure-and-production/23-sre-for-ai/quiz.json
@@ -1,0 +1,78 @@
+{
+  "lesson": "23-sre-for-ai",
+  "title": "SRE for AI — Multi-Agent Incident Response, Runbooks, Predictive Detection",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "What multi-agent shape does the lesson recommend for AI SRE?",
+      "options": [
+        "One monolithic agent owning everything",
+        "Supervisor agent that breaks the incident into sub-queries for specialized log, metric, and runbook agents, then synthesizes and presents to a human",
+        "Random selection of one of three agents",
+        "Two agents in series with no supervisor"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Which auto-remediation set does the lesson call safe?",
+      "options": [
+        "Re-architecting service topology",
+        "Restart pod, revert a specific deploy, scale a pool within pre-approved bounds, enable a pre-approved feature flag",
+        "Modifying IAM policies",
+        "Altering databases"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "How does NeuBird Hawkeye use adversarial evaluation to filter hallucinated root causes?",
+      "options": [
+        "Runs the same model twice on the same input",
+        "Two models independently analyze the same incident; agreement = high confidence, disagreement = escalate to human with both hypotheses",
+        "Uses GAN-style training",
+        "Picks the higher-confidence model's answer always"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "What does operational memory solve in AI SRE?",
+      "options": [
+        "Cold start of inference pods",
+        "Loss of tribal knowledge when teams turn over — runbooks and post-mortems live in a vector DB that agents retrieve on every incident",
+        "Network egress filtering",
+        "Token cost attribution"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "What MIT 2025 result does the lesson cite for pre-incident prediction?",
+      "options": [
+        "100% prediction with 1-second lead",
+        "89% of outages predicted 10-15 minutes early using logs + GPU temps + API error patterns",
+        "10% with no lead time",
+        "Predictions remain unsolved"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "What operational constraint does the lesson stress about predictive detection?",
+      "options": [
+        "Predictions are always accurate",
+        "Predictions without actuation are just dashboards — the operational question is what action (pre-drain, page, auto-scale) the prediction triggers",
+        "Predictions should never be wired to action",
+        "Predictions replace runbooks"
+      ],
+      "correct": 1,
+      "explanation": ""
+    }
+  ]
+}

--- a/phases/17-infrastructure-and-production/23-sre-for-ai/quiz.json
+++ b/phases/17-infrastructure-and-production/23-sre-for-ai/quiz.json
@@ -6,12 +6,12 @@
       "stage": "pre",
       "question": "What multi-agent shape does the lesson recommend for AI SRE?",
       "options": [
-        "One monolithic agent owning everything",
-        "Supervisor agent that breaks the incident into sub-queries for specialized log, metric, and runbook agents, then synthesizes and presents to a human",
         "Random selection of one of three agents",
-        "Two agents in series with no supervisor"
+        "Two agents in series with no supervisor",
+        "One monolithic agent owning everything",
+        "Supervisor agent that breaks the incident into sub-queries for specialized log, metric, and runbook agents, then synthesizes and presents to a human"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
@@ -19,23 +19,23 @@
       "question": "Which auto-remediation set does the lesson call safe?",
       "options": [
         "Re-architecting service topology",
-        "Restart pod, revert a specific deploy, scale a pool within pre-approved bounds, enable a pre-approved feature flag",
+        "Altering databases",
         "Modifying IAM policies",
-        "Altering databases"
+        "Restart pod, revert a specific deploy, scale a pool within pre-approved bounds, enable a pre-approved feature flag"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "How does NeuBird Hawkeye use adversarial evaluation to filter hallucinated root causes?",
       "options": [
-        "Runs the same model twice on the same input",
         "Two models independently analyze the same incident; agreement = high confidence, disagreement = escalate to human with both hypotheses",
         "Uses GAN-style training",
-        "Picks the higher-confidence model's answer always"
+        "Picks the higher-confidence model's answer always",
+        "Runs the same model twice on the same input"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     },
     {
@@ -43,11 +43,11 @@
       "question": "What does operational memory solve in AI SRE?",
       "options": [
         "Cold start of inference pods",
-        "Loss of tribal knowledge when teams turn over — runbooks and post-mortems live in a vector DB that agents retrieve on every incident",
         "Network egress filtering",
+        "Loss of tribal knowledge when teams turn over — runbooks and post-mortems live in a vector DB that agents retrieve on every incident",
         "Token cost attribution"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     },
     {
@@ -56,8 +56,8 @@
       "options": [
         "100% prediction with 1-second lead",
         "89% of outages predicted 10-15 minutes early using logs + GPU temps + API error patterns",
-        "10% with no lead time",
-        "Predictions remain unsolved"
+        "Predictions remain unsolved",
+        "10% with no lead time"
       ],
       "correct": 1,
       "explanation": ""
@@ -66,12 +66,12 @@
       "stage": "post",
       "question": "What operational constraint does the lesson stress about predictive detection?",
       "options": [
-        "Predictions are always accurate",
-        "Predictions without actuation are just dashboards — the operational question is what action (pre-drain, page, auto-scale) the prediction triggers",
+        "Predictions replace runbooks",
         "Predictions should never be wired to action",
-        "Predictions replace runbooks"
+        "Predictions without actuation are just dashboards — the operational question is what action (pre-drain, page, auto-scale) the prediction triggers",
+        "Predictions are always accurate"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     }
   ]

--- a/phases/17-infrastructure-and-production/24-chaos-engineering-llm/quiz.json
+++ b/phases/17-infrastructure-and-production/24-chaos-engineering-llm/quiz.json
@@ -1,0 +1,78 @@
+{
+  "lesson": "24-chaos-engineering-llm",
+  "title": "Chaos Engineering for LLM Production",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "Which five prerequisites does the lesson require before running chaos in production?",
+      "options": [
+        "Slack channel, sticker pack, mascot, hashtag, blog post",
+        "SLI/SLO, observability, automated rollback, structured runbooks, on-call",
+        "Vector database only",
+        "Three frontier models"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Which four planes does the chaos architecture have, plus the feedback loop?",
+      "options": [
+        "Frontend, backend, mobile, web",
+        "Control, target, safety, observability — with feedback into SLO adjustments",
+        "Train, eval, deploy, archive",
+        "Ingest, transform, store, serve"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "What does the burn-rate alert guardrail do during chaos experiments?",
+      "options": [
+        "Speeds up the experiment",
+        "Pauses the experiment when daily error-budget burn exceeds roughly 2x expected",
+        "Auto-promotes the experiment to production",
+        "Disables observability"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Which is an LLM-specific chaos experiment listed in the lesson?",
+      "options": [
+        "Random fan-speed reduction",
+        "KV eviction storm that forces vLLM block-budget saturation",
+        "Reboot the entire datacenter",
+        "Drop all DNS"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Which cadence does the lesson recommend for chaos exercises?",
+      "options": [
+        "Yearly only",
+        "Weekly small canary, monthly game day with postmortem, quarterly cross-team resilience audit",
+        "Daily full-prod outages",
+        "Never"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "What LLM-specific failure mode does the malformed-prompt experiment uncover?",
+      "options": [
+        "Network packet loss",
+        "Tokenizer stalls that lock up a worker on inputs like deeply nested unicode or huge UTF-8 codepoints",
+        "GPU undervolt",
+        "Disk I/O contention"
+      ],
+      "correct": 1,
+      "explanation": ""
+    }
+  ]
+}

--- a/phases/17-infrastructure-and-production/24-chaos-engineering-llm/quiz.json
+++ b/phases/17-infrastructure-and-production/24-chaos-engineering-llm/quiz.json
@@ -18,60 +18,60 @@
       "stage": "check",
       "question": "Which four planes does the chaos architecture have, plus the feedback loop?",
       "options": [
-        "Frontend, backend, mobile, web",
-        "Control, target, safety, observability — with feedback into SLO adjustments",
+        "Ingest, transform, store, serve",
         "Train, eval, deploy, archive",
-        "Ingest, transform, store, serve"
+        "Control, target, safety, observability — with feedback into SLO adjustments",
+        "Frontend, backend, mobile, web"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "What does the burn-rate alert guardrail do during chaos experiments?",
       "options": [
-        "Speeds up the experiment",
-        "Pauses the experiment when daily error-budget burn exceeds roughly 2x expected",
+        "Disables observability",
         "Auto-promotes the experiment to production",
-        "Disables observability"
+        "Speeds up the experiment",
+        "Pauses the experiment when daily error-budget burn exceeds roughly 2x expected"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "Which is an LLM-specific chaos experiment listed in the lesson?",
       "options": [
+        "Drop all DNS",
         "Random fan-speed reduction",
         "KV eviction storm that forces vLLM block-budget saturation",
-        "Reboot the entire datacenter",
-        "Drop all DNS"
+        "Reboot the entire datacenter"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     },
     {
       "stage": "post",
       "question": "Which cadence does the lesson recommend for chaos exercises?",
       "options": [
-        "Yearly only",
         "Weekly small canary, monthly game day with postmortem, quarterly cross-team resilience audit",
         "Daily full-prod outages",
-        "Never"
+        "Never",
+        "Yearly only"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     },
     {
       "stage": "post",
       "question": "What LLM-specific failure mode does the malformed-prompt experiment uncover?",
       "options": [
-        "Network packet loss",
         "Tokenizer stalls that lock up a worker on inputs like deeply nested unicode or huge UTF-8 codepoints",
+        "Disk I/O contention",
         "GPU undervolt",
-        "Disk I/O contention"
+        "Network packet loss"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     }
   ]

--- a/phases/17-infrastructure-and-production/25-security-secrets-audit/quiz.json
+++ b/phases/17-infrastructure-and-production/25-security-secrets-audit/quiz.json
@@ -1,0 +1,78 @@
+{
+  "lesson": "25-security-secrets-audit",
+  "title": "Security — Secrets, API Key Rotation, Audit Logs, Guardrails",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "What is the 2026 standard pattern for LLM service credentials?",
+      "options": [
+        "Hardcode API keys in config files for speed",
+        "Centralized vault pulled by an AI gateway at runtime via IAM role; rotate in vault and all apps pick up in minutes",
+        "Email the key to each engineer",
+        "Store keys in a Slack channel"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "What rotation cadence does the lesson recommend for API keys, vault root tokens, and CI/CD credentials?",
+      "options": [
+        "Every 5 years",
+        "Within 90 days, automated where possible, logged and tracked when manual",
+        "Only when leaked",
+        "Never"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Why is consistent tokenization (Mesh approach) used for PII scrubbing?",
+      "options": [
+        "It uses less memory than regex",
+        "Same source value maps to the same placeholder, so the LLM preserves code and relationship semantics across the prompt",
+        "It is required by ISO 27001",
+        "It encrypts the prompt to the model"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "What egress posture does the lesson recommend for LLM service subnets?",
+      "options": [
+        "Allow all outbound traffic",
+        "Whitelist a small set of domains (api.openai.com, api.anthropic.com, vector DB, vault) and drop everything else, with an allowlist-only DNS resolver",
+        "Block all egress including providers",
+        "Allow DNS but block HTTP"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "What did the 2026 Vercel supply-chain incident teach about CI/CD credentials?",
+      "options": [
+        "CI/CD credentials are low-risk and can stay in env files",
+        "CI/CD credentials are prod-equivalent — store in vault, scope narrowly, rotate aggressively",
+        "Vercel was unaffected",
+        "CI/CD secrets cannot be stolen"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Which audit log fields does the lesson recommend keeping for every LLM call?",
+      "options": [
+        "Just the raw prompt",
+        "Timestamp, user/tenant, prompt hash (not raw), model + version, token counts, cost, response hash, any guardrail trips",
+        "Only the response",
+        "Only the cost"
+      ],
+      "correct": 1,
+      "explanation": ""
+    }
+  ]
+}

--- a/phases/17-infrastructure-and-production/25-security-secrets-audit/quiz.json
+++ b/phases/17-infrastructure-and-production/25-security-secrets-audit/quiz.json
@@ -6,10 +6,10 @@
       "stage": "pre",
       "question": "What is the 2026 standard pattern for LLM service credentials?",
       "options": [
-        "Hardcode API keys in config files for speed",
+        "Store keys in a Slack channel",
         "Centralized vault pulled by an AI gateway at runtime via IAM role; rotate in vault and all apps pick up in minutes",
         "Email the key to each engineer",
-        "Store keys in a Slack channel"
+        "Hardcode API keys in config files for speed"
       ],
       "correct": 1,
       "explanation": ""
@@ -18,12 +18,12 @@
       "stage": "check",
       "question": "What rotation cadence does the lesson recommend for API keys, vault root tokens, and CI/CD credentials?",
       "options": [
-        "Every 5 years",
         "Within 90 days, automated where possible, logged and tracked when manual",
+        "Every 5 years",
         "Only when leaked",
         "Never"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     },
     {
@@ -31,35 +31,35 @@
       "question": "Why is consistent tokenization (Mesh approach) used for PII scrubbing?",
       "options": [
         "It uses less memory than regex",
-        "Same source value maps to the same placeholder, so the LLM preserves code and relationship semantics across the prompt",
+        "It encrypts the prompt to the model",
         "It is required by ISO 27001",
-        "It encrypts the prompt to the model"
+        "Same source value maps to the same placeholder, so the LLM preserves code and relationship semantics across the prompt"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "What egress posture does the lesson recommend for LLM service subnets?",
       "options": [
-        "Allow all outbound traffic",
         "Whitelist a small set of domains (api.openai.com, api.anthropic.com, vector DB, vault) and drop everything else, with an allowlist-only DNS resolver",
         "Block all egress including providers",
-        "Allow DNS but block HTTP"
+        "Allow DNS but block HTTP",
+        "Allow all outbound traffic"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     },
     {
       "stage": "post",
       "question": "What did the 2026 Vercel supply-chain incident teach about CI/CD credentials?",
       "options": [
-        "CI/CD credentials are low-risk and can stay in env files",
         "CI/CD credentials are prod-equivalent — store in vault, scope narrowly, rotate aggressively",
-        "Vercel was unaffected",
-        "CI/CD secrets cannot be stolen"
+        "CI/CD secrets cannot be stolen",
+        "CI/CD credentials are low-risk and can stay in env files",
+        "Vercel was unaffected"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     },
     {
@@ -67,11 +67,11 @@
       "question": "Which audit log fields does the lesson recommend keeping for every LLM call?",
       "options": [
         "Just the raw prompt",
-        "Timestamp, user/tenant, prompt hash (not raw), model + version, token counts, cost, response hash, any guardrail trips",
         "Only the response",
+        "Timestamp, user/tenant, prompt hash (not raw), model + version, token counts, cost, response hash, any guardrail trips",
         "Only the cost"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     }
   ]

--- a/phases/17-infrastructure-and-production/26-compliance-frameworks/quiz.json
+++ b/phases/17-infrastructure-and-production/26-compliance-frameworks/quiz.json
@@ -1,0 +1,78 @@
+{
+  "lesson": "26-compliance-frameworks",
+  "title": "Compliance — SOC 2, HIPAA, GDPR, PCI-DSS, EU AI Act, ISO 42001",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "When does EU AI Act enforcement for high-risk systems begin?",
+      "options": [
+        "February 2, 2025",
+        "August 2, 2026",
+        "January 1, 2030",
+        "Already fully enforced in 2024"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Which two-tier fine ceiling does the EU AI Act define?",
+      "options": [
+        "Up to €1M flat for any violation",
+        "Up to €15M or 3% global annual turnover for high-risk-system obligations (Art. 99(4)); up to €35M or 7% for prohibited AI practices (Art. 99(3))",
+        "Up to €100K for any violation",
+        "No financial penalties, only takedown orders"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Why is post-processing PII cleanup not a defensible GDPR posture?",
+      "options": [
+        "It is too slow at scale",
+        "The model already saw the data, so real-time inference-layer redaction (before the LLM call) is the defensible 2026 standard",
+        "GDPR forbids redaction entirely",
+        "Post-processing is identical to real-time"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "What is the practical difference between SOC 2 Type I and Type II?",
+      "options": [
+        "Type I is more rigorous than Type II",
+        "Type I attests controls designed and documented; Type II attests controls operating effectively over 6-12 months",
+        "Type I requires HIPAA BAA",
+        "Type II is for startups only"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "What does cross-framework control mapping aim to deliver?",
+      "options": [
+        "More distinct controls per framework",
+        "One control policy that satisfies multiple framework requirements (e.g. access logging maps to ISO 27001 A.5.15-5.18, GDPR Art. 32, HIPAA §164.312(a))",
+        "Replacing all frameworks with ISO 42001",
+        "Eliminating audits"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "What does the lesson recommend for HIPAA + LLM workloads?",
+      "options": [
+        "Ship PHI to any provider; BAA is optional",
+        "Never send PHI to an external AI service without a signed BAA; all three hyperscalers and major LLM API providers offer BAAs",
+        "Use only on-prem models, never managed",
+        "HIPAA does not apply to LLMs"
+      ],
+      "correct": 1,
+      "explanation": ""
+    }
+  ]
+}

--- a/phases/17-infrastructure-and-production/26-compliance-frameworks/quiz.json
+++ b/phases/17-infrastructure-and-production/26-compliance-frameworks/quiz.json
@@ -8,8 +8,8 @@
       "options": [
         "February 2, 2025",
         "August 2, 2026",
-        "January 1, 2030",
-        "Already fully enforced in 2024"
+        "Already fully enforced in 2024",
+        "January 1, 2030"
       ],
       "correct": 1,
       "explanation": ""
@@ -19,11 +19,11 @@
       "question": "Which two-tier fine ceiling does the EU AI Act define?",
       "options": [
         "Up to €1M flat for any violation",
-        "Up to €15M or 3% global annual turnover for high-risk-system obligations (Art. 99(4)); up to €35M or 7% for prohibited AI practices (Art. 99(3))",
         "Up to €100K for any violation",
+        "Up to €15M or 3% global annual turnover for high-risk-system obligations (Art. 99(4)); up to €35M or 7% for prohibited AI practices (Art. 99(3))",
         "No financial penalties, only takedown orders"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     },
     {
@@ -31,45 +31,45 @@
       "question": "Why is post-processing PII cleanup not a defensible GDPR posture?",
       "options": [
         "It is too slow at scale",
-        "The model already saw the data, so real-time inference-layer redaction (before the LLM call) is the defensible 2026 standard",
         "GDPR forbids redaction entirely",
-        "Post-processing is identical to real-time"
+        "Post-processing is identical to real-time",
+        "The model already saw the data, so real-time inference-layer redaction (before the LLM call) is the defensible 2026 standard"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "What is the practical difference between SOC 2 Type I and Type II?",
       "options": [
+        "Type I requires HIPAA BAA",
         "Type I is more rigorous than Type II",
         "Type I attests controls designed and documented; Type II attests controls operating effectively over 6-12 months",
-        "Type I requires HIPAA BAA",
         "Type II is for startups only"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     },
     {
       "stage": "post",
       "question": "What does cross-framework control mapping aim to deliver?",
       "options": [
-        "More distinct controls per framework",
         "One control policy that satisfies multiple framework requirements (e.g. access logging maps to ISO 27001 A.5.15-5.18, GDPR Art. 32, HIPAA §164.312(a))",
+        "Eliminating audits",
         "Replacing all frameworks with ISO 42001",
-        "Eliminating audits"
+        "More distinct controls per framework"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     },
     {
       "stage": "post",
       "question": "What does the lesson recommend for HIPAA + LLM workloads?",
       "options": [
-        "Ship PHI to any provider; BAA is optional",
+        "HIPAA does not apply to LLMs",
         "Never send PHI to an external AI service without a signed BAA; all three hyperscalers and major LLM API providers offer BAAs",
         "Use only on-prem models, never managed",
-        "HIPAA does not apply to LLMs"
+        "Ship PHI to any provider; BAA is optional"
       ],
       "correct": 1,
       "explanation": ""

--- a/phases/17-infrastructure-and-production/27-finops-llms/quiz.json
+++ b/phases/17-infrastructure-and-production/27-finops-llms/quiz.json
@@ -1,0 +1,78 @@
+{
+  "lesson": "27-finops-llms",
+  "title": "FinOps for LLMs — Unit Economics and Multi-Tenant Attribution",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "Why does traditional FinOps break on LLM spend?",
+      "options": [
+        "LLMs don't cost money",
+        "Costs are token-transactions rather than resource-uptime; tags don't auto-propagate from API calls and you must stamp user/task/tenant at the call site",
+        "LLM bills are always free",
+        "Cloud providers refuse to itemize"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Which three attribution dimensions does the lesson require instrumenting on day one?",
+      "options": [
+        "GPU, CPU, RAM",
+        "Per-user (user_id), per-task (task_id + route), per-tenant (tenant_id)",
+        "Region, AZ, datacenter",
+        "Provider, model, API version"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Which four token layers should be broken out in cost attribution?",
+      "options": [
+        "Prompt, tool, memory, response",
+        "Input, output, network, disk",
+        "GPU, CPU, RAM, storage",
+        "Cache, model, gateway, observability"
+      ],
+      "correct": 0,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "What is the kill-switch trigger in the enforcement ladder?",
+      "options": [
+        "Tenant spend z-score > 4 relative to baseline; auto-pause tenant and page on-call",
+        "Any 5xx response",
+        "Spend over $1 in a minute",
+        "Latency P50 > 2s"
+      ],
+      "correct": 0,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Which unit metric does the lesson recommend instead of $/M tokens?",
+      "options": [
+        "Cost per second",
+        "Cost per product outcome (e.g. cost per resolved support ticket, cost per generated article, cost per successful agent task)",
+        "Cost per GPU-hour",
+        "Cost per gateway"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Which attribution pattern does the lesson call the highest-accuracy one mature teams use?",
+      "options": [
+        "Sampling and extrapolation",
+        "Telemetry joiner — join traces to billing via trace IDs",
+        "Tag-and-aggregate only",
+        "Model-based allocation"
+      ],
+      "correct": 1,
+      "explanation": ""
+    }
+  ]
+}

--- a/phases/17-infrastructure-and-production/27-finops-llms/quiz.json
+++ b/phases/17-infrastructure-and-production/27-finops-llms/quiz.json
@@ -7,23 +7,23 @@
       "question": "Why does traditional FinOps break on LLM spend?",
       "options": [
         "LLMs don't cost money",
-        "Costs are token-transactions rather than resource-uptime; tags don't auto-propagate from API calls and you must stamp user/task/tenant at the call site",
         "LLM bills are always free",
-        "Cloud providers refuse to itemize"
+        "Cloud providers refuse to itemize",
+        "Costs are token-transactions rather than resource-uptime; tags don't auto-propagate from API calls and you must stamp user/task/tenant at the call site"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "Which three attribution dimensions does the lesson require instrumenting on day one?",
       "options": [
-        "GPU, CPU, RAM",
         "Per-user (user_id), per-task (task_id + route), per-tenant (tenant_id)",
+        "Provider, model, API version",
         "Region, AZ, datacenter",
-        "Provider, model, API version"
+        "GPU, CPU, RAM"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     },
     {
@@ -32,8 +32,8 @@
       "options": [
         "Prompt, tool, memory, response",
         "Input, output, network, disk",
-        "GPU, CPU, RAM, storage",
-        "Cache, model, gateway, observability"
+        "Cache, model, gateway, observability",
+        "GPU, CPU, RAM, storage"
       ],
       "correct": 0,
       "explanation": ""
@@ -43,9 +43,9 @@
       "question": "What is the kill-switch trigger in the enforcement ladder?",
       "options": [
         "Tenant spend z-score > 4 relative to baseline; auto-pause tenant and page on-call",
+        "Latency P50 > 2s",
         "Any 5xx response",
-        "Spend over $1 in a minute",
-        "Latency P50 > 2s"
+        "Spend over $1 in a minute"
       ],
       "correct": 0,
       "explanation": ""
@@ -54,12 +54,12 @@
       "stage": "post",
       "question": "Which unit metric does the lesson recommend instead of $/M tokens?",
       "options": [
-        "Cost per second",
-        "Cost per product outcome (e.g. cost per resolved support ticket, cost per generated article, cost per successful agent task)",
+        "Cost per gateway",
         "Cost per GPU-hour",
-        "Cost per gateway"
+        "Cost per second",
+        "Cost per product outcome (e.g. cost per resolved support ticket, cost per generated article, cost per successful agent task)"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
@@ -67,11 +67,11 @@
       "question": "Which attribution pattern does the lesson call the highest-accuracy one mature teams use?",
       "options": [
         "Sampling and extrapolation",
-        "Telemetry joiner — join traces to billing via trace IDs",
+        "Model-based allocation",
         "Tag-and-aggregate only",
-        "Model-based allocation"
+        "Telemetry joiner — join traces to billing via trace IDs"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     }
   ]

--- a/phases/17-infrastructure-and-production/28-self-hosted-serving-selection/quiz.json
+++ b/phases/17-infrastructure-and-production/28-self-hosted-serving-selection/quiz.json
@@ -1,0 +1,78 @@
+{
+  "lesson": "28-self-hosted-serving-selection",
+  "title": "Self-Hosted Serving Selection — llama.cpp, Ollama, TGI, vLLM, SGLang",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "Which engine does the lesson pick as the dev-laptop one-command default?",
+      "options": [
+        "vLLM",
+        "TGI",
+        "Ollama",
+        "llama.cpp"
+      ],
+      "correct": 2,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "What 2025 event changes the default away from TGI for new projects?",
+      "options": [
+        "TGI dropped CUDA support",
+        "TGI entered maintenance mode on December 11, 2025 — only bug fixes going forward",
+        "TGI raised prices",
+        "TGI was acquired by Anthropic"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Which hardware constraint forces llama.cpp and excludes vLLM / TRT-LLM?",
+      "options": [
+        "NVIDIA Hopper",
+        "CPU only (no accelerator)",
+        "AMD MI300X",
+        "Apple M4"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "check",
+      "question": "Which engine does the lesson position for agentic multi-turn and prefix-heavy workloads thanks to RadixAttention?",
+      "options": [
+        "Ollama",
+        "TGI",
+        "SGLang",
+        "llama.cpp"
+      ],
+      "correct": 2,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "What dev-to-prod pipeline does the lesson recommend on the same GGUF or HF weights?",
+      "options": [
+        "TGI everywhere",
+        "Ollama in dev, llama.cpp in staging, vLLM (or SGLang for prefix-heavy) in prod",
+        "Ollama in dev and Ollama in prod",
+        "Only TRT-LLM, top to bottom"
+      ],
+      "correct": 1,
+      "explanation": ""
+    },
+    {
+      "stage": "post",
+      "question": "Why is Ollama discouraged for shared production?",
+      "options": [
+        "It is closed source",
+        "Go HTTP serialization adds overhead, concurrency management is simpler than vLLM, and OpenTelemetry support lags",
+        "It cannot load GGUF",
+        "It only runs on Windows"
+      ],
+      "correct": 1,
+      "explanation": ""
+    }
+  ]
+}

--- a/phases/17-infrastructure-and-production/28-self-hosted-serving-selection/quiz.json
+++ b/phases/17-infrastructure-and-production/28-self-hosted-serving-selection/quiz.json
@@ -6,36 +6,36 @@
       "stage": "pre",
       "question": "Which engine does the lesson pick as the dev-laptop one-command default?",
       "options": [
-        "vLLM",
         "TGI",
         "Ollama",
+        "vLLM",
         "llama.cpp"
       ],
-      "correct": 2,
+      "correct": 1,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "What 2025 event changes the default away from TGI for new projects?",
       "options": [
-        "TGI dropped CUDA support",
-        "TGI entered maintenance mode on December 11, 2025 — only bug fixes going forward",
+        "TGI was acquired by Anthropic",
         "TGI raised prices",
-        "TGI was acquired by Anthropic"
+        "TGI dropped CUDA support",
+        "TGI entered maintenance mode on December 11, 2025 — only bug fixes going forward"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
       "stage": "check",
       "question": "Which hardware constraint forces llama.cpp and excludes vLLM / TRT-LLM?",
       "options": [
-        "NVIDIA Hopper",
-        "CPU only (no accelerator)",
+        "Apple M4",
         "AMD MI300X",
-        "Apple M4"
+        "NVIDIA Hopper",
+        "CPU only (no accelerator)"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
@@ -43,9 +43,9 @@
       "question": "Which engine does the lesson position for agentic multi-turn and prefix-heavy workloads thanks to RadixAttention?",
       "options": [
         "Ollama",
-        "TGI",
+        "llama.cpp",
         "SGLang",
-        "llama.cpp"
+        "TGI"
       ],
       "correct": 2,
       "explanation": ""
@@ -54,12 +54,12 @@
       "stage": "post",
       "question": "What dev-to-prod pipeline does the lesson recommend on the same GGUF or HF weights?",
       "options": [
-        "TGI everywhere",
-        "Ollama in dev, llama.cpp in staging, vLLM (or SGLang for prefix-heavy) in prod",
+        "Only TRT-LLM, top to bottom",
         "Ollama in dev and Ollama in prod",
-        "Only TRT-LLM, top to bottom"
+        "Ollama in dev, llama.cpp in staging, vLLM (or SGLang for prefix-heavy) in prod",
+        "TGI everywhere"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     },
     {
@@ -67,11 +67,11 @@
       "question": "Why is Ollama discouraged for shared production?",
       "options": [
         "It is closed source",
+        "It only runs on Windows",
         "Go HTTP serialization adds overhead, concurrency management is simpler than vLLM, and OpenTelemetry support lags",
-        "It cannot load GGUF",
-        "It only runs on Windows"
+        "It cannot load GGUF"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     }
   ]


### PR DESCRIPTION
## Summary

Backfills `quiz.json` across all 28 lessons in Phase 17 (Infrastructure & Production), taking quiz coverage from 0/28 to 28/28.

- 28 atomic per-lesson commits, one per `quiz.json`, plus one catalog rebuild commit.
- 169 questions total. Stage distribution: 29 pre, 84 check, 56 post.
- Schema matches `phases/11-llm-engineering/14-model-context-protocol/quiz.json` (canonical `stage` / `question` / `options` / `correct` / `explanation`).
- `python3 scripts/audit_lessons.py --phase 17` exits 0.
- `python3 scripts/build_catalog.py` rebuild flips `has_quiz: true` for every Phase 17 lesson.

## Test plan

- [ ] CI passes (`audit_lessons.py` and `check_readme_counts.py`).
- [ ] Site quiz UI loads each lesson without "Lesson not found" / blank renderer.
- [ ] Each quiz answers map to a single integer index in options[0..n].
- [ ] No legacy q / choices / answer keys anywhere under phases/17-*.