### PR TITLE
fix(site): WCAG accessibility pass across all pages

### DIFF
--- a/site/app.js
+++ b/site/app.js
@@ -124,11 +124,12 @@
       var statusClass = p.status.replace(/ /g, '-');
       var roman = toRoman(p.id);
       var num = String(p.id).padStart(2, '0');
-      html += '<div class="toc-row" data-phase="' + i + '">';
-      html += '<span class="toc-num">' + roman + '.</span>';
-      html += '<div><span class="toc-status ' + statusClass + '"></span><span class="toc-name">' + escapeHtml(p.name) + '</span></div>';
-      html += '<span class="toc-meta">' + done + ' / ' + total + '</span>';
-      html += '<span class="toc-meta">' + num + '</span>';
+      var label = 'Phase ' + num + ': ' + p.name + ', ' + done + ' of ' + total + ' lessons complete';
+      html += '<div class="toc-row" data-phase="' + i + '" role="button" tabindex="0" aria-label="' + escapeHtml(label) + '">';
+      html += '<span class="toc-num" aria-hidden="true">' + roman + '.</span>';
+      html += '<div><span class="toc-status ' + statusClass + '" aria-hidden="true"></span><span class="toc-name">' + escapeHtml(p.name) + '</span></div>';
+      html += '<span class="toc-meta" aria-hidden="true">' + done + ' / ' + total + '</span>';
+      html += '<span class="toc-meta" aria-hidden="true">' + num + '</span>';
       html += '</div>';
     }
     grid.innerHTML = html;
@@ -179,8 +180,18 @@
       var row = e.target.closest('.toc-row, .phase-card');
       if (row) {
         var idx = parseInt(row.getAttribute('data-phase'), 10);
-        if (!isNaN(idx)) openModal(idx);
+        if (!isNaN(idx)) openModal(idx, row);
       }
+    });
+
+    // Keyboard activation for the role="button" phase rows.
+    document.addEventListener('keydown', function (e) {
+      if (e.key !== 'Enter' && e.key !== ' ') return;
+      var row = e.target.closest && e.target.closest('.toc-row, .phase-card');
+      if (!row || !row.hasAttribute('data-phase')) return;
+      e.preventDefault();
+      var idx = parseInt(row.getAttribute('data-phase'), 10);
+      if (!isNaN(idx)) openModal(idx, row);
     });
 
     closeBtn.addEventListener('click', closeModal);
@@ -188,7 +199,15 @@
       if (e.target === overlay) closeModal();
     });
     document.addEventListener('keydown', function (e) {
-      if (e.key === 'Escape') closeModal();
+      if (!overlay.classList.contains('open')) return;
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        closeModal();
+        return;
+      }
+      if (e.key === 'Tab') {
+        trapTab(e, overlay);
+      }
     });
 
     var resetBtn = document.getElementById('modalReset');
@@ -202,12 +221,35 @@
     }
   }
 
-  var currentPhaseIdx = -1;
+  function getFocusables(root) {
+    return Array.prototype.slice.call(root.querySelectorAll(
+      'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+    )).filter(function (el) { return el.offsetParent !== null; });
+  }
 
-  function openModal(idx) {
+  function trapTab(e, container) {
+    var f = getFocusables(container);
+    if (!f.length) return;
+    var first = f[0];
+    var last = f[f.length - 1];
+    var active = document.activeElement;
+    if (e.shiftKey && active === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && active === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  }
+
+  var currentPhaseIdx = -1;
+  var lastModalTrigger = null;
+
+  function openModal(idx, triggerEl) {
     var p = PHASES[idx];
     if (!p) return;
     currentPhaseIdx = idx;
+    lastModalTrigger = triggerEl || document.activeElement;
 
     document.getElementById('modalPhaseNum').textContent = 'PHASE ' + String(p.id).padStart(2, '0');
     document.getElementById('modalTitle').textContent = p.name;
@@ -215,8 +257,14 @@
 
     renderModalLessons(p);
 
-    document.getElementById('modalOverlay').classList.add('open');
+    var overlay = document.getElementById('modalOverlay');
+    overlay.classList.add('open');
+    overlay.setAttribute('aria-hidden', 'false');
     document.body.style.overflow = 'hidden';
+
+    // Move focus into the dialog so screen readers and keyboards land there.
+    var closeBtn = document.getElementById('modalClose');
+    if (closeBtn) closeBtn.focus();
   }
 
   function renderModalLessons(p) {
@@ -238,11 +286,13 @@
       if (userComplete) statusClass = 'complete';
 
       html += '<div class="modal-lesson' + (userComplete ? ' user-done' : '') + '">';
-      html += '<span class="modal-lesson-status ' + statusClass + '"' + (userComplete ? ' title="You completed this lesson"' : '') + '></span>';
+      html += '<span class="modal-lesson-status ' + statusClass + '"' + (userComplete ? ' title="You completed this lesson"' : '') + ' aria-hidden="true"></span>';
       if (l.url) {
         html += '<a href="' + l.url + '" target="_blank" rel="noopener">' + escapeHtml(l.name) + '</a>';
       } else {
-        html += '<a>' + escapeHtml(l.name) + '</a>';
+        // Unreleased lesson: render as plain text rather than a non-functional <a>
+        // so it isn't announced or focused as a link.
+        html += '<span class="modal-lesson-pending" aria-label="' + escapeHtml(l.name) + ' (not yet available)">' + escapeHtml(l.name) + '</span>';
       }
       html += '<span class="modal-lesson-type" data-type="' + escapeHtml(l.type) + '"' + (l.combines ? ' title="Combines: ' + escapeHtml(l.combines) + '"' : '') + '>' + escapeHtml(l.type) + '</span>';
       html += '<span class="modal-lesson-lang">' + escapeHtml(l.lang) + '</span>';
@@ -306,8 +356,14 @@
   }
 
   function closeModal() {
-    document.getElementById('modalOverlay').classList.remove('open');
+    var overlay = document.getElementById('modalOverlay');
+    overlay.classList.remove('open');
+    overlay.setAttribute('aria-hidden', 'true');
     document.body.style.overflow = '';
+    if (lastModalTrigger && typeof lastModalTrigger.focus === 'function') {
+      try { lastModalTrigger.focus(); } catch (_) {}
+    }
+    lastModalTrigger = null;
   }
 
   function initCopyButton() {

--- a/site/app.js
+++ b/site/app.js
@@ -380,7 +380,14 @@
         btn.textContent = '✓';
         // Announce via a dedicated live region — the button's aria-label
         // overrides its textContent, so AT won't hear "✓" otherwise.
-        if (status) status.textContent = 'Command copied to clipboard';
+        // Clear first, then set on the next frame so repeated clicks
+        // produce a fresh AT announcement (live regions debounce identical text).
+        if (status) {
+          status.textContent = '';
+          window.requestAnimationFrame(function () {
+            status.textContent = 'Command copied to clipboard';
+          });
+        }
         if (revertTimer) clearTimeout(revertTimer);
         revertTimer = setTimeout(function () {
           btn.textContent = originalLabel;

--- a/site/app.js
+++ b/site/app.js
@@ -222,9 +222,11 @@
   }
 
   function getFocusables(root) {
+    // getClientRects().length is more reliable than offsetParent for visibility:
+    // offsetParent returns null for position: fixed elements even when visible.
     return Array.prototype.slice.call(root.querySelectorAll(
       'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
-    )).filter(function (el) { return el.offsetParent !== null; });
+    )).filter(function (el) { return el.getClientRects().length > 0; });
   }
 
   function trapTab(e, container) {
@@ -369,14 +371,21 @@
   function initCopyButton() {
     var btn = document.getElementById('copyBtn');
     var code = document.getElementById('cloneCmd');
+    var status = document.getElementById('copyStatus');
     if (!btn || !code) return;
     var originalLabel = btn.textContent;
     var revertTimer = null;
     btn.addEventListener('click', function () {
       navigator.clipboard.writeText(code.textContent).then(function () {
         btn.textContent = '✓';
+        // Announce via a dedicated live region — the button's aria-label
+        // overrides its textContent, so AT won't hear "✓" otherwise.
+        if (status) status.textContent = 'Command copied to clipboard';
         if (revertTimer) clearTimeout(revertTimer);
-        revertTimer = setTimeout(function () { btn.textContent = originalLabel; }, 1500);
+        revertTimer = setTimeout(function () {
+          btn.textContent = originalLabel;
+          if (status) status.textContent = '';
+        }, 1500);
       });
     });
   }

--- a/site/catalog.html
+++ b/site/catalog.html
@@ -112,20 +112,28 @@
     }
 
     .catalog-table th {
+      text-align: left;
+      padding: 0;
+      border-bottom: 2px solid var(--border);
+      white-space: nowrap;
+    }
+
+    .catalog-table th .sort-btn {
+      width: 100%;
+      text-align: left;
+      background: none;
+      border: 0;
+      padding: 14px 16px;
       font-family: var(--font-heading);
       font-weight: 700;
       font-size: 0.9rem;
-      text-align: left;
-      padding: 14px 16px;
-      border-bottom: 2px solid var(--border);
       color: var(--text-muted);
       cursor: pointer;
       user-select: none;
-      white-space: nowrap;
       transition: color 0.2s;
     }
 
-    .catalog-table th:hover {
+    .catalog-table th .sort-btn:hover {
       color: var(--accent);
     }
 
@@ -229,10 +237,10 @@
         <a href="catalog.html">Catalog</a>
         <a href="prereqs.html">Roadmap</a>
         <a href="glossary.html">Glossary</a>
-        <a href="https://github.com/rohitg00/ai-engineering-from-scratch" target="_blank" rel="noopener" class="header-github">
+        <a href="https://github.com/rohitg00/ai-engineering-from-scratch" target="_blank" rel="noopener" class="header-github" aria-label="GitHub repository (opens in new tab)">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.4 3-.405 1.02.005 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
           <svg class="star-icon" width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .587l3.668 7.568 8.332 1.151-6.064 5.828 1.48 8.279L12 19.896l-7.416 3.517 1.48-8.279L0 9.306l8.332-1.151z"/></svg>
-          <span class="star-count" data-loading="true" aria-label="GitHub stars">…</span>
+          <span class="star-count" data-loading="true" aria-hidden="true">…</span>
         </a>
       </nav>
       <button class="search-toggle" type="button" data-cmd-palette
@@ -245,7 +253,7 @@
         </svg>
       </button>
       <button class="theme-toggle" id="themeToggle" aria-label="Toggle theme" type="button">
-        <span class="theme-icon" id="themeIcon">N</span>
+        <span class="theme-icon" id="themeIcon" aria-hidden="true">N</span>
       </button>
     </div>
   </header>
@@ -257,26 +265,29 @@
         <p>Every lesson across all 20 phases. Search, filter, sort.</p>
       </div>
       <div class="catalog-controls">
-        <input type="text" class="catalog-search" id="catalogSearch" placeholder="Search lessons...">
-        <select class="catalog-filter" id="catalogPhase">
+        <label for="catalogSearch" class="sr-only">Search lessons</label>
+        <input type="search" class="catalog-search" id="catalogSearch" placeholder="Search lessons..." aria-controls="catalogTable">
+        <label for="catalogPhase" class="sr-only">Filter by phase</label>
+        <select class="catalog-filter" id="catalogPhase" aria-controls="catalogTable">
           <option value="">All Phases</option>
         </select>
-        <select class="catalog-filter" id="catalogStatus">
+        <label for="catalogStatus" class="sr-only">Filter by status</label>
+        <select class="catalog-filter" id="catalogStatus" aria-controls="catalogTable">
           <option value="">All Status</option>
           <option value="complete">Complete</option>
           <option value="planned">Planned</option>
         </select>
       </div>
-      <div class="catalog-count" id="catalogCount"></div>
+      <div class="catalog-count" id="catalogCount" role="status" aria-live="polite" aria-atomic="true"></div>
       <div class="catalog-table-wrap">
         <table class="catalog-table" id="catalogTable">
           <thead>
             <tr>
-              <th data-sort="phase">Phase <span class="sort-arrow"></span></th>
-              <th data-sort="name">Lesson <span class="sort-arrow"></span></th>
-              <th data-sort="type">Type <span class="sort-arrow"></span></th>
-              <th data-sort="lang">Language <span class="sort-arrow"></span></th>
-              <th data-sort="status">Status <span class="sort-arrow"></span></th>
+              <th data-sort="phase" aria-sort="none"><button type="button" class="sort-btn">Phase <span class="sort-arrow" aria-hidden="true"></span></button></th>
+              <th data-sort="name" aria-sort="none"><button type="button" class="sort-btn">Lesson <span class="sort-arrow" aria-hidden="true"></span></button></th>
+              <th data-sort="type" aria-sort="none"><button type="button" class="sort-btn">Type <span class="sort-arrow" aria-hidden="true"></span></button></th>
+              <th data-sort="lang" aria-sort="none"><button type="button" class="sort-btn">Language <span class="sort-arrow" aria-hidden="true"></span></button></th>
+              <th data-sort="status" aria-sort="none"><button type="button" class="sort-btn">Status <span class="sort-arrow" aria-hidden="true"></span></button></th>
             </tr>
           </thead>
           <tbody id="catalogBody"></tbody>
@@ -448,7 +459,8 @@
         statusSelect.addEventListener('change', render);
 
         document.querySelectorAll('.catalog-table th[data-sort]').forEach(function (th) {
-          th.addEventListener('click', function () {
+          var btn = th.querySelector('.sort-btn');
+          var handler = function () {
             var col = th.getAttribute('data-sort');
             if (sortCol === col) {
               sortDir = sortDir * -1;
@@ -456,12 +468,18 @@
               sortCol = col;
               sortDir = 1;
             }
-            document.querySelectorAll('.catalog-table th .sort-arrow').forEach(function (a) {
-              a.textContent = '';
+            document.querySelectorAll('.catalog-table th[data-sort]').forEach(function (otherTh) {
+              otherTh.setAttribute('aria-sort', 'none');
+              var arrow = otherTh.querySelector('.sort-arrow');
+              if (arrow) arrow.textContent = '';
             });
-            th.querySelector('.sort-arrow').textContent = sortDir === 1 ? ' \u25B2' : ' \u25BC';
+            th.setAttribute('aria-sort', sortDir === 1 ? 'ascending' : 'descending');
+            var arrow = th.querySelector('.sort-arrow');
+            if (arrow) arrow.textContent = sortDir === 1 ? ' \u25B2' : ' \u25BC';
             render();
-          });
+          };
+          if (btn) btn.addEventListener('click', handler);
+          else th.addEventListener('click', handler);
         });
 
         render();

--- a/site/glossary.html
+++ b/site/glossary.html
@@ -180,10 +180,10 @@
         <a href="catalog.html">Catalog</a>
         <a href="prereqs.html">Roadmap</a>
         <a href="glossary.html">Glossary</a>
-        <a href="https://github.com/rohitg00/ai-engineering-from-scratch" target="_blank" rel="noopener" class="header-github">
+        <a href="https://github.com/rohitg00/ai-engineering-from-scratch" target="_blank" rel="noopener" class="header-github" aria-label="GitHub repository (opens in new tab)">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.4 3-.405 1.02.005 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
           <svg class="star-icon" width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .587l3.668 7.568 8.332 1.151-6.064 5.828 1.48 8.279L12 19.896l-7.416 3.517 1.48-8.279L0 9.306l8.332-1.151z"/></svg>
-          <span class="star-count" data-loading="true" aria-label="GitHub stars">…</span>
+          <span class="star-count" data-loading="true" aria-hidden="true">…</span>
         </a>
       </nav>
       <button class="search-toggle" type="button" data-cmd-palette
@@ -196,7 +196,7 @@
         </svg>
       </button>
       <button class="theme-toggle" id="themeToggle" aria-label="Toggle theme" type="button">
-        <span class="theme-icon" id="themeIcon">N</span>
+        <span class="theme-icon" id="themeIcon" aria-hidden="true">N</span>
       </button>
     </div>
   </header>
@@ -208,9 +208,10 @@
         <p>What people <em>say</em> vs what things actually <em>mean</em></p>
       </div>
       <div class="glossary-search-wrap">
-        <input type="text" class="glossary-search" id="glossarySearch" placeholder="Search terms...">
+        <label for="glossarySearch" class="sr-only">Search glossary terms</label>
+        <input type="search" class="glossary-search" id="glossarySearch" placeholder="Search terms..." aria-controls="glossaryList">
       </div>
-      <div class="glossary-count" id="glossaryCount"></div>
+      <div class="glossary-count" id="glossaryCount" role="status" aria-live="polite" aria-atomic="true"></div>
       <div class="glossary-list" id="glossaryList"></div>
     </div>
   </main>

--- a/site/index.html
+++ b/site/index.html
@@ -688,8 +688,9 @@
           <p>The entire curriculum is on GitHub. Clone it, fork it, learn at your own pace. No paywall, no signup. Every lesson has runnable code in Python, TypeScript, Rust, or Julia, depending on what fits the concept best.</p>
           <div class="colophon-cmd">
             <code id="cloneCmd">git clone https://github.com/rohitg00/ai-engineering-from-scratch.git</code>
-            <button class="copy-btn" id="copyBtn" aria-label="Copy command" type="button" aria-live="polite">cp</button>
+            <button class="copy-btn" id="copyBtn" aria-label="Copy command" type="button">cp</button>
           </div>
+          <div id="copyStatus" class="sr-only" role="status" aria-live="polite"></div>
         </div>
       </div>
     </section>

--- a/site/index.html
+++ b/site/index.html
@@ -580,9 +580,9 @@
         <a href="catalog.html">Catalog</a>
         <a href="prereqs.html">Roadmap</a>
         <a href="glossary.html">Glossary</a>
-        <a href="https://github.com/rohitg00/ai-engineering-from-scratch" target="_blank" rel="noopener" class="header-github">
+        <a href="https://github.com/rohitg00/ai-engineering-from-scratch" target="_blank" rel="noopener" class="header-github" aria-label="GitHub repository (opens in new tab)">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.4 3-.405 1.02.005 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
-          <span class="star-count" data-loading="true" aria-label="GitHub stars">…</span>
+          <span class="star-count" data-loading="true" aria-hidden="true">…</span>
         </a>
       </nav>
       <button class="search-toggle" type="button" data-cmd-palette
@@ -595,7 +595,7 @@
         </svg>
       </button>
       <button class="theme-toggle" id="themeToggle" aria-label="Toggle theme" type="button">
-        <span class="theme-icon" id="themeIcon">N</span>
+        <span class="theme-icon" id="themeIcon" aria-hidden="true">N</span>
       </button>
     </div>
   </header>
@@ -630,29 +630,29 @@
       <div class="stat-rows reveal" style="--stagger-delay: 100ms;" id="statRows">
         <div class="stat-row">
           <span class="stat-row-label">Finished Lessons</span>
-          <span class="stat-row-bar" data-bar="complete" style="--bar-pct:0%;" aria-hidden="true">bar</span>
+          <span class="stat-row-bar" data-bar="complete" style="--bar-pct:0%;" aria-hidden="true"></span>
           <span class="stat-row-value" data-stat="complete-frac">0 / 0</span>
         </div>
         <div class="stat-row">
           <span class="stat-row-label">Phases</span>
-          <span class="stat-row-bar" data-bar="phases" style="--bar-pct:0%;" aria-hidden="true">bar</span>
+          <span class="stat-row-bar" data-bar="phases" style="--bar-pct:0%;" aria-hidden="true"></span>
           <span class="stat-row-value" data-stat="phases-frac">0 / 0</span>
         </div>
         <div class="stat-row">
           <span class="stat-row-label">Languages</span>
-          <span class="stat-row-bar" data-bar="languages" style="--bar-pct:100%;" aria-hidden="true">bar</span>
+          <span class="stat-row-bar" data-bar="languages" style="--bar-pct:100%;" aria-hidden="true"></span>
           <span class="stat-row-value">4</span>
         </div>
         <div class="stat-row">
           <span class="stat-row-label">Glossary Terms</span>
-          <span class="stat-row-bar" data-bar="glossary" style="--bar-pct:100%;" aria-hidden="true">bar</span>
+          <span class="stat-row-bar" data-bar="glossary" style="--bar-pct:100%;" aria-hidden="true"></span>
           <span class="stat-row-value" data-stat="glossary-count">···</span>
         </div>
       </div>
     </section>
 
-    <section class="toc container" id="contents">
-      <div class="toc-title reveal reveal--left">Curriculum · 20 phases · 435 lessons</div>
+    <section class="toc container" id="contents" aria-labelledby="contentsHeading">
+      <h2 class="toc-title reveal reveal--left" id="contentsHeading">Curriculum · 20 phases · 435 lessons</h2>
       <div class="toc-subtitle reveal" style="--stagger-delay: 80ms;">Tap a phase to expand its lessons. Each one ships when its math, code, and test are all written.</div>
       <div class="toc-list" id="phasesGrid"></div>
       <div class="legend">
@@ -662,9 +662,9 @@
       </div>
     </section>
 
-    <div class="modal-overlay" id="modalOverlay">
-      <div class="modal" id="modal">
-        <button class="modal-close" id="modalClose" type="button">×</button>
+    <div class="modal-overlay" id="modalOverlay" aria-hidden="true">
+      <div class="modal" id="modal" role="dialog" aria-modal="true" aria-labelledby="modalTitle">
+        <button class="modal-close" id="modalClose" type="button" aria-label="Close phase details">×</button>
         <div class="modal-header">
           <span class="modal-phase-num" id="modalPhaseNum"></span>
           <h2 class="modal-title" id="modalTitle"></h2>
@@ -688,7 +688,7 @@
           <p>The entire curriculum is on GitHub. Clone it, fork it, learn at your own pace. No paywall, no signup. Every lesson has runnable code in Python, TypeScript, Rust, or Julia, depending on what fits the concept best.</p>
           <div class="colophon-cmd">
             <code id="cloneCmd">git clone https://github.com/rohitg00/ai-engineering-from-scratch.git</code>
-            <button class="copy-btn" id="copyBtn" aria-label="Copy command" type="button">cp</button>
+            <button class="copy-btn" id="copyBtn" aria-label="Copy command" type="button" aria-live="polite">cp</button>
           </div>
         </div>
       </div>

--- a/site/lesson.html
+++ b/site/lesson.html
@@ -1577,10 +1577,10 @@
         <a href="catalog.html">Catalog</a>
         <a href="prereqs.html">Roadmap</a>
         <a href="glossary.html">Glossary</a>
-        <a href="https://github.com/rohitg00/ai-engineering-from-scratch" target="_blank" rel="noopener" class="header-github">
+        <a href="https://github.com/rohitg00/ai-engineering-from-scratch" target="_blank" rel="noopener" class="header-github" aria-label="GitHub repository (opens in new tab)">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.4 3-.405 1.02.005 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
           <svg class="star-icon" width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .587l3.668 7.568 8.332 1.151-6.064 5.828 1.48 8.279L12 19.896l-7.416 3.517 1.48-8.279L0 9.306l8.332-1.151z"/></svg>
-          <span class="star-count" data-loading="true" aria-label="GitHub stars">…</span>
+          <span class="star-count" data-loading="true" aria-hidden="true">…</span>
         </a>
       </nav>
       <button class="search-toggle" type="button" data-cmd-palette
@@ -1593,12 +1593,12 @@
         </svg>
       </button>
       <button class="theme-toggle" id="themeToggle" aria-label="Toggle theme" type="button">
-        <span class="theme-icon" id="themeIcon">N</span>
+        <span class="theme-icon" id="themeIcon" aria-hidden="true">N</span>
       </button>
     </div>
   </header>
 
-  <button class="lesson-sidebar-toggle" id="sidebarToggle" aria-label="Toggle sidebar">&#9776;</button>
+  <button class="lesson-sidebar-toggle" id="sidebarToggle" type="button" aria-label="Toggle lesson sidebar" aria-expanded="false" aria-controls="lessonSidebar">&#9776;</button>
 
   <div class="mermaid-modal-overlay" id="mermaidModalOverlay" aria-hidden="true">
     <div class="mermaid-modal" role="dialog" aria-modal="true" aria-label="Expanded diagram">
@@ -1613,16 +1613,16 @@
   </div>
 
   <div class="lesson-layout">
-    <aside class="lesson-sidebar" id="lessonSidebar"></aside>
-    <main class="lesson-main" id="main">
+    <aside class="lesson-sidebar" id="lessonSidebar" aria-label="Lessons in this phase"></aside>
+    <main class="lesson-main" id="main" tabindex="-1">
       <div class="lesson-content" id="lessonContent">
-        <div class="lesson-loading" id="lessonLoading">
-          <div class="spinner"></div>
+        <div class="lesson-loading" id="lessonLoading" role="status" aria-live="polite">
+          <div class="spinner" aria-hidden="true"></div>
           <div class="lesson-loading-text">Loading lesson...</div>
         </div>
       </div>
     </main>
-    <aside class="toc-sidebar" id="tocSidebar" aria-hidden="true"></aside>
+    <aside class="toc-sidebar" id="tocSidebar" aria-label="On this page" aria-hidden="true"></aside>
   </div>
 
   <script src="data.js?v=20260508a"></script>
@@ -1810,17 +1810,25 @@
         var sidebar = document.getElementById('lessonSidebar');
         if (!toggle || !sidebar) return;
 
+        function syncExpanded() {
+          toggle.setAttribute('aria-expanded', sidebar.classList.contains('open') ? 'true' : 'false');
+        }
+
         toggle.addEventListener('click', function () {
           sidebar.classList.toggle('open');
+          syncExpanded();
         });
 
         document.addEventListener('click', function (e) {
           if (window.innerWidth <= 900 && sidebar.classList.contains('open')) {
             if (!sidebar.contains(e.target) && e.target !== toggle) {
               sidebar.classList.remove('open');
+              syncExpanded();
             }
           }
         });
+
+        syncExpanded();
       }
 
       function initScrollProgress() {
@@ -2690,22 +2698,23 @@
         for (var qi = 0; qi < questions.length; qi++) {
           var q = questions[qi];
           var qid = id + '-q' + qi;
-          html += '<div class="quiz-question" data-correct="' + q.correct + '" id="' + qid + '">';
-          html += '<div class="quiz-question-text">' + (qi + 1) + '. ' + escapeHtml(q.question) + '</div>';
-          html += '<div class="quiz-options">';
+          var optsId = qid + '-opts';
+          html += '<div class="quiz-question" data-correct="' + q.correct + '" id="' + qid + '" role="group" aria-labelledby="' + qid + '-text">';
+          html += '<div class="quiz-question-text" id="' + qid + '-text">' + (qi + 1) + '. ' + escapeHtml(q.question) + '</div>';
+          html += '<div class="quiz-options" id="' + optsId + '">';
           for (var oi = 0; oi < q.options.length; oi++) {
-            html += '<div class="quiz-option" data-index="' + oi + '" onclick="handleQuizClick(this)">';
-            html += '<span class="quiz-marker"></span>';
+            html += '<button type="button" class="quiz-option" data-index="' + oi + '" onclick="handleQuizClick(this)">';
+            html += '<span class="quiz-marker" aria-hidden="true"></span>';
             html += '<span>' + escapeHtml(q.options[oi]) + '</span>';
-            html += '</div>';
+            html += '</button>';
           }
           html += '</div>';
           if (q.explanation) {
-            html += '<div class="quiz-explanation" id="' + qid + '-exp">' + escapeHtml(q.explanation) + '</div>';
+            html += '<div class="quiz-explanation" id="' + qid + '-exp" role="status" aria-live="polite">' + escapeHtml(q.explanation) + '</div>';
           }
           html += '</div>';
         }
-        html += '<div class="quiz-score" id="quiz-' + id + '-score"></div>';
+        html += '<div class="quiz-score" id="quiz-' + id + '-score" role="status" aria-live="polite"></div>';
         html += '</div>';
         return html;
       }

--- a/site/lesson.html
+++ b/site/lesson.html
@@ -2710,7 +2710,9 @@
           }
           html += '</div>';
           if (q.explanation) {
-            html += '<div class="quiz-explanation" id="' + qid + '-exp" role="status" aria-live="polite">' + escapeHtml(q.explanation) + '</div>';
+            // Render empty; text is injected on reveal so the live region
+            // fires a content-change announcement (not just a visibility flip).
+            html += '<div class="quiz-explanation" id="' + qid + '-exp" role="status" aria-live="polite" data-explanation="' + escapeAttr(q.explanation) + '"></div>';
           }
           html += '</div>';
         }
@@ -2750,7 +2752,13 @@
         }
 
         var exp = questionDiv.querySelector('.quiz-explanation');
-        if (exp) exp.style.display = 'block';
+        if (exp) {
+          var explanationText = exp.getAttribute('data-explanation');
+          if (explanationText && !exp.textContent) {
+            exp.textContent = explanationText;
+          }
+          exp.style.display = 'block';
+        }
 
         if (persist && window.AIFSProgress && lessonPath) {
           window.AIFSProgress.recordAnswer(lessonPath, questionDiv.id, chosen, chosen === correct);

--- a/site/prereqs.html
+++ b/site/prereqs.html
@@ -406,10 +406,10 @@
         <a href="catalog.html">Catalog</a>
         <a href="prereqs.html">Roadmap</a>
         <a href="glossary.html">Glossary</a>
-        <a href="https://github.com/rohitg00/ai-engineering-from-scratch" target="_blank" rel="noopener" class="header-github">
+        <a href="https://github.com/rohitg00/ai-engineering-from-scratch" target="_blank" rel="noopener" class="header-github" aria-label="GitHub repository (opens in new tab)">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.4 3-.405 1.02.005 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
           <svg class="star-icon" width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .587l3.668 7.568 8.332 1.151-6.064 5.828 1.48 8.279L12 19.896l-7.416 3.517 1.48-8.279L0 9.306l8.332-1.151z"/></svg>
-          <span class="star-count" data-loading="true" aria-label="GitHub stars">…</span>
+          <span class="star-count" data-loading="true" aria-hidden="true">…</span>
         </a>
       </nav>
       <button class="search-toggle" type="button" data-cmd-palette
@@ -421,8 +421,8 @@
           <line x1="21" y1="21" x2="16.65" y2="16.65"/>
         </svg>
       </button>
-      <button class="theme-toggle" id="themeToggle" aria-label="Toggle theme">
-        <span class="theme-icon" id="themeIcon">N</span>
+      <button class="theme-toggle" id="themeToggle" aria-label="Toggle theme" type="button">
+        <span class="theme-icon" id="themeIcon" aria-hidden="true">N</span>
       </button>
     </div>
   </header>

--- a/site/style.css
+++ b/site/style.css
@@ -129,7 +129,8 @@ body {
   outline-offset: 2px;
 }
 
-/* Visually-hidden but accessible to assistive tech. */
+/* Visually-hidden but accessible to assistive tech. clip is kept as a
+   fallback for older WebKit; modern browsers honor clip-path. */
 .sr-only {
   position: absolute;
   width: 1px;
@@ -138,6 +139,7 @@ body {
   margin: -1px;
   overflow: hidden;
   clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
   white-space: nowrap;
   border: 0;
 }

--- a/site/style.css
+++ b/site/style.css
@@ -9,9 +9,13 @@
   --bg-surface-hover: #ece9dc;
   --ink: #1a1a1a;
   --ink-soft: #4a4a4a;
-  --ink-mute: #7a7a78;
+  /* Bumped from #7a7a78 → #686867 to meet WCAG AA 4.5:1 on --bg. */
+  --ink-mute: #686867;
   --rule: #1a1a1a;
+  /* Decorative paper rules stay subtle; component borders use --rule-strong
+     for WCAG 1.4.11 (3:1) contrast against the background. */
   --rule-soft: rgba(26, 26, 26, 0.16);
+  --rule-strong: rgba(26, 26, 26, 0.45);
   --paper-rule: rgba(26, 26, 26, 0.08);
 
   --blueprint: #3553ff;
@@ -50,9 +54,11 @@
   --bg-surface-hover: #1b2244;
   --ink: #e8e6dc;
   --ink-soft: #a8a6a0;
-  --ink-mute: #7a7878;
+  /* Bumped from #7a7878 → #9a9a98 to meet WCAG AA 4.5:1 on --bg. */
+  --ink-mute: #9a9a98;
   --rule: #e8e6dc;
   --rule-soft: rgba(232, 230, 220, 0.18);
+  --rule-strong: rgba(232, 230, 220, 0.5);
   --paper-rule: rgba(232, 230, 220, 0.08);
 
   --blueprint: #6b8eff;
@@ -120,6 +126,30 @@ body {
   left: 16px;
   top: 16px;
   outline: 2px solid var(--ink);
+  outline-offset: 2px;
+}
+
+/* Visually-hidden but accessible to assistive tech. */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Global keyboard-focus indicator. Individual components may still override
+   for tighter styling, but every focusable element gets a visible ring. */
+a:focus-visible,
+button:focus-visible,
+[role="button"]:focus-visible,
+[tabindex]:focus-visible,
+summary:focus-visible {
+  outline: 2px solid var(--blueprint);
   outline-offset: 2px;
 }
 
@@ -296,7 +326,7 @@ p.dropcap::first-letter {
   align-items: center;
   gap: 8px;
   padding: 6px 12px;
-  border: 1px solid var(--rule-soft);
+  border: 1px solid var(--rule-strong);
   background: var(--bg-surface);
   font-family: var(--font-mono);
   font-size: 0.78rem;
@@ -334,7 +364,7 @@ p.dropcap::first-letter {
 
 .theme-toggle {
   background: transparent;
-  border: 1px solid var(--rule-soft);
+  border: 1px solid var(--rule-strong);
   width: 36px;
   height: 36px;
   cursor: pointer;
@@ -626,6 +656,17 @@ p.dropcap::first-letter {
 .modal-lesson > a:hover {
   color: var(--blueprint);
   border-bottom-color: var(--blueprint);
+}
+
+.modal-lesson > .modal-lesson-pending {
+  color: var(--ink-mute);
+  font-family: var(--font-body);
+  font-size: 0.96rem;
+  font-weight: 500;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .modal-lesson-status {
@@ -1031,7 +1072,7 @@ body.js-anim .toc-row.in-view {
 /* ── Search trigger button in the header ─────────────────────────────── */
 .search-toggle {
   background: transparent;
-  border: 1px solid var(--rule-soft);
+  border: 1px solid var(--rule-strong);
   width: 36px;
   height: 36px;
   cursor: pointer;


### PR DESCRIPTION
## Summary

Brings the static site (`site/`) up to WCAG 2.1 AA across all five HTML pages (`index`, `catalog`, `lesson`, `glossary`, `prereqs`). Visible changes are limited to slightly darker muted text and stronger borders on the header buttons; no layout or behavior regressions.

## What changed, by WCAG criterion

**Level A**
- **2.1.1 Keyboard** — Home-page phase cards are now `role="button" tabindex="0"` with Enter/Space activation. Quiz options in the stage-based renderer switched from `<div onclick>` to real `<button>`s.
- **2.4.3 / 4.1.2** — Phase modal gets `role="dialog"`, `aria-modal="true"`, `aria-labelledby`, a Tab focus trap, initial focus on the close button, and focus restore to the trigger on close.
- **3.3.2 Labels** — `sr-only` labels added to the catalog search/phase/status controls and the glossary search.
- **2.4.4 Link Purpose** — Header GitHub link gets an `aria-label` on every page (was previously announced as just "…" while the star count loaded).
- **4.1.2** — Lesson sidebar toggle syncs `aria-expanded` / `aria-controls`. Unreleased lessons in the modal no longer render as empty `<a>` (now a labeled `<span>`).

**Level AA**
- **1.4.3 Contrast (Minimum)** — `--ink-mute` darkened on both themes to clear 4.5:1 against the body background.
- **1.4.11 Non-text Contrast** — New `--rule-strong` token (~3:1) used for borders on `.theme-toggle`, `.search-toggle`, `.header-github`.
- **2.4.7 Focus Visible** — Global `:focus-visible` outline so every link / button / role=button shows a focus ring.
- **4.1.2** — Catalog sort headers are now `<button>`s with `aria-sort` cycling `none → ascending → descending`.
- **4.1.3 Status Messages** — `role="status" aria-live="polite"` on catalog count, glossary count, lesson loader, quiz score, and quiz explanations.

**Polish**
- `<aside>` regions on the lesson page get `aria-label`s.
- `<div class="toc-title">` on the home page promoted to `<h2>` for proper heading order.
- Theme-toggle inner letter is `aria-hidden` so AT no longer reads "Toggle theme, N".
- Decorative spinner / status dots / stat bars marked `aria-hidden`.
- `<main>` on the lesson page gets `tabindex="-1"` so the skip-link target reliably receives focus.
- Stripped leftover "bar" text from progress-bar spans.

## Files

```
site/app.js        keyboard support, focus trap/restore, empty-<a> fix
site/catalog.html  form labels, button-wrapped sort headers, aria-sort, live count
site/glossary.html form label, aria-label on GitHub link, live count
site/index.html    dialog semantics, h2 toc-title, aria-labels, aria-hidden cleanup
site/lesson.html   sidebar aria-label/expanded, quiz <div>→<button>, live regions
site/prereqs.html  aria-label, type="button" on theme toggle
site/style.css     sr-only, global :focus-visible, --rule-strong, --ink-mute bump
```

## Verified

- Tabbed through every page — visible focus ring on all interactive elements.
- Phase card → Enter opens modal with focus on close button; Tab/Shift+Tab stay trapped; Esc closes and restores focus to the originating card.
- Catalog sort headers respond to Enter/Space and announce direction via `aria-sort`.
- Lesson quiz options accept keyboard input; explanations and score announce via live regions.
- Mobile sidebar toggle reflects expanded/collapsed state.
- Both light and dark themes render cleanly with the stronger borders.