### PR TITLE
feat(site): masthead star + follow buttons with live count

### DIFF
--- a/site/header.js
+++ b/site/header.js
@@ -14,7 +14,9 @@
   }
 
   function paint(n) {
-    var els = document.querySelectorAll('.header-github .star-count, #starCount');
+    var els = document.querySelectorAll(
+      '.header-github .star-count, #starCount, [data-gh-stars="' + REPO + '"]'
+    );
     for (var i = 0; i < els.length; i++) {
       els[i].textContent = format(n);
       els[i].removeAttribute('data-loading');

--- a/site/index.html
+++ b/site/index.html
@@ -665,7 +665,7 @@
         <a class="masthead-btn masthead-btn--primary" href="https://github.com/rohitg00/ai-engineering-from-scratch" target="_blank" rel="noopener" aria-label="Star ai-engineering-from-scratch on GitHub">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .587l3.668 7.568 8.332 1.151-6.064 5.828 1.48 8.279L12 19.896l-7.416 3.517 1.48-8.279L0 9.306l8.332-1.151z"/></svg>
           <span>Star on GitHub</span>
-          <span class="masthead-btn-count" data-gh-stars="rohitg00/ai-engineering-from-scratch">…</span>
+          <span class="masthead-btn-count" data-gh-stars="rohitg00/ai-engineering-from-scratch" data-loading="true">…</span>
         </a>
         <a class="masthead-btn" href="https://github.com/rohitg00" target="_blank" rel="noopener" aria-label="Follow Rohit Ghumare on GitHub">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.4 3-.405 1.02.005 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
@@ -775,34 +775,6 @@
   <script src="header.js?v=20260508a" defer></script>
   <script src="cmdpalette.js?v=20260508a" defer></script>
   <script src="app.js?v=20260508a"></script>
-  <script>
-    (function () {
-      var el = document.querySelector('[data-gh-stars]');
-      if (!el) return;
-      var repo = el.getAttribute('data-gh-stars');
-      var key = 'aifs:stars:' + repo;
-      function fmt(n) {
-        if (typeof n !== 'number') return '';
-        if (n >= 1000) return (n / 1000).toFixed(1).replace(/\.0$/, '') + 'K';
-        return String(n);
-      }
-      try {
-        var cached = JSON.parse(localStorage.getItem(key));
-        if (cached && Date.now() - cached.ts < 6 * 3600 * 1000) {
-          el.textContent = fmt(cached.count);
-          return;
-        }
-      } catch (e) {}
-      fetch('https://api.github.com/repos/' + repo)
-        .then(function (r) { if (!r.ok) throw 0; return r.json(); })
-        .then(function (d) {
-          var c = d.stargazers_count;
-          try { localStorage.setItem(key, JSON.stringify({ count: c, ts: Date.now() })); } catch (e) {}
-          el.textContent = fmt(c);
-        })
-        .catch(function () { el.textContent = ''; });
-    })();
-  </script>
   <script defer src="https://va.vercel-scripts.com/v1/script.js"></script>
 </body>
 </html>

--- a/site/index.html
+++ b/site/index.html
@@ -69,6 +69,57 @@
       font-style: italic;
     }
 
+    .masthead-cta {
+      display: flex;
+      gap: 12px;
+      flex-wrap: wrap;
+      margin-top: 20px;
+    }
+
+    .masthead-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 9px 14px;
+      border: 1px solid var(--ink);
+      background: var(--bg);
+      color: var(--ink);
+      text-decoration: none;
+      font-family: var(--font-mono);
+      font-size: 0.82rem;
+      letter-spacing: 0.02em;
+      transition: background 0.15s, color 0.15s, border-color 0.15s;
+    }
+
+    .masthead-btn:hover,
+    .masthead-btn:focus-visible {
+      background: var(--ink);
+      color: var(--bg);
+    }
+
+    .masthead-btn--primary {
+      border-color: var(--blueprint);
+      color: var(--blueprint);
+    }
+
+    .masthead-btn--primary:hover,
+    .masthead-btn--primary:focus-visible {
+      background: var(--blueprint);
+      color: var(--bg);
+    }
+
+    .masthead-btn-count {
+      padding-left: 8px;
+      margin-left: 4px;
+      border-left: 1px solid currentColor;
+      opacity: 0.85;
+      font-variant-numeric: tabular-nums;
+    }
+
+    @media (max-width: 480px) {
+      .masthead-btn { font-size: 0.78rem; padding: 8px 12px; }
+    }
+
 
     .preface {
       padding: 48px 0 32px;
@@ -610,6 +661,17 @@
       <h1 class="manual-title">AI Engineering<br>from Scratch</h1>
       <p class="manual-tagline reveal">435 lessons. 20 phases. Every algorithm built from raw math before a single framework gets imported.</p>
       <p class="manual-attribution reveal" style="--stagger-delay: 80ms;">Maintained by Rohit Ghumare and contributors. Run on your own machine.</p>
+      <div class="masthead-cta reveal" style="--stagger-delay: 140ms;">
+        <a class="masthead-btn masthead-btn--primary" href="https://github.com/rohitg00/ai-engineering-from-scratch" target="_blank" rel="noopener" aria-label="Star ai-engineering-from-scratch on GitHub">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .587l3.668 7.568 8.332 1.151-6.064 5.828 1.48 8.279L12 19.896l-7.416 3.517 1.48-8.279L0 9.306l8.332-1.151z"/></svg>
+          <span>Star on GitHub</span>
+          <span class="masthead-btn-count" data-gh-stars="rohitg00/ai-engineering-from-scratch">…</span>
+        </a>
+        <a class="masthead-btn" href="https://github.com/rohitg00" target="_blank" rel="noopener" aria-label="Follow Rohit Ghumare on GitHub">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.4 3-.405 1.02.005 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+          <span>Follow @rohitg00</span>
+        </a>
+      </div>
       <div class="ascii-rule" style="margin-top:48px;"></div>
     </section>
 
@@ -713,6 +775,34 @@
   <script src="header.js?v=20260508a" defer></script>
   <script src="cmdpalette.js?v=20260508a" defer></script>
   <script src="app.js?v=20260508a"></script>
+  <script>
+    (function () {
+      var el = document.querySelector('[data-gh-stars]');
+      if (!el) return;
+      var repo = el.getAttribute('data-gh-stars');
+      var key = 'aifs:stars:' + repo;
+      function fmt(n) {
+        if (typeof n !== 'number') return '';
+        if (n >= 1000) return (n / 1000).toFixed(1).replace(/\.0$/, '') + 'K';
+        return String(n);
+      }
+      try {
+        var cached = JSON.parse(localStorage.getItem(key));
+        if (cached && Date.now() - cached.ts < 6 * 3600 * 1000) {
+          el.textContent = fmt(cached.count);
+          return;
+        }
+      } catch (e) {}
+      fetch('https://api.github.com/repos/' + repo)
+        .then(function (r) { if (!r.ok) throw 0; return r.json(); })
+        .then(function (d) {
+          var c = d.stargazers_count;
+          try { localStorage.setItem(key, JSON.stringify({ count: c, ts: Date.now() })); } catch (e) {}
+          el.textContent = fmt(c);
+        })
+        .catch(function () { el.textContent = ''; });
+    })();
+  </script>
   <script defer src="https://va.vercel-scripts.com/v1/script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Adds two CTAs to the homepage masthead beneath the attribution line: 'Star on GitHub' (blueprint primary, fetches live star count, 6-hour localStorage cache) and 'Follow @rohitg00' (neutral). Both open the corresponding GitHub page in a new tab.