### PR TITLE
fix: pipe symbol markdown table rendering on terminal docs

### DIFF
--- a/phases/00-setup-and-tooling/10-terminal-and-shell/docs/en.md
+++ b/phases/00-setup-and-tooling/10-terminal-and-shell/docs/en.md
@@ -1,4 +1,4 @@
-# Terminal & Shell
+﻿# Terminal & Shell
 
 > The terminal is where AI engineers live. Get comfortable here.
 
@@ -101,7 +101,7 @@ The three redirects you need:
 | `>>` | Append stdout to file |
 | `2>` | Write stderr to file |
 | `2>&1` | Send stderr to same place as stdout |
-| `\|` | Send stdout of one command as stdin to the next |
+| <code>&#124;</code> | Send stdout of one command as stdin to the next |
 
 ### Step 3: Background processes
 


### PR DESCRIPTION
Line 104 uses `\|` which breaks table rendering — pipe character conflicts with table cell delimiter. Replace with `<code>&#124;</code>` for correct rendering.