### PR TITLE
feat(typescript): add code/main.ts to 6 lessons promising TypeScript

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -6,7 +6,7 @@
     "skills": 378,
     "prompts": 99,
     "agents": 0,
-    "code_files": 435
+    "code_files": 441
   },
   "phases": [
     {
@@ -25,7 +25,8 @@
           "has_quiz": true,
           "has_notebook": false,
           "code_files": [
-            "verify.py"
+            "verify.py",
+            "verify.ts"
           ],
           "outputs": [
             {
@@ -74,7 +75,8 @@
           "has_quiz": true,
           "has_notebook": false,
           "code_files": [
-            "first_api_call.py"
+            "first_api_call.py",
+            "first_api_call.ts"
           ],
           "outputs": [
             {
@@ -5946,7 +5948,8 @@
           "has_quiz": true,
           "has_notebook": false,
           "code_files": [
-            "main.py"
+            "main.py",
+            "main.ts"
           ],
           "outputs": [
             {
@@ -6022,7 +6025,8 @@
           "has_quiz": true,
           "has_notebook": false,
           "code_files": [
-            "main.py"
+            "main.py",
+            "main.ts"
           ],
           "outputs": [
             {
@@ -6060,7 +6064,8 @@
           "has_quiz": true,
           "has_notebook": false,
           "code_files": [
-            "main.py"
+            "main.py",
+            "main.ts"
           ],
           "outputs": [
             {
@@ -8396,7 +8401,8 @@
           "has_quiz": true,
           "has_notebook": true,
           "code_files": [
-            "main.py"
+            "main.py",
+            "main.ts"
           ],
           "outputs": [
             {

--- a/phases/00-setup-and-tooling/01-dev-environment/code/verify.ts
+++ b/phases/00-setup-and-tooling/01-dev-environment/code/verify.ts
@@ -1,0 +1,102 @@
+// Phase 0 · Lesson 01 — Dev Environment verifier (TypeScript port).
+// Probes node version + presence of git, python3, cargo, deno; mirrors verify.py.
+// Refs: https://nodejs.org/api/process.html  https://nodejs.org/api/child_process.html
+
+import { execFileSync } from "node:child_process";
+import process from "node:process";
+
+type ProbeFn = () => { ok: boolean; detail?: string };
+
+type Probe = {
+  name: string;
+  required: boolean;
+  run: ProbeFn;
+};
+
+function whichVersion(cmd: string, args: string[] = ["--version"]): ReturnType<ProbeFn> {
+  // execFile (not exec) avoids a shell, so user PATH lookups can't be re-interpreted.
+  try {
+    const out = execFileSync(cmd, args, {
+      stdio: ["ignore", "pipe", "ignore"],
+      encoding: "utf8",
+      timeout: 4000,
+    });
+    return { ok: true, detail: out.trim().split("\n")[0] };
+  } catch {
+    return { ok: false };
+  }
+}
+
+const PROBES: Probe[] = [
+  {
+    name: "Node.js 20+",
+    required: true,
+    run: () => {
+      const major = Number.parseInt(process.versions.node.split(".")[0]!, 10);
+      return { ok: major >= 20, detail: `v${process.versions.node}` };
+    },
+  },
+  {
+    name: "TypeScript runner (tsx)",
+    required: false,
+    run: () => whichVersion("npx", ["-y", "tsx", "--version"]),
+  },
+  {
+    name: "Git",
+    required: true,
+    run: () => whichVersion("git"),
+  },
+  {
+    name: "Python 3.10+",
+    required: true,
+    run: () => {
+      const probe = whichVersion("python3");
+      if (!probe.ok || !probe.detail) return probe;
+      // Detail looks like "Python 3.11.7"; pull major.minor.
+      const match = probe.detail.match(/(\d+)\.(\d+)/);
+      if (!match) return { ok: false, detail: probe.detail };
+      const [major, minor] = [Number(match[1]), Number(match[2])];
+      const ok = major > 3 || (major === 3 && minor >= 10);
+      return { ok, detail: probe.detail };
+    },
+  },
+  {
+    name: "Rust (cargo)",
+    required: false,
+    run: () => whichVersion("cargo"),
+  },
+  {
+    name: "Deno",
+    required: false,
+    run: () => whichVersion("deno"),
+  },
+];
+
+function run(): number {
+  process.stdout.write("\n=== AI Engineering from Scratch — Environment Check ===\n\n");
+
+  let requiredPassed = 0;
+  let requiredTotal = 0;
+
+  for (const probe of PROBES) {
+    const result = probe.run();
+    const tag = result.ok ? "PASS" : "FAIL";
+    const detail = result.detail ? ` (${result.detail})` : "";
+    const flag = probe.required ? "" : "  [optional]";
+    process.stdout.write(`  [${tag}] ${probe.name}${detail}${flag}\n`);
+    if (probe.required) {
+      requiredTotal += 1;
+      if (result.ok) requiredPassed += 1;
+    }
+  }
+
+  process.stdout.write(`\nResult: ${requiredPassed}/${requiredTotal} required checks passed\n`);
+  if (requiredPassed === requiredTotal) {
+    process.stdout.write("\nYou're ready. Start with Phase 1.\n\n");
+    return 0;
+  }
+  process.stdout.write("\nFix the failed required checks above, then re-run.\n\n");
+  return 1;
+}
+
+process.exit(run());

--- a/phases/00-setup-and-tooling/04-apis-and-keys/code/first_api_call.ts
+++ b/phases/00-setup-and-tooling/04-apis-and-keys/code/first_api_call.ts
@@ -101,7 +101,7 @@ async function main(): Promise<number> {
   );
 
   const request: MessagesRequest = {
-    model: "claude-sonnet-4-20250514",
+    model: "claude-sonnet-4-5",
     max_tokens: 256,
     messages: [{ role: "user", content: "What is a neural network in one sentence?" }],
   };

--- a/phases/00-setup-and-tooling/04-apis-and-keys/code/first_api_call.ts
+++ b/phases/00-setup-and-tooling/04-apis-and-keys/code/first_api_call.ts
@@ -1,0 +1,123 @@
+// Phase 0 · Lesson 04 — APIs and keys (TypeScript port).
+// Reads ANTHROPIC_API_KEY from env, parses a minimal .env file, then makes one
+// /v1/messages call with global fetch. Set MOCK=1 to skip the network entirely.
+// Refs: https://docs.anthropic.com/en/api/messages
+//       https://nodejs.org/api/process.html#processenv
+//       https://nodejs.org/api/globals.html#fetch (Node 18+ ships fetch)
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import process from "node:process";
+
+type MessagesRequest = {
+  model: string;
+  max_tokens: number;
+  messages: { role: "user" | "assistant"; content: string }[];
+};
+
+type MessagesResponse = {
+  content: { type: string; text: string }[];
+  usage: { input_tokens: number; output_tokens: number };
+};
+
+// .env loader. Same shape every framework follows; we skip a dep to stay
+// portable. KEY=VALUE per line, # comments, optional surrounding quotes.
+function loadDotenv(path: string): Record<string, string> {
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch {
+    return {};
+  }
+  const out: Record<string, string> = {};
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq <= 0) continue;
+    const key = trimmed.slice(0, eq).trim();
+    let value = trimmed.slice(eq + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+function mergeEnv(): NodeJS.ProcessEnv {
+  // process.env wins so users can override the file without editing it.
+  const fromFile = loadDotenv(resolve(process.cwd(), ".env"));
+  return { ...fromFile, ...process.env };
+}
+
+// Fixture matches the real /v1/messages response shape, so the surrounding
+// code is identical whether MOCK=1 or not.
+const MOCK_RESPONSE: MessagesResponse = {
+  content: [
+    {
+      type: "text",
+      text: "A neural network is a stack of differentiable functions that learns patterns by adjusting weights against a loss signal.",
+    },
+  ],
+  usage: { input_tokens: 12, output_tokens: 28 },
+};
+
+async function callMessages(apiKey: string, request: MessagesRequest): Promise<MessagesResponse> {
+  if (process.env.MOCK === "1" || apiKey === "mock") {
+    return MOCK_RESPONSE;
+  }
+
+  const resp = await fetch("https://api.anthropic.com/v1/messages", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-api-key": apiKey,
+      "anthropic-version": "2023-06-01",
+    },
+    body: JSON.stringify(request),
+  });
+
+  if (!resp.ok) {
+    const body = await resp.text();
+    throw new Error(`anthropic ${resp.status}: ${body.slice(0, 200)}`);
+  }
+  return (await resp.json()) as MessagesResponse;
+}
+
+async function main(): Promise<number> {
+  const env = mergeEnv();
+  const apiKey = env.ANTHROPIC_API_KEY ?? "mock";
+  const usingMock = process.env.MOCK === "1" || apiKey === "mock";
+
+  process.stdout.write("=== API Calls ===\n\n");
+  process.stdout.write(
+    usingMock
+      ? "Mode: MOCK (no network). Unset MOCK and export ANTHROPIC_API_KEY for a live call.\n\n"
+      : "Mode: LIVE.\n\n",
+  );
+
+  const request: MessagesRequest = {
+    model: "claude-sonnet-4-20250514",
+    max_tokens: 256,
+    messages: [{ role: "user", content: "What is a neural network in one sentence?" }],
+  };
+
+  try {
+    const response = await callMessages(apiKey, request);
+    const text = response.content[0]?.text ?? "";
+    process.stdout.write(`response: ${text}\n`);
+    process.stdout.write(
+      `tokens: ${response.usage.input_tokens} in, ${response.usage.output_tokens} out\n`,
+    );
+    return 0;
+  } catch (err) {
+    process.stderr.write(`request failed: ${(err as Error).message}\n`);
+    return 1;
+  }
+}
+
+main().then((code) => process.exit(code));

--- a/phases/00-setup-and-tooling/04-apis-and-keys/code/first_api_call.ts
+++ b/phases/00-setup-and-tooling/04-apis-and-keys/code/first_api_call.ts
@@ -101,7 +101,7 @@ async function main(): Promise<number> {
   );
 
   const request: MessagesRequest = {
-    model: "claude-sonnet-4-5",
+    model: "claude-sonnet-4-6",
     max_tokens: 256,
     messages: [{ role: "user", content: "What is a neural network in one sentence?" }],
   };

--- a/phases/11-llm-engineering/03-structured-outputs/code/main.ts
+++ b/phases/11-llm-engineering/03-structured-outputs/code/main.ts
@@ -1,0 +1,262 @@
+// Phase 11 · Lesson 03 — Structured outputs (TypeScript port).
+// Zod-shaped schema DSL + validator + mocked LLM extractor with retry.
+// We inline the schema layer instead of pulling in zod so the lesson stays
+// dep-free; the API (`.parse`, `.safeParse`) mirrors what real zod ships.
+// Refs: https://zod.dev/?id=basic-usage
+//       https://docs.anthropic.com/en/docs/build-with-claude/tool-use
+//       https://platform.openai.com/docs/guides/structured-outputs
+
+import process from "node:process";
+
+type ValidationIssue = { path: string; message: string };
+type ParseResult<T> = { ok: true; value: T } | { ok: false; issues: ValidationIssue[] };
+
+// All schemas implement the same contract: take an unknown, return ParseResult.
+interface Schema<T> {
+  parse(input: unknown, path?: string): ParseResult<T>;
+  toJSONSchema(): Record<string, unknown>;
+}
+
+function ok<T>(value: T): ParseResult<T> {
+  return { ok: true, value };
+}
+function fail<T>(issues: ValidationIssue[]): ParseResult<T> {
+  return { ok: false, issues };
+}
+
+class StringSchema implements Schema<string> {
+  constructor(
+    private opts: { enum?: readonly string[]; minLength?: number } = {},
+  ) {}
+  parse(input: unknown, path = ""): ParseResult<string> {
+    if (typeof input !== "string") {
+      return fail([{ path, message: `expected string, got ${typeof input}` }]);
+    }
+    if (this.opts.minLength !== undefined && input.length < this.opts.minLength) {
+      return fail([{ path, message: `string shorter than ${this.opts.minLength}` }]);
+    }
+    if (this.opts.enum && !this.opts.enum.includes(input)) {
+      return fail([
+        { path, message: `${JSON.stringify(input)} not in [${this.opts.enum.join(", ")}]` },
+      ]);
+    }
+    return ok(input);
+  }
+  toJSONSchema() {
+    const out: Record<string, unknown> = { type: "string" };
+    if (this.opts.enum) out.enum = [...this.opts.enum];
+    if (this.opts.minLength !== undefined) out.minLength = this.opts.minLength;
+    return out;
+  }
+}
+
+class NumberSchema implements Schema<number> {
+  constructor(private opts: { minimum?: number; maximum?: number; integer?: boolean } = {}) {}
+  parse(input: unknown, path = ""): ParseResult<number> {
+    if (typeof input !== "number" || Number.isNaN(input)) {
+      return fail([{ path, message: `expected number, got ${typeof input}` }]);
+    }
+    if (this.opts.integer && !Number.isInteger(input)) {
+      return fail([{ path, message: `expected integer, got ${input}` }]);
+    }
+    if (this.opts.minimum !== undefined && input < this.opts.minimum) {
+      return fail([{ path, message: `${input} below minimum ${this.opts.minimum}` }]);
+    }
+    if (this.opts.maximum !== undefined && input > this.opts.maximum) {
+      return fail([{ path, message: `${input} above maximum ${this.opts.maximum}` }]);
+    }
+    return ok(input);
+  }
+  toJSONSchema() {
+    const out: Record<string, unknown> = { type: this.opts.integer ? "integer" : "number" };
+    if (this.opts.minimum !== undefined) out.minimum = this.opts.minimum;
+    if (this.opts.maximum !== undefined) out.maximum = this.opts.maximum;
+    return out;
+  }
+}
+
+class BoolSchema implements Schema<boolean> {
+  parse(input: unknown, path = ""): ParseResult<boolean> {
+    if (typeof input !== "boolean") {
+      return fail([{ path, message: `expected boolean, got ${typeof input}` }]);
+    }
+    return ok(input);
+  }
+  toJSONSchema() {
+    return { type: "boolean" };
+  }
+}
+
+class ArraySchema<T> implements Schema<T[]> {
+  constructor(
+    private item: Schema<T>,
+    private opts: { minItems?: number; maxItems?: number } = {},
+  ) {}
+  parse(input: unknown, path = ""): ParseResult<T[]> {
+    if (!Array.isArray(input)) {
+      return fail([{ path, message: `expected array, got ${typeof input}` }]);
+    }
+    if (this.opts.minItems !== undefined && input.length < this.opts.minItems) {
+      return fail([{ path, message: `array length ${input.length} < ${this.opts.minItems}` }]);
+    }
+    const issues: ValidationIssue[] = [];
+    const out: T[] = [];
+    for (let i = 0; i < input.length; i += 1) {
+      const child = this.item.parse(input[i], `${path}[${i}]`);
+      if (!child.ok) issues.push(...child.issues);
+      else out.push(child.value);
+    }
+    return issues.length ? fail(issues) : ok(out);
+  }
+  toJSONSchema() {
+    const out: Record<string, unknown> = { type: "array", items: this.item.toJSONSchema() };
+    if (this.opts.minItems !== undefined) out.minItems = this.opts.minItems;
+    return out;
+  }
+}
+
+type ObjectShape = Record<string, { schema: Schema<unknown>; required: boolean }>;
+
+class ObjectSchema<S extends ObjectShape> implements Schema<{ [K in keyof S]: unknown }> {
+  constructor(private shape: S) {}
+  parse(input: unknown, path = ""): ParseResult<{ [K in keyof S]: unknown }> {
+    if (input === null || typeof input !== "object" || Array.isArray(input)) {
+      return fail([{ path, message: `expected object, got ${typeof input}` }]);
+    }
+    const issues: ValidationIssue[] = [];
+    const out: Record<string, unknown> = {};
+    const record = input as Record<string, unknown>;
+    for (const [key, field] of Object.entries(this.shape)) {
+      const childPath = path ? `${path}.${key}` : key;
+      if (!(key in record)) {
+        if (field.required) issues.push({ path: childPath, message: "required field missing" });
+        continue;
+      }
+      const child = field.schema.parse(record[key], childPath);
+      if (!child.ok) issues.push(...child.issues);
+      else out[key] = child.value;
+    }
+    return issues.length ? fail(issues) : ok(out as { [K in keyof S]: unknown });
+  }
+  toJSONSchema() {
+    const properties: Record<string, unknown> = {};
+    const required: string[] = [];
+    for (const [key, field] of Object.entries(this.shape)) {
+      properties[key] = field.schema.toJSONSchema();
+      if (field.required) required.push(key);
+    }
+    return { type: "object", properties, required };
+  }
+}
+
+const z = {
+  string: (opts?: ConstructorParameters<typeof StringSchema>[0]) => new StringSchema(opts),
+  number: (opts?: ConstructorParameters<typeof NumberSchema>[0]) => new NumberSchema(opts),
+  integer: () => new NumberSchema({ integer: true }),
+  boolean: () => new BoolSchema(),
+  array: <T>(item: Schema<T>, opts?: ConstructorParameters<typeof ArraySchema>[1]) =>
+    new ArraySchema(item, opts),
+  object: <S extends ObjectShape>(shape: S) => new ObjectSchema(shape),
+  field: <T>(schema: Schema<T>, required = true) => ({ schema: schema as Schema<unknown>, required }),
+};
+
+const ProductSchema = z.object({
+  product: z.field(z.string({ minLength: 1 })),
+  price: z.field(z.number({ minimum: 0 })),
+  in_stock: z.field(z.boolean()),
+  categories: z.field(z.array(z.string()), false),
+});
+
+// Mock LLM. First attempt for "headphones" is bad on purpose so the retry
+// loop has something to do.
+function simulateLLM(text: string, attempt: number): string {
+  const t = text.toLowerCase();
+  if (t.includes("headphones") || t.includes("sony")) {
+    if (attempt === 0) {
+      return 'Here is the JSON:\n```\n{"product": "Sony WH-1000XM5", "price": "348.00", "in_stock": true}\n```';
+    }
+    return '{"product": "Sony WH-1000XM5", "price": 348, "in_stock": true, "categories": ["audio", "headphones"]}';
+  }
+  if (t.includes("macbook") || t.includes("laptop")) {
+    return '{"product": "MacBook Pro 16", "price": 2499, "in_stock": false, "categories": ["computers"]}';
+  }
+  if (t.includes("keyboard")) {
+    return '{"product": "Keychron Q1", "price": 169, "in_stock": true, "categories": ["peripherals"]}';
+  }
+  return '{"product": "Unknown", "price": 0, "in_stock": false}';
+}
+
+// Strip the markdown fence + preamble that real models love to add.
+function extractJSONBlock(raw: string): string {
+  const fence = raw.match(/```(?:json)?\s*([\s\S]*?)```/);
+  if (fence) return fence[1]!.trim();
+  const first = raw.indexOf("{");
+  const last = raw.lastIndexOf("}");
+  if (first >= 0 && last > first) return raw.slice(first, last + 1);
+  return raw.trim();
+}
+
+type Product = { product: string; price: number; in_stock: boolean; categories?: string[] };
+
+function extractWithRetry(text: string, maxRetries = 3): Product | null {
+  for (let attempt = 0; attempt < maxRetries; attempt += 1) {
+    const raw = simulateLLM(text, attempt);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(extractJSONBlock(raw));
+    } catch (err) {
+      process.stdout.write(`    attempt ${attempt + 1}: json parse error — ${(err as Error).message}\n`);
+      continue;
+    }
+    const result = ProductSchema.parse(parsed);
+    if (result.ok) return result.value as Product;
+    process.stdout.write(
+      `    attempt ${attempt + 1}: schema errors — ${result.issues.map((i) => i.message).join("; ")}\n`,
+    );
+  }
+  return null;
+}
+
+function runSchemaDemo(): void {
+  process.stdout.write("=".repeat(60) + "\n  STEP 1: schema validation\n" + "=".repeat(60) + "\n");
+  const cases: { data: unknown; label: string }[] = [
+    { data: { product: "Sony WH-1000XM5", price: 348, in_stock: true }, label: "valid minimal" },
+    { data: { product: "Test", price: -5, in_stock: true }, label: "negative price" },
+    { data: { product: "Test", in_stock: true }, label: "missing price" },
+    { data: { product: 123, price: 10, in_stock: true }, label: "number as product" },
+    { data: { product: "Test", price: 10, in_stock: "yes" }, label: "string as boolean" },
+  ];
+  for (const c of cases) {
+    const result = ProductSchema.parse(c.data);
+    const status = result.ok ? "PASS" : `FAIL: ${result.issues.map((i) => i.message).join("; ")}`;
+    process.stdout.write(`  ${c.label}: ${status}\n`);
+  }
+}
+
+function runJSONSchemaDemo(): void {
+  process.stdout.write("\n" + "=".repeat(60) + "\n  STEP 2: schema → JSON Schema (for provider APIs)\n" + "=".repeat(60) + "\n");
+  process.stdout.write(JSON.stringify(ProductSchema.toJSONSchema(), null, 2) + "\n");
+}
+
+function runExtractionDemo(): void {
+  process.stdout.write("\n" + "=".repeat(60) + "\n  STEP 3: extraction with retry\n" + "=".repeat(60) + "\n");
+  const inputs = [
+    "The Sony WH-1000XM5 headphones are priced at $348 and currently in stock.",
+    "The new MacBook Pro 16 laptop costs $2499 but is sold out.",
+    "I just bought a Keychron Q1 keyboard for $169.",
+    "This sentence has no product information at all.",
+  ];
+  for (const text of inputs) {
+    process.stdout.write(`\n  input: ${text.slice(0, 70)}...\n`);
+    const result = extractWithRetry(text);
+    process.stdout.write(`  output: ${result ? JSON.stringify(result) : "FAILED after retries"}\n`);
+  }
+}
+
+function main(): void {
+  runSchemaDemo();
+  runJSONSchemaDemo();
+  runExtractionDemo();
+}
+
+main();

--- a/phases/11-llm-engineering/03-structured-outputs/code/main.ts
+++ b/phases/11-llm-engineering/03-structured-outputs/code/main.ts
@@ -99,6 +99,9 @@ class ArraySchema<T> implements Schema<T[]> {
     if (this.opts.minItems !== undefined && input.length < this.opts.minItems) {
       return fail([{ path, message: `array length ${input.length} < ${this.opts.minItems}` }]);
     }
+    if (this.opts.maxItems !== undefined && input.length > this.opts.maxItems) {
+      return fail([{ path, message: `array length ${input.length} > ${this.opts.maxItems}` }]);
+    }
     const issues: ValidationIssue[] = [];
     const out: T[] = [];
     for (let i = 0; i < input.length; i += 1) {
@@ -111,6 +114,7 @@ class ArraySchema<T> implements Schema<T[]> {
   toJSONSchema() {
     const out: Record<string, unknown> = { type: "array", items: this.item.toJSONSchema() };
     if (this.opts.minItems !== undefined) out.minItems = this.opts.minItems;
+    if (this.opts.maxItems !== undefined) out.maxItems = this.opts.maxItems;
     return out;
   }
 }

--- a/phases/11-llm-engineering/05-context-engineering/code/main.ts
+++ b/phases/11-llm-engineering/05-context-engineering/code/main.ts
@@ -1,0 +1,249 @@
+// Phase 11 · Lesson 05 — Context engineering (TypeScript port).
+// Token budget, sliding-window history compressor, lost-in-the-middle reorder.
+// Token counts use the 1 word ≈ 1.3 tokens heuristic — close enough for budgeting
+// without dragging in tiktoken. Real assemblers swap in a tokenizer at the seam.
+// Refs: https://arxiv.org/abs/2307.03172  (Lost in the Middle — Liu et al.)
+//       https://www.anthropic.com/news/contextual-retrieval
+//       https://platform.openai.com/docs/guides/context-window
+
+import process from "node:process";
+
+const WORD_TO_TOKEN = 1.3;
+
+function countTokens(text: string): number {
+  if (!text) return 0;
+  return Math.floor(text.trim().split(/\s+/).length * WORD_TO_TOKEN);
+}
+
+type AllocationResult = { content: string; tokens: number };
+
+class ContextBudget {
+  readonly maxTokens: number;
+  readonly generationReserve: number;
+  readonly available: number;
+  private readonly allocations = new Map<string, number>();
+
+  constructor(maxTokens = 128_000, generationReserve = 4_000) {
+    this.maxTokens = maxTokens;
+    this.generationReserve = generationReserve;
+    this.available = maxTokens - generationReserve;
+  }
+
+  allocate(component: string, content: string, maxComponentTokens?: number): AllocationResult {
+    let tokens = countTokens(content);
+    let trimmed = content;
+
+    if (maxComponentTokens !== undefined && tokens > maxComponentTokens) {
+      const words = trimmed.split(/\s+/);
+      trimmed = words.slice(0, Math.floor(maxComponentTokens / WORD_TO_TOKEN)).join(" ");
+      tokens = countTokens(trimmed);
+    }
+
+    const used = this.usedTokens();
+    if (used + tokens > this.available) {
+      const allowed = this.available - used;
+      if (allowed <= 0) return { content: "", tokens: 0 };
+      const words = trimmed.split(/\s+/);
+      trimmed = words.slice(0, Math.floor(allowed / WORD_TO_TOKEN)).join(" ");
+      tokens = countTokens(trimmed);
+    }
+
+    this.allocations.set(component, tokens);
+    return { content: trimmed, tokens };
+  }
+
+  usedTokens(): number {
+    let total = 0;
+    for (const v of this.allocations.values()) total += v;
+    return total;
+  }
+
+  remaining(): number {
+    return this.available - this.usedTokens();
+  }
+
+  report(): string {
+    const lines: string[] = [];
+    lines.push(`\n  Context Budget Report (${this.maxTokens.toLocaleString()} token window)`);
+    lines.push("  " + "-".repeat(55));
+    for (const [component, tokens] of this.allocations) {
+      const pct = (tokens / this.maxTokens) * 100;
+      const bar = pct >= 0.5 ? "#".repeat(Math.floor(pct * 2)) : "";
+      lines.push(`    ${component.padEnd(25)} ${String(tokens).padStart(6)} tokens (${pct.toFixed(1).padStart(5)}%) ${bar}`);
+    }
+    lines.push("  " + "-".repeat(55));
+    lines.push(`    ${"Used".padEnd(25)} ${String(this.usedTokens()).padStart(6)} tokens`);
+    lines.push(`    ${"Generation reserve".padEnd(25)} ${String(this.generationReserve).padStart(6)} tokens`);
+    lines.push(`    ${"Remaining".padEnd(25)} ${String(this.remaining()).padStart(6)} tokens`);
+    return lines.join("\n");
+  }
+}
+
+// Liu et al. 2023: attention dips for tokens placed in the middle of long
+// contexts. So we put the highest-relevance docs at the head AND tail and
+// hide the weakest in the middle.
+function reorderLostInMiddle<T>(items: T[], scores: number[]): T[] {
+  const paired = items.map((item, i) => ({ item, score: scores[i] ?? 0 }));
+  paired.sort((a, b) => b.score - a.score);
+  const sorted = paired.map((p) => p.item);
+  if (sorted.length <= 2) return sorted;
+  const head: T[] = [];
+  const tail: T[] = [];
+  for (let i = 0; i < sorted.length; i += 1) {
+    if (i % 2 === 0) head.push(sorted[i]!);
+    else tail.unshift(sorted[i]!);
+  }
+  return [...head, ...tail];
+}
+
+type Turn = { role: "user" | "assistant"; content: string };
+
+class ConversationManager {
+  private turns: Turn[] = [];
+  private summaries: string[] = [];
+  constructor(private readonly maxHistoryTokens = 5_000) {}
+
+  addTurn(role: Turn["role"], content: string): void {
+    this.turns.push({ role, content });
+    this.compress();
+  }
+
+  // Sliding window with cheap summarisation. Real systems summarise with an
+  // LLM; here we keep just the first 100 chars of each compacted turn.
+  private compress(): void {
+    let total = this.totalTurnTokens();
+    while (total > this.maxHistoryTokens && this.turns.length > 4) {
+      const oldTurns = this.turns.slice(0, 2);
+      this.summaries.push(this.summarise(oldTurns));
+      this.turns = this.turns.slice(2);
+      total = this.totalTurnTokens();
+    }
+  }
+
+  private totalTurnTokens(): number {
+    let total = 0;
+    for (const t of this.turns) total += countTokens(t.content);
+    return total;
+  }
+
+  private summarise(turns: Turn[]): string {
+    const parts = turns.map((t) => {
+      const slice = t.content.length > 100 ? `${t.content.slice(0, 100)}...` : t.content;
+      return `${t.role}: ${slice}`;
+    });
+    return `Previous: ${parts.join(" | ")}`;
+  }
+
+  contextText(): string {
+    const parts: string[] = [];
+    if (this.summaries.length) {
+      parts.push("[Conversation Summary]");
+      parts.push(...this.summaries);
+    }
+    if (this.turns.length) {
+      parts.push("[Recent Conversation]");
+      for (const t of this.turns) parts.push(`${t.role}: ${t.content}`);
+    }
+    return parts.join("\n");
+  }
+
+  stats(): { liveTurns: number; summaries: number; tokens: number } {
+    return {
+      liveTurns: this.turns.length,
+      summaries: this.summaries.length,
+      tokens: countTokens(this.contextText()),
+    };
+  }
+}
+
+function scoreRelevance(query: string, docs: string[]): number[] {
+  const queryWords = new Set(query.toLowerCase().split(/\s+/));
+  if (queryWords.size === 0) return docs.map(() => 0);
+  return docs.map((doc) => {
+    const docWords = new Set(doc.toLowerCase().split(/\s+/));
+    let overlap = 0;
+    for (const w of queryWords) if (docWords.has(w)) overlap += 1;
+    return Number((overlap / queryWords.size).toFixed(3));
+  });
+}
+
+function runBudgetDemo(): void {
+  process.stdout.write("=".repeat(60) + "\n  STEP 1: Context Budget Manager\n" + "=".repeat(60) + "\n");
+  const budget = new ContextBudget(128_000, 4_000);
+  budget.allocate("system_prompt", "You are a helpful assistant. ".repeat(20), 500);
+  budget.allocate("tools", JSON.stringify(["read_file", "write_file", "search_code", "run_command"]), 2_000);
+  budget.allocate("retrieved_docs", "The project uses PostgreSQL. ".repeat(50), 3_000);
+  budget.allocate("history", "user: How? assistant: Check logs. ".repeat(20), 5_000);
+  budget.allocate("query", "Fix the auth bug in JWT validation", 500);
+  process.stdout.write(budget.report() + "\n");
+}
+
+function runReorderDemo(): void {
+  process.stdout.write("\n" + "=".repeat(60) + "\n  STEP 2: Lost-in-the-middle reordering\n" + "=".repeat(60) + "\n");
+  const docs = [
+    "Doc A: PostgreSQL connection pooling",
+    "Doc B: Redis caching layer",
+    "Doc C: CSS styling guide",
+    "Doc D: Database migration scripts",
+    "Doc E: CI/CD pipeline config",
+    "Doc F: API authentication flow",
+    "Doc G: Frontend routing",
+  ];
+  const scores = [0.95, 0.6, 0.05, 0.8, 0.3, 0.75, 0.1];
+  const reordered = reorderLostInMiddle(docs, scores);
+  process.stdout.write("\n  reordered (high relevance at start + end, low in middle):\n");
+  for (let i = 0; i < reordered.length; i += 1) {
+    const position = i < 2 ? "START" : i >= reordered.length - 2 ? "END" : "middle";
+    process.stdout.write(`    [${position.padStart(6)}] ${reordered[i]}\n`);
+  }
+}
+
+function runConversationDemo(): void {
+  process.stdout.write("\n" + "=".repeat(60) + "\n  STEP 3: Conversation compression (sliding window)\n" + "=".repeat(60) + "\n");
+  const conv = new ConversationManager(200);
+  const exchanges: [string, string][] = [
+    ["How do I set up the database?", "Run docker-compose up to start PostgreSQL, then run migrations."],
+    ["What about environment variables?", "Copy .env.example to .env and fill in DATABASE_URL and JWT_SECRET."],
+    ["The migrations are failing.", "Check PostgreSQL is on port 5432 and DATABASE_URL matches."],
+    ["How do I seed test data?", "Run npm run seed which loads fixtures from test/fixtures."],
+    ["Can I run the tests?", "Yes, run npm test. Use a separate test database."],
+  ];
+  exchanges.forEach(([user, assistant], idx) => {
+    conv.addTurn("user", user);
+    conv.addTurn("assistant", assistant);
+    const stats = conv.stats();
+    process.stdout.write(
+      `\n  after turn ${idx + 1}: live=${stats.liveTurns} summaries=${stats.summaries} tokens=${stats.tokens}\n`,
+    );
+  });
+  process.stdout.write("\n  final context:\n");
+  for (const line of conv.contextText().split("\n")) process.stdout.write(`    ${line}\n`);
+}
+
+function runRelevanceDemo(): void {
+  process.stdout.write("\n" + "=".repeat(60) + "\n  STEP 4: Relevance scoring\n" + "=".repeat(60) + "\n");
+  const docs = [
+    "Python 3.12 introduced type parameter syntax for generic classes.",
+    "The project uses PostgreSQL 16 with pgvector for embedding storage.",
+    "Authentication is handled by Supabase Auth with JWT tokens.",
+    "The frontend is built with Next.js 15 using the App Router.",
+    "API rate limits are 100 requests per minute per user.",
+  ];
+  const query = "How do I fix the JWT authentication token expiry bug?";
+  const scores = scoreRelevance(query, docs);
+  const ranked = docs.map((d, i) => ({ d, s: scores[i] ?? 0 })).sort((a, b) => b.s - a.s);
+  process.stdout.write(`\n  query: ${query}\n\n`);
+  for (const { d, s } of ranked) {
+    const marker = s >= 0.05 ? "*" : " ";
+    process.stdout.write(`    ${marker} ${s.toFixed(3)}  ${d}\n`);
+  }
+}
+
+function main(): void {
+  runBudgetDemo();
+  runReorderDemo();
+  runConversationDemo();
+  runRelevanceDemo();
+}
+
+main();

--- a/phases/11-llm-engineering/06-rag/code/main.ts
+++ b/phases/11-llm-engineering/06-rag/code/main.ts
@@ -1,0 +1,248 @@
+// Phase 11 · Lesson 06 — Minimal RAG (TypeScript port).
+// TF-IDF vector store + cosine similarity + retrieval + prompt assembly,
+// over a toy corpus. End-to-end pipeline runs on Node stdlib only.
+// Swap the embedder for OpenAI text-embedding-3-small (or any 1536-dim
+// model) and the simple_generate stub for a real /v1/messages call —
+// the rest of the pipeline stays.
+// Refs: https://platform.openai.com/docs/guides/embeddings
+//       https://en.wikipedia.org/wiki/Tf%E2%80%93idf
+//       https://docs.anthropic.com/en/docs/build-with-claude/embeddings
+
+import process from "node:process";
+
+function chunkText(text: string, chunkSize = 200, overlap = 50): string[] {
+  const words = text.split(/\s+/).filter(Boolean);
+  const chunks: string[] = [];
+  let start = 0;
+  const step = Math.max(1, chunkSize - overlap);
+  while (start < words.length) {
+    chunks.push(words.slice(start, start + chunkSize).join(" "));
+    start += step;
+  }
+  return chunks;
+}
+
+function buildVocabulary(documents: string[]): string[] {
+  const vocab = new Set<string>();
+  for (const doc of documents) for (const w of doc.toLowerCase().split(/\s+/)) if (w) vocab.add(w);
+  return [...vocab].sort();
+}
+
+function computeTF(text: string, vocab: string[]): number[] {
+  const words = text.toLowerCase().split(/\s+/).filter(Boolean);
+  const counts = new Map<string, number>();
+  for (const w of words) counts.set(w, (counts.get(w) ?? 0) + 1);
+  const total = words.length;
+  if (total === 0) return new Array<number>(vocab.length).fill(0);
+  return vocab.map((w) => (counts.get(w) ?? 0) / total);
+}
+
+// Smoothed IDF (the `+1`s avoid divide-by-zero and a zero IDF for terms in
+// every document). Matches scikit-learn's default formula.
+function computeIDF(documents: string[], vocab: string[]): number[] {
+  const n = documents.length;
+  const docTokens = documents.map((d) => new Set(d.toLowerCase().split(/\s+/)));
+  return vocab.map((word) => {
+    let dc = 0;
+    for (const tokens of docTokens) if (tokens.has(word)) dc += 1;
+    return Math.log((n + 1) / (dc + 1)) + 1;
+  });
+}
+
+function tfidfEmbed(text: string, vocab: string[], idf: number[]): number[] {
+  const tf = computeTF(text, vocab);
+  return tf.map((t, i) => t * (idf[i] ?? 0));
+}
+
+function cosineSimilarity(a: number[], b: number[]): number {
+  let dot = 0;
+  let na = 0;
+  let nb = 0;
+  const len = Math.min(a.length, b.length);
+  for (let i = 0; i < len; i += 1) {
+    const x = a[i] ?? 0;
+    const y = b[i] ?? 0;
+    dot += x * y;
+    na += x * x;
+    nb += y * y;
+  }
+  if (na === 0 || nb === 0) return 0;
+  return dot / (Math.sqrt(na) * Math.sqrt(nb));
+}
+
+type Retrieved = { chunk: string; source: string; score: number; index: number };
+
+function search(queryEmb: number[], embeddings: number[][], topK = 5): { index: number; score: number }[] {
+  const scored = embeddings.map((emb, i) => ({ index: i, score: cosineSimilarity(queryEmb, emb) }));
+  scored.sort((a, b) => b.score - a.score);
+  return scored.slice(0, topK);
+}
+
+function buildRagPrompt(query: string, chunks: string[]): string {
+  const context = chunks.map((c, i) => `[Source ${i + 1}]\n${c}`).join("\n\n---\n\n");
+  return [
+    "Answer the question based ONLY on the following context.",
+    'If the context does not contain enough information, say "I don\'t have enough information to answer that."',
+    "",
+    `Context:\n${context}`,
+    "",
+    `Question: ${query}`,
+    "",
+    "Answer:",
+  ].join("\n");
+}
+
+// Stand-in for the generation step. Picks the chunk-sentence with most
+// non-stopword overlap with the question. In production this is one
+// /v1/messages call with `prompt` as the user message.
+const STOPWORDS = new Set([
+  "the", "a", "an", "is", "are", "was", "were", "what", "how",
+  "why", "when", "where", "do", "does", "for", "of", "in", "to",
+  "and", "or", "on", "at", "by", "it", "its", "this", "that",
+]);
+
+function simpleGenerate(query: string, chunks: string[]): string {
+  const queryWords = new Set(
+    query
+      .toLowerCase()
+      .split(/\s+/)
+      .filter((w) => w && !STOPWORDS.has(w)),
+  );
+  let best = "";
+  let bestScore = 0;
+  for (const chunk of chunks) {
+    for (const sentence of chunk.split(".")) {
+      const trimmed = sentence.trim();
+      if (trimmed.length < 10) continue;
+      const words = new Set(trimmed.toLowerCase().split(/\s+/));
+      let overlap = 0;
+      for (const w of queryWords) if (words.has(w)) overlap += 1;
+      if (overlap > bestScore) {
+        bestScore = overlap;
+        best = trimmed;
+      }
+    }
+  }
+  return best || "I don't have enough information.";
+}
+
+class RAGPipeline {
+  private chunks: string[] = [];
+  private sources: string[] = [];
+  private embeddings: number[][] = [];
+  vocab: string[] = [];
+  private idf: number[] = [];
+
+  constructor(
+    private readonly chunkSize = 200,
+    private readonly overlap = 50,
+    private readonly topK = 5,
+  ) {}
+
+  index(documents: string[], sourceNames?: string[]): number {
+    const allChunks: string[] = [];
+    const allSources: string[] = [];
+    documents.forEach((doc, i) => {
+      const docChunks = chunkText(doc, this.chunkSize, this.overlap);
+      allChunks.push(...docChunks);
+      const name = sourceNames?.[i] ?? `doc_${i}`;
+      for (let j = 0; j < docChunks.length; j += 1) allSources.push(name);
+    });
+    this.chunks = allChunks;
+    this.sources = allSources;
+    this.vocab = buildVocabulary(allChunks);
+    this.idf = computeIDF(allChunks, this.vocab);
+    this.embeddings = allChunks.map((c) => tfidfEmbed(c, this.vocab, this.idf));
+    return allChunks.length;
+  }
+
+  query(question: string, topK?: number): {
+    question: string;
+    answer: string;
+    prompt: string;
+    retrieved: Retrieved[];
+  } {
+    const k = topK ?? this.topK;
+    const queryEmb = tfidfEmbed(question, this.vocab, this.idf);
+    const results = search(queryEmb, this.embeddings, k);
+    const retrieved: Retrieved[] = results.map(({ index, score }) => ({
+      chunk: this.chunks[index] ?? "",
+      source: this.sources[index] ?? "",
+      score,
+      index,
+    }));
+    const chunkTexts = retrieved.map((r) => r.chunk);
+    const prompt = buildRagPrompt(question, chunkTexts);
+    const answer = simpleGenerate(question, chunkTexts);
+    return { question, answer, prompt, retrieved };
+  }
+}
+
+const SAMPLE_DOCUMENTS = [
+  `Acme Corp Refund Policy. All standard plan customers are eligible for a full refund within 30 days of purchase. Enterprise plan customers receive an extended 60-day refund window with pro-rated refunds. Refunds are processed within 5-7 business days. No refunds are available after the refund window closes. Customers must submit refund requests through the support portal.`,
+  `Acme Corp Product Overview. Acme offers three product tiers: Starter, Professional, and Enterprise. The Starter plan includes basic features for individual users at $29 per month. The Professional plan adds team collaboration and priority support for $99 per month per user. The Enterprise plan includes everything in Professional plus custom integrations, dedicated account management, SSO, audit logs, and a 99.99% uptime SLA. Enterprise pricing starts at $500 per month.`,
+  `Acme Corp Security Practices. Acme maintains SOC 2 Type II compliance and undergoes annual third-party security audits. All data is encrypted at rest using AES-256 and in transit using TLS 1.3. Customer data is stored in isolated tenants within AWS us-east-1 and eu-west-1 regions. Backups are performed every 6 hours with 30-day retention.`,
+  `Acme Corp API Documentation. The Acme API uses REST with JSON request and response bodies. Authentication is via Bearer tokens issued through OAuth 2.0. Rate limits are 100 requests per minute for Starter, 1000 for Professional, and 10000 for Enterprise. Exceeding the rate limit returns HTTP 429 with a Retry-After header. Webhooks are available for real-time event notifications.`,
+  `Acme Corp Uptime and Reliability. Acme guarantees 99.9% uptime for Professional plans and 99.99% uptime for Enterprise plans. If uptime falls below the guaranteed level, customers receive service credits: 10% credit for each 0.1% below the SLA threshold, up to a maximum of 30% of the monthly fee. Status updates are posted at status.acme.com within 5 minutes of any incident.`,
+];
+
+function bar(): string {
+  return "=".repeat(60);
+}
+
+function main(): void {
+  process.stdout.write(`${bar()}\nSTEP 1: chunking\n${bar()}\n`);
+  const sample = SAMPLE_DOCUMENTS[0]!;
+  const chunks = chunkText(sample, 30, 10);
+  process.stdout.write(`  document: ${sample.split(/\s+/).length} words → ${chunks.length} chunks\n`);
+  chunks.forEach((c, i) => {
+    process.stdout.write(`    chunk ${i} (${c.split(/\s+/).length} words): ${c.slice(0, 80)}...\n`);
+  });
+
+  process.stdout.write(`\n${bar()}\nSTEP 2: TF-IDF on a toy corpus\n${bar()}\n`);
+  const miniDocs = [
+    "The cat sat on the mat",
+    "The dog sat on the rug",
+    "Machine learning is a branch of artificial intelligence",
+  ];
+  const vocab = buildVocabulary(miniDocs);
+  const idf = computeIDF(miniDocs, vocab);
+  process.stdout.write(`  vocab size: ${vocab.length}\n`);
+  const ranked = vocab.map((w, i) => ({ w, s: idf[i] ?? 0 })).sort((a, b) => b.s - a.s).slice(0, 6);
+  for (const { w, s } of ranked) process.stdout.write(`    ${w.padEnd(18)} IDF=${s.toFixed(3)}\n`);
+
+  const e1 = tfidfEmbed(miniDocs[0]!, vocab, idf);
+  const e2 = tfidfEmbed(miniDocs[1]!, vocab, idf);
+  const e3 = tfidfEmbed(miniDocs[2]!, vocab, idf);
+  process.stdout.write(`\n${bar()}\nSTEP 3: cosine similarity\n${bar()}\n`);
+  process.stdout.write(`  cat-mat vs dog-rug:       ${cosineSimilarity(e1, e2).toFixed(4)}\n`);
+  process.stdout.write(`  cat-mat vs ml/ai:         ${cosineSimilarity(e1, e3).toFixed(4)}\n`);
+  process.stdout.write(`  dog-rug vs ml/ai:         ${cosineSimilarity(e2, e3).toFixed(4)}\n`);
+
+  process.stdout.write(`\n${bar()}\nSTEP 4: full RAG pipeline\n${bar()}\n`);
+  const rag = new RAGPipeline(50, 10, 3);
+  const sourceNames = ["refund-policy.md", "product-overview.md", "security.md", "api-docs.md", "uptime-sla.md"];
+  const numChunks = rag.index(SAMPLE_DOCUMENTS, sourceNames);
+  process.stdout.write(`  indexed ${SAMPLE_DOCUMENTS.length} docs → ${numChunks} chunks, vocab=${rag.vocab.length}\n`);
+
+  const queries = [
+    "What is the refund policy for enterprise customers?",
+    "What are the API rate limits?",
+    "How is customer data encrypted?",
+    "What happens if uptime falls below the SLA?",
+  ];
+  for (const q of queries) {
+    const result = rag.query(q, 3);
+    process.stdout.write(`\n  query:  ${q}\n  answer: ${result.answer}\n`);
+    for (const r of result.retrieved) {
+      const preview = r.chunk.slice(0, 80).replace(/\n/g, " ");
+      process.stdout.write(`    [${r.source}] score=${r.score.toFixed(4)} | ${preview}...\n`);
+    }
+  }
+
+  process.stdout.write(`\n${bar()}\nSUMMARY\n${bar()}\n`);
+  process.stdout.write("  RAG: query → embed → search → augment → generate\n");
+  process.stdout.write("  Swap TF-IDF for text-embedding-3-small and simpleGenerate for a real LLM call.\n");
+}
+
+main();

--- a/phases/14-agent-engineering/18-agno-and-mastra-runtimes/code/main.ts
+++ b/phases/14-agent-engineering/18-agno-and-mastra-runtimes/code/main.ts
@@ -1,0 +1,209 @@
+// Phase 14 · Lesson 18 — Agno vs Mastra runtimes (TypeScript port).
+// Minimal Mastra-shaped sketch: Agent + Tool registry + Workflow, with a
+// mocked LLM step. Plus an Agno-shaped sketch for contrast. Stdlib only —
+// the real Mastra package wires Zod, the Vercel AI SDK, telemetry.
+// Refs: https://mastra.ai/docs/agents/overview
+//       https://mastra.ai/docs/workflows/overview
+//       https://docs.agno.com/introduction
+//       https://sdk.vercel.ai/docs/foundations/agents
+
+import process from "node:process";
+
+// --- Shared LLM stub. Mastra wires Vercel AI SDK's `generateText` here.
+
+type LLMResponse = { text: string; inputTokens: number; outputTokens: number };
+
+async function mockLLM(systemPrompt: string, userMessage: string): Promise<LLMResponse> {
+  const inputTokens = Math.ceil((systemPrompt.length + userMessage.length) / 4);
+  // Simulate network latency without using a real model.
+  await new Promise((r) => setTimeout(r, 5));
+  return {
+    text: `[mock reply to ${userMessage.slice(0, 60)}]`,
+    inputTokens,
+    outputTokens: 32,
+  };
+}
+
+// --- Agno-shaped: stateless agent + session store. One fresh agent per
+// request, history lives in the session store (your DB in production).
+
+type AgnoAgent = {
+  name: string;
+  run: (prompt: string) => Promise<string>;
+};
+
+class AgnoSession {
+  private turns = new Map<string, string[]>();
+  append(sessionId: string, turn: string): void {
+    const list = this.turns.get(sessionId) ?? [];
+    list.push(turn);
+    this.turns.set(sessionId, list);
+  }
+  history(sessionId: string): string[] {
+    return [...(this.turns.get(sessionId) ?? [])];
+  }
+}
+
+async function agnoHandler(
+  session: AgnoSession,
+  agent: AgnoAgent,
+  sessionId: string,
+  prompt: string,
+): Promise<{ reply: string; elapsedUs: number }> {
+  const start = process.hrtime.bigint();
+  session.append(sessionId, `user: ${prompt}`);
+  const reply = await agent.run(prompt);
+  session.append(sessionId, `assistant: ${reply}`);
+  const elapsedUs = Number((process.hrtime.bigint() - start) / 1000n);
+  return { reply, elapsedUs };
+}
+
+// --- Mastra-shaped: Agents + Tools + Workflows.
+
+type ToolInputSchema = Record<string, "string" | "number" | "boolean">;
+type ToolInput = Record<string, string | number | boolean>;
+type ToolResult = { output: string };
+
+type MastraTool = {
+  id: string;
+  description: string;
+  inputSchema: ToolInputSchema;
+  execute: (input: ToolInput) => Promise<ToolResult>;
+};
+
+// Cheap runtime check so a tool can refuse a wrong-shaped call. Real Mastra
+// uses zod schemas + inferred TS types here.
+function checkSchema(schema: ToolInputSchema, input: ToolInput): string | null {
+  for (const [key, expected] of Object.entries(schema)) {
+    if (!(key in input)) return `missing field ${key}`;
+    if (typeof input[key] !== expected) return `field ${key}: expected ${expected}, got ${typeof input[key]}`;
+  }
+  return null;
+}
+
+type ToolCall = { tool: string; input: ToolInput };
+type AgentTrace = { tool: string; result: string }[];
+
+class MastraAgent {
+  constructor(
+    readonly name: string,
+    readonly instructions: string,
+    private readonly tools: Map<string, MastraTool>,
+  ) {}
+
+  static withTools(name: string, instructions: string, tools: MastraTool[]): MastraAgent {
+    const map = new Map<string, MastraTool>();
+    for (const t of tools) map.set(t.id, t);
+    return new MastraAgent(name, instructions, map);
+  }
+
+  async run(userMessage: string, calls: ToolCall[]): Promise<{ output: string; trace: AgentTrace; tokens: number }> {
+    const trace: AgentTrace = [];
+    let tokens = 0;
+
+    // Agent decides tool calls (here pre-supplied). Each successful call
+    // appends a step to the trace; bad calls record the error.
+    for (const call of calls) {
+      const tool = this.tools.get(call.tool);
+      if (!tool) {
+        trace.push({ tool: call.tool, result: "error: unknown tool" });
+        continue;
+      }
+      const schemaError = checkSchema(tool.inputSchema, call.input);
+      if (schemaError) {
+        trace.push({ tool: call.tool, result: `error: ${schemaError}` });
+        continue;
+      }
+      const { output } = await tool.execute(call.input);
+      trace.push({ tool: call.tool, result: output });
+    }
+
+    // Final LLM step composes trace + user message into a reply.
+    const traceText = trace.map((t) => `${t.tool}: ${t.result}`).join("\n");
+    const reply = await mockLLM(this.instructions, `${userMessage}\n\nTool results:\n${traceText}`);
+    tokens = reply.inputTokens + reply.outputTokens;
+    return { output: reply.text, trace, tokens };
+  }
+}
+
+// Workflows: an ordered list of steps. Each step gets the previous output.
+type WorkflowStep<I, O> = { name: string; run: (input: I) => Promise<O> | O };
+
+class MastraWorkflow {
+  private steps: WorkflowStep<unknown, unknown>[] = [];
+  addStep<I, O>(name: string, run: (input: I) => Promise<O> | O): MastraWorkflow {
+    this.steps.push({ name, run: run as (input: unknown) => unknown });
+    return this;
+  }
+  async run(initial: unknown): Promise<{ name: string; output: unknown }[]> {
+    const trace: { name: string; output: unknown }[] = [];
+    let current: unknown = initial;
+    for (const step of this.steps) {
+      current = await step.run(current);
+      trace.push({ name: step.name, output: current });
+    }
+    return trace;
+  }
+}
+
+// --- Demo
+
+const searchTool: MastraTool = {
+  id: "search",
+  description: "Web search over a fixture corpus",
+  inputSchema: { query: "string" },
+  execute: async (input) => ({ output: `3 results for ${String(input.query)}` }),
+};
+
+const summariseTool: MastraTool = {
+  id: "summarise",
+  description: "Compress text to one sentence",
+  inputSchema: { text: "string" },
+  execute: async (input) => ({ output: `summary: ${String(input.text).slice(0, 40)}...` }),
+};
+
+async function main(): Promise<void> {
+  process.stdout.write("=".repeat(70) + "\nAgno vs Mastra runtimes — Phase 14 · 18\n" + "=".repeat(70) + "\n");
+
+  // 1. Agno-shaped — measure agent creation + handler latency.
+  process.stdout.write("\n1. Agno-shaped (stateless FastAPI-style handler)\n");
+  const session = new AgnoSession();
+  const agnoAgent: AgnoAgent = {
+    name: "agno_a",
+    run: async (prompt) => `[agno reply] ${prompt.slice(0, 40)}`,
+  };
+  for (let i = 0; i < 3; i += 1) {
+    const { reply, elapsedUs } = await agnoHandler(session, agnoAgent, "s001", `query ${i}: how do I ship an agent`);
+    process.stdout.write(`  turn ${i}: ${reply}  (handler ${elapsedUs} us)\n`);
+  }
+  process.stdout.write(`  session history length: ${session.history("s001").length}\n`);
+  process.stdout.write("  pattern: fresh agent per request, session holds state, FastAPI/Hono is stateless.\n");
+
+  // 2. Mastra-shaped — agent runs tools then summarises.
+  process.stdout.write("\n2. Mastra-shaped (Agents + Tools + Workflows)\n");
+  const mastraAgent = MastraAgent.withTools(
+    "research_agent",
+    "Search, summarise, cite",
+    [searchTool, summariseTool],
+  );
+  const result = await mastraAgent.run("research agent engineering", [
+    { tool: "search", input: { query: "agent engineering 2026" } },
+    { tool: "search", input: { query: "BFCL V4 benchmarks" } },
+    { tool: "unknown_tool", input: { query: "fails on purpose" } },
+  ]);
+  process.stdout.write(`  agent output: ${result.output}  (~${result.tokens} tokens)\n`);
+  for (const t of result.trace) process.stdout.write(`    tool ${t.tool}: ${t.result}\n`);
+
+  // 3. Workflow — normalise → search → summarise.
+  process.stdout.write("\n3. Workflow run\n");
+  const workflow = new MastraWorkflow()
+    .addStep<string, string>("normalise", (p) => p.trim().toLowerCase())
+    .addStep<string, string>("search", async (p) => (await searchTool.execute({ query: p })).output)
+    .addStep<string, string>("summarise", async (p) => (await summariseTool.execute({ text: p })).output);
+  const workflowTrace = await workflow.run("  Agent Engineering 2026  ");
+  for (const { name, output } of workflowTrace) process.stdout.write(`    ${name}: ${String(output)}\n`);
+
+  process.stdout.write("\npick by stack: python+fastapi → Agno; typescript+next/vercel → Mastra.\n");
+}
+
+main();


### PR DESCRIPTION
Adds idiomatic TypeScript ports to six lessons that list TypeScript in the README language column but shipped no `.ts` source. Each port is dependency-free (Node 20+ stdlib), typechecks under strict mode, and runs end-to-end via `npx tsx`.

Lessons covered:

- `phases/00-setup-and-tooling/01-dev-environment/code/verify.ts` — node/git/python/cargo/deno probe mirroring `verify.py`
- `phases/00-setup-and-tooling/04-apis-and-keys/code/first_api_call.ts` — minimal `.env` loader + `fetch` against `/v1/messages` with `MOCK=1` fixture for offline runs
- `phases/11-llm-engineering/03-structured-outputs/code/main.ts` — inline zod-shaped schema DSL, JSON Schema export, mocked LLM extractor with retry
- `phases/11-llm-engineering/05-context-engineering/code/main.ts` — token budget manager, lost-in-the-middle reorder, sliding-window conversation compressor
- `phases/11-llm-engineering/06-rag/code/main.ts` — TF-IDF vector store + cosine similarity + retrieval + RAG prompt assembly over a toy corpus
- `phases/14-agent-engineering/18-agno-and-mastra-runtimes/code/main.ts` — Agno-shaped stateless handler vs Mastra-shaped Agent + Tool registry + Workflow

Each file ships a 4-6 line header citing the source URLs it leans on (Anthropic API, Zod, Mastra, Liu et al. lost-in-the-middle, scikit-learn TF-IDF). Catalog rebuilt; `python3 scripts/audit_lessons.py` reports 0 issues across 435 lessons.

## Test plan

- [x] `npx tsc --noEmit --strict --target ES2022 --module nodenext --moduleResolution nodenext --types node --skipLibCheck <file>` on every new `.ts`
- [x] `npx tsx <file>` runs to completion with exit code 0 on every new `.ts`
- [x] `python3 scripts/audit_lessons.py` → 0 issues
- [x] `python3 scripts/build_catalog.py` → catalog rebuilt