### PR TITLE
fix(installer): guard artifact target paths

### DIFF
--- a/scripts/install_skills.py
+++ b/scripts/install_skills.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import shutil
 import sys
 from dataclasses import dataclass, field
@@ -42,6 +43,7 @@ PHASES_DIR = ROOT / "phases"
 
 VALID_TYPES = ("skill", "prompt", "agent")
 LAYOUTS = ("flat", "by-phase", "skills")
+SAFE_ARTIFACT_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 
 
 @dataclass
@@ -155,14 +157,39 @@ def filter_artifacts(
 
 
 def target_path(artifact: Artifact, target_root: Path, layout: str) -> Path:
+    name = safe_artifact_name(artifact.name, artifact.source)
     if layout == "flat":
-        return target_root / f"{artifact.name}.md"
-    if layout == "by-phase":
+        dest = target_root / f"{name}.md"
+    elif layout == "by-phase":
         phase_dir = f"phase-{artifact.phase:02d}" if artifact.phase is not None else "phase-unknown"
-        return target_root / phase_dir / f"{artifact.name}.md"
-    if layout == "skills":
-        return target_root / artifact.name / "SKILL.md"
-    raise ValueError(f"unknown layout: {layout}")
+        dest = target_root / phase_dir / f"{name}.md"
+    elif layout == "skills":
+        dest = target_root / name / "SKILL.md"
+    else:
+        raise ValueError(f"unknown layout: {layout}")
+    return ensure_target_path(dest, target_root, artifact.source)
+
+
+def safe_artifact_name(name: str, source: Path) -> str:
+    if SAFE_ARTIFACT_NAME_RE.fullmatch(name):
+        return name
+    try:
+        rel = source.relative_to(ROOT).as_posix()
+    except ValueError:
+        rel = source.as_posix()
+    raise ValueError(f"unsafe artifact name {name!r} in {rel}")
+
+
+def ensure_target_path(dest: Path, target_root: Path, source: Path) -> Path:
+    root = target_root.resolve(strict=False)
+    resolved = dest.resolve(strict=False)
+    if resolved.is_relative_to(root):
+        return dest
+    try:
+        rel = source.relative_to(ROOT).as_posix()
+    except ValueError:
+        rel = source.as_posix()
+    raise ValueError(f"artifact target escapes target_dir for {rel}: {dest}")
 
 
 @dataclass
@@ -248,7 +275,11 @@ def main(argv: list[str]) -> int:
         sys.stderr.write("no artifacts matched the given filters\n")
         return 1
 
-    plan = build_plan(selected, args.target_dir, args.layout, args.force)
+    try:
+        plan = build_plan(selected, args.target_dir, args.layout, args.force)
+    except ValueError as exc:
+        sys.stderr.write(f"error: {exc}\n")
+        return 1
     if plan.collisions and not args.force:
         sys.stderr.write(
             f"error: {len(plan.collisions)} target file(s) already exist. "


### PR DESCRIPTION
## What this PR does

- Validates artifact frontmatter `name` values before using them in installer destination paths.
- Keeps generated install targets under the requested target directory for all layouts.
- Reports a concise CLI error if an artifact name is unsafe.

## Kind of change

- [ ] New lesson
- [ ] Fix to an existing lesson
- [ ] Translation
- [ ] New output (prompt, skill, agent, MCP server)
- [x] Docs / website / tooling

## Checklist

- [x] Code runs without errors with the listed dependencies
- [x] No comments in code files
- [ ] Built from scratch first, then shown with a framework
- [ ] Lesson folder matches `LESSON_TEMPLATE.md` structure
- [ ] ROADMAP.md row for the lesson is a markdown link (`[Name](phases/...)`), not bare text
- [x] Tested locally / code output matches what `docs/en.md` claims

## Phase / lesson

Installer tooling: `scripts/install_skills.py`.

## Notes for reviewer

`install_skills.py` uses artifact metadata to derive output paths. This keeps valid slug-style artifact names working as before, while rejecting names with path separators, `..`-style traversal, drive-like values, or hidden/empty names before files are copied.

Duplicate check: searched open and recent PRs/issues for `install_skills`, target paths, path traversal, and artifact-name sanitization; no overlapping fix found.

## Validation

- Ran: `python -m py_compile scripts/install_skills.py`
- Ran: `python scripts/install_skills.py _tmp-install-preview --type all --layout flat --dry-run`
- Ran: targeted Python harness confirming safe names still map normally and unsafe names like `../escape`, `sub/name`, `.hidden`, `C:drive`, and empty names are rejected
- Ran: `python scripts/audit_lessons.py`
- Ran: `python scripts/check_readme_counts.py`
- Ran: `git diff --check`