### PR TITLE
fix(data-management): update canonical hugging face dataset paths and configs

### DIFF
--- a/phases/00-setup-and-tooling/09-data-management/code/data_utils.py
+++ b/phases/00-setup-and-tooling/09-data-management/code/data_utils.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import json
 import hashlib

--- a/phases/00-setup-and-tooling/09-data-management/code/data_utils.py
+++ b/phases/00-setup-and-tooling/09-data-management/code/data_utils.py
@@ -159,10 +159,10 @@ if __name__ == "__main__":
     print("=" * 60)
 
     print("\n--- 1. Load and inspect a dataset ---")
-    ds = load_and_inspect("rotten_tomatoes", split="train")
+    ds = load_and_inspect("cornell-movie-review-data/rotten_tomatoes", split="train")
 
     print("\n--- 2. Stream a dataset ---")
-    rows = stream_dataset("rotten_tomatoes", max_rows=3)
+    rows = stream_dataset("cornell-movie-review-data/rotten_tomatoes", max_rows=3)
     for row in rows:
         print(f"  {row['text'][:80]}...")
 

--- a/phases/00-setup-and-tooling/09-data-management/outputs/prompt-data-helper.md
+++ b/phases/00-setup-and-tooling/09-data-management/outputs/prompt-data-helper.md
@@ -35,12 +35,12 @@ Common task-to-dataset mapping:
 |------|----------------|-------|
 | Text classification | Rotten Tomatoes | `cornell-movie-review-data/rotten_tomatoes` |
 | Sentiment analysis | IMDB | `stanfordnlp/imdb` |
-| Natural language inference | MNLI | `glue/mnli` |
+| Natural language inference | MNLI | `nyu-mll/glue` (config:`mnli`) |
 | Question answering | SQuAD | `rajpurkar/squad` |
-| Summarization | CNN/DailyMail | `cnn_dailymail` |
-| Translation | WMT | `wmt/wmt16` |
+| Summarization | CNN/DailyMail | `abisee/cnn_dailymail`(config: `3.0.0`) |
+| Translation | WMT | `wmt/wmt16`(config: `cs-en`) |
 | Language modeling | WikiText | `Salesforce/wikitext` |
-| Token classification | CoNLL-2003 | `conll2003` |
+| Token classification | CoNLL-2003 | `lhoestq/conll2003` |
 | Image classification | MNIST / CIFAR-10 | `ylecun/mnist` / `uoft-cs/cifar10` |
 | Object detection | COCO | `detection-datasets/coco` |
 

--- a/phases/00-setup-and-tooling/09-data-management/outputs/prompt-data-helper.md
+++ b/phases/00-setup-and-tooling/09-data-management/outputs/prompt-data-helper.md
@@ -33,15 +33,15 @@ Common task-to-dataset mapping:
 
 | Task | Starter Dataset | HF ID |
 |------|----------------|-------|
-| Text classification | Rotten Tomatoes | `rotten_tomatoes` |
-| Sentiment analysis | IMDB | `imdb` |
+| Text classification | Rotten Tomatoes | `cornell-movie-review-data/rotten_tomatoes` |
+| Sentiment analysis | IMDB | `stanfordnlp/imdb` |
 | Natural language inference | MNLI | `glue/mnli` |
-| Question answering | SQuAD | `squad` |
+| Question answering | SQuAD | `rajpurkar/squad` |
 | Summarization | CNN/DailyMail | `cnn_dailymail` |
-| Translation | WMT | `wmt16` |
-| Language modeling | WikiText | `wikitext` |
+| Translation | WMT | `wmt/wmt16` |
+| Language modeling | WikiText | `Salesforce/wikitext` |
 | Token classification | CoNLL-2003 | `conll2003` |
-| Image classification | MNIST / CIFAR-10 | `mnist` / `cifar10` |
+| Image classification | MNIST / CIFAR-10 | `ylecun/mnist` / `uoft-cs/cifar10` |
 | Object detection | COCO | `detection-datasets/coco` |
 
 When recommending, prefer smaller datasets for learning and prototyping. Suggest larger datasets only when the user is ready to train at scale.


### PR DESCRIPTION
## What this PR does
Fixes #179 incorrect HuggingFace dataset path and removes unused import in data_utils.py
Additionally, expands into a full audit of `prompt-data-helper.md` to update all dataset identifiers to their canonical Hugging Face source names and structures (including required configurations for datasets like GLUE and WMT16) to ensure learners can copy-paste working code.

## Kind of change
- [ ] New lesson
- [x] Fix to an existing lesson
- [ ] Translation
- [ ] New output (prompt, skill, agent, MCP server)
- [ ] Docs / website / tooling

## Checklist
- [x] Code runs without errors with the listed dependencies
- [x] No comments in code files (docs explain, code is self-explanatory)
- [ ] Built from scratch first, then shown with a framework (for new lessons)
- [ ] Lesson folder matches `LESSON_TEMPLATE.md` structure
- [ ] ROADMAP.md row for the lesson is a markdown link (`[Name](phases/...)`), not bare text
- [x] One lesson per commit (atomic per-lesson rule)
- [x] Tested locally / code output matches what `docs/en.md` claims

## Phase / lesson
Phase 0 · 09-data-management

## Notes for reviewer
Two small fixes:
1. Dataset path was "rotten_tomatoes" but should be "cornell-movie-review-data/rotten_tomatoes" (correct HF namespace)
2. Removed unused `import os` at the top

Both changes verified to work correctly. Attached screenshot showing dataset loading successfully.
<img width="1592" height="912" alt="image" src="https://github.com/user-attachments/assets/0d3178c6-9464-4966-93d6-6fbaa55ee408" />
