### PR TITLE
chore(site): bump asset cache version

### DIFF
--- a/site/catalog.html
+++ b/site/catalog.html
@@ -18,7 +18,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=VT323&family=Source+Serif+4:ital,opsz,wght@0,8..60,400..700;1,8..60,400..700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css?v=20260508a">
+  <link rel="stylesheet" href="style.css?v=20260525a">
   <style>
     .catalog-page {
       padding: 100px 0 80px;
@@ -297,10 +297,10 @@
     </div>
   </footer>
 
-  <script src="data.js?v=20260508a"></script>
-  <script src="progress.js?v=20260508a"></script>
-  <script src="header.js?v=20260508a" defer></script>
-  <script src="cmdpalette.js?v=20260508a" defer></script>
+  <script src="data.js?v=20260525a"></script>
+  <script src="progress.js?v=20260525a"></script>
+  <script src="header.js?v=20260525a" defer></script>
+  <script src="cmdpalette.js?v=20260525a" defer></script>
   <script>
     (function () {
       var root = document.documentElement;

--- a/site/glossary.html
+++ b/site/glossary.html
@@ -18,7 +18,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=VT323&family=Source+Serif+4:ital,opsz,wght@0,8..60,400..700;1,8..60,400..700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css?v=20260508a">
+  <link rel="stylesheet" href="style.css?v=20260525a">
   <style>
     .glossary-page {
       padding: 100px 0 80px;
@@ -227,10 +227,10 @@
     </div>
   </footer>
 
-  <script src="data.js?v=20260508a"></script>
-  <script src="progress.js?v=20260508a"></script>
-  <script src="header.js?v=20260508a" defer></script>
-  <script src="cmdpalette.js?v=20260508a" defer></script>
+  <script src="data.js?v=20260525a"></script>
+  <script src="progress.js?v=20260525a"></script>
+  <script src="header.js?v=20260525a" defer></script>
+  <script src="cmdpalette.js?v=20260525a" defer></script>
   <script>
     (function () {
       var root = document.documentElement;

--- a/site/index.html
+++ b/site/index.html
@@ -18,7 +18,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=VT323&family=Source+Serif+4:ital,opsz,wght@0,8..60,400..700;1,8..60,400..700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css?v=20260508a">
+  <link rel="stylesheet" href="style.css?v=20260525a">
   <style>
     .manual-masthead {
       padding: 96px 0 24px;
@@ -770,11 +770,11 @@
     </div>
   </footer>
 
-  <script src="data.js?v=20260508a"></script>
-  <script src="progress.js?v=20260508a"></script>
-  <script src="header.js?v=20260508a" defer></script>
-  <script src="cmdpalette.js?v=20260508a" defer></script>
-  <script src="app.js?v=20260508a"></script>
+  <script src="data.js?v=20260525a"></script>
+  <script src="progress.js?v=20260525a"></script>
+  <script src="header.js?v=20260525a" defer></script>
+  <script src="cmdpalette.js?v=20260525a" defer></script>
+  <script src="app.js?v=20260525a"></script>
   <script defer src="https://va.vercel-scripts.com/v1/script.js"></script>
 </body>
 </html>

--- a/site/lesson.html
+++ b/site/lesson.html
@@ -18,7 +18,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=VT323&family=Source+Serif+4:ital,opsz,wght@0,8..60,400..700;1,8..60,400..700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css?v=20260508a">
+  <link rel="stylesheet" href="style.css?v=20260525a">
   <style>
     .scroll-progress {
       position: fixed;
@@ -1625,10 +1625,10 @@
     <aside class="toc-sidebar" id="tocSidebar" aria-hidden="true"></aside>
   </div>
 
-  <script src="data.js?v=20260508a"></script>
-  <script src="progress.js?v=20260508a"></script>
-  <script src="header.js?v=20260508a" defer></script>
-  <script src="cmdpalette.js?v=20260508a" defer></script>
+  <script src="data.js?v=20260525a"></script>
+  <script src="progress.js?v=20260525a"></script>
+  <script src="header.js?v=20260525a" defer></script>
+  <script src="cmdpalette.js?v=20260525a" defer></script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
     mermaid.initialize({

--- a/site/prereqs.html
+++ b/site/prereqs.html
@@ -18,7 +18,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=VT323&family=Source+Serif+4:ital,opsz,wght@0,8..60,400..700;1,8..60,400..700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css?v=20260508a">
+  <link rel="stylesheet" href="style.css?v=20260525a">
   <style>
     /* ===================================================
        Learning Path — Page Styles
@@ -468,10 +468,10 @@
     </div>
   </footer>
 
-  <script src="data.js?v=20260508a"></script>
-  <script src="progress.js?v=20260508a"></script>
-  <script src="header.js?v=20260508a" defer></script>
-  <script src="cmdpalette.js?v=20260508a" defer></script>
+  <script src="data.js?v=20260525a"></script>
+  <script src="progress.js?v=20260525a"></script>
+  <script src="header.js?v=20260525a" defer></script>
+  <script src="cmdpalette.js?v=20260525a" defer></script>
   <script>
   (function () {
     /* ===================================================


### PR DESCRIPTION
Bumps `?v=20260508a` to `?v=20260525a` across all 5 HTML pages to force browsers to refetch `header.js` (and other static assets) so the new `[data-gh-stars]` selector lands.