### PR TITLE
fix: use uv for Jupyter installation commands

### DIFF
--- a/phases/00-setup-and-tooling/05-jupyter-notebooks/docs/en.md
+++ b/phases/00-setup-and-tooling/05-jupyter-notebooks/docs/en.md
@@ -50,14 +50,14 @@ Three options, one format:
 
 | Interface | Install | Best for |
 |-----------|---------|----------|
-| JupyterLab | `pip install jupyterlab` then `jupyter lab` | Full IDE experience, multiple tabs, file browser, terminal |
-| Jupyter Notebook | `pip install notebook` then `jupyter notebook` | Simple, lightweight, one notebook at a time |
+| JupyterLab | `uv pip install jupyterlab` then `jupyter lab` | Full IDE experience, multiple tabs, file browser, terminal |
+| Jupyter Notebook | `uv pip install notebook` then `jupyter notebook` | Simple, lightweight, one notebook at a time |
 | VS Code | Install "Jupyter" extension | Already in your editor, git integration, debugging |
 
 All three read and write the same `.ipynb` file. Pick whatever you like. JupyterLab is the most common in AI work.
 
 ```bash
-pip install jupyterlab
+uv pip install jupyterlab
 jupyter lab
 ```
 


### PR DESCRIPTION
## Summary
- replace JupyterLab and Jupyter Notebook installation commands with `uv pip install`
- keep the Jupyter notebook setup lesson consistent with the `uv` workflow introduced in Phase 00 Lesson 01

## Testing
- documentation-only change; verified the updated commands in the lesson text