### PR TITLE
docs(readme): add Translations section listing the Turkish adaptation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1040,6 +1040,18 @@ relative links inside lesson docs.
 ░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒
 ```
 
+## Translations
+
+Community-maintained adaptations of this curriculum:
+
+- 🇹🇷 **Turkish** — [komunite/ai-engineering](https://github.com/komunite/ai-engineering) · maintained by [Komünite](https://komunite.com.tr) · site: <https://ai-muhendisligi.komunite.com.tr>
+
+Maintain a translation in another language? Open a PR adding it here, following the [FORKING.md](FORKING.md) guidance under "For Other Languages".
+
+```
+░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒
+```
+
 ## Sponsor the work
 
 Free, MIT-licensed, 435 lessons. The curriculum is maintained on sponsorship alone. Cash only.


### PR DESCRIPTION
## Summary

Per [`FORKING.md`](FORKING.md) → **For Other Languages** (step 4 — "Submit a PR to link your fork from the main README"), this PR adds a `## Translations` section between Contributing and Sponsor the work and lists the first community translation:

- 🇹🇷 **Turkish** — [komunite/ai-engineering](https://github.com/komunite/ai-engineering)
  - Maintained by [Komünite](https://komunite.com.tr)
  - Live site: <https://ai-muhendisligi.komunite.com.tr>

The Turkish adaptation:
- Tracks this upstream as canonical (every English file is preserved, Turkish lives side-by-side as `.tr.md` / `.tr.json` siblings + Turkish-canonical site/build)
- Ships translated content for **all 20 phases, 435 lessons, 240 quizzes, 83 glossary terms, 489 artifacts**
- Released under MIT with full attribution to you and the contributors
- Deployed at [`ai-muhendisligi.komunite.com.tr`](https://ai-muhendisligi.komunite.com.tr) with proper SEO (per-lesson OG, JSON-LD `Course` / `LearningResource` / `BreadcrumbList`, `llms.txt`, sitemap, etc.)

The new section also includes a one-line invitation for future translation maintainers to PR themselves in, so this stays self-extending.

## Test plan

- [x] Insertion preserves the existing ASCII rule rhythm (closing rule of Contributing → new section → closing rule → next section)
- [x] Section header level (`##`) matches the surrounding heading depth
- [x] Markdown renders correctly on GitHub
- [x] No other file touched (12-line README diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)