### PR TITLE
feat: rust ports for 5 systems-heavy transformer/LLM lessons

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -6,7 +6,7 @@
     "skills": 378,
     "prompts": 99,
     "agents": 0,
-    "code_files": 435
+    "code_files": 440
   },
   "phases": [
     {
@@ -3929,6 +3929,7 @@
           "has_quiz": true,
           "has_notebook": false,
           "code_files": [
+            "main.rs",
             "self_attention.py"
           ],
           "outputs": [
@@ -3952,7 +3953,8 @@
           "has_quiz": false,
           "has_notebook": true,
           "code_files": [
-            "main.py"
+            "main.py",
+            "main.rs"
           ],
           "outputs": [
             {
@@ -3980,7 +3982,8 @@
           "has_quiz": false,
           "has_notebook": true,
           "code_files": [
-            "main.py"
+            "main.py",
+            "main.rs"
           ],
           "outputs": [
             {
@@ -5210,7 +5213,8 @@
           "has_quiz": true,
           "has_notebook": false,
           "code_files": [
-            "main.py"
+            "main.py",
+            "main.rs"
           ],
           "outputs": [
             {
@@ -5464,7 +5468,8 @@
           "has_quiz": true,
           "has_notebook": false,
           "code_files": [
-            "main.py"
+            "main.py",
+            "main.rs"
           ],
           "outputs": [
             {

--- a/phases/07-transformers-deep-dive/02-self-attention-from-scratch/code/main.rs
+++ b/phases/07-transformers-deep-dive/02-self-attention-from-scratch/code/main.rs
@@ -1,0 +1,237 @@
+// Self-attention kernel from scratch, stdlib only.
+// Topic: scaled dot-product attention with explicit row-major memory.
+// References (cited in spirit, not as deps):
+//   - Vaswani 2017, "Attention Is All You Need": https://arxiv.org/abs/1706.03762
+//   - candle reference attention kernel:        https://github.com/huggingface/candle/blob/main/candle-nn/src/ops.rs
+//   - Karpathy llm.c attention forward pass:    https://github.com/karpathy/llm.c/blob/master/train_gpt2.c
+//
+// Compile + run:  rustc --edition 2021 main.rs -o /tmp/sa && /tmp/sa
+
+use std::f32::consts::E;
+
+// Row-major matrix backed by a flat Vec<f32>. Helpers index by (row, col).
+struct Mat {
+    rows: usize,
+    cols: usize,
+    data: Vec<f32>,
+}
+
+impl Mat {
+    fn zeros(rows: usize, cols: usize) -> Self {
+        Mat { rows, cols, data: vec![0.0; rows * cols] }
+    }
+
+    #[inline] fn at(&self, i: usize, j: usize) -> f32 { self.data[i * self.cols + j] }
+    #[inline] fn set(&mut self, i: usize, j: usize, v: f32) { self.data[i * self.cols + j] = v; }
+
+    fn matmul(&self, b: &Mat) -> Mat {
+        assert_eq!(self.cols, b.rows, "shape mismatch: {}x{} @ {}x{}", self.rows, self.cols, b.rows, b.cols);
+        let mut out = Mat::zeros(self.rows, b.cols);
+        for i in 0..self.rows {
+            for k in 0..self.cols {
+                let aik = self.at(i, k);
+                if aik == 0.0 { continue; }
+                let row_base = i * out.cols;
+                let bk_base = k * b.cols;
+                for j in 0..b.cols {
+                    out.data[row_base + j] += aik * b.data[bk_base + j];
+                }
+            }
+        }
+        out
+    }
+
+    fn transpose(&self) -> Mat {
+        let mut t = Mat::zeros(self.cols, self.rows);
+        for i in 0..self.rows {
+            for j in 0..self.cols {
+                t.set(j, i, self.at(i, j));
+            }
+        }
+        t
+    }
+
+    fn scale(&mut self, s: f32) {
+        for v in self.data.iter_mut() { *v *= s; }
+    }
+}
+
+// Softmax along the last axis (per row), numerically stable.
+fn softmax_rows(m: &Mat) -> Mat {
+    let mut out = Mat::zeros(m.rows, m.cols);
+    for i in 0..m.rows {
+        let mut row_max = f32::NEG_INFINITY;
+        for j in 0..m.cols { if m.at(i, j) > row_max { row_max = m.at(i, j); } }
+        let mut sum = 0.0f32;
+        for j in 0..m.cols {
+            let e = E.powf(m.at(i, j) - row_max);
+            out.set(i, j, e);
+            sum += e;
+        }
+        let inv = 1.0 / sum;
+        for j in 0..m.cols {
+            let v = out.at(i, j) * inv;
+            out.set(i, j, v);
+        }
+    }
+    out
+}
+
+// Q @ K^T / sqrt(d_k), softmax, then @ V.
+fn scaled_dot_product_attention(q: &Mat, k: &Mat, v: &Mat) -> (Mat, Mat) {
+    let dk = q.cols as f32;
+    let k_t = k.transpose();
+    let mut scores = q.matmul(&k_t);
+    scores.scale(1.0 / dk.sqrt());
+    let weights = softmax_rows(&scores);
+    let out = weights.matmul(v);
+    (out, weights)
+}
+
+// Deterministic, dependency-free Gaussian via Box-Muller from a Lehmer LCG.
+struct Rng { state: u64 }
+impl Rng {
+    fn new(seed: u64) -> Self { Rng { state: seed.wrapping_mul(0x9E37_79B9_7F4A_7C15) | 1 } }
+    fn next_u32(&mut self) -> u32 {
+        self.state = self.state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        (self.state >> 33) as u32
+    }
+    fn uniform(&mut self) -> f32 {
+        (self.next_u32() as f32 + 1.0) / (u32::MAX as f32 + 2.0)
+    }
+    fn gauss(&mut self) -> f32 {
+        let u1 = self.uniform();
+        let u2 = self.uniform();
+        (-2.0 * u1.ln()).sqrt() * (2.0 * std::f32::consts::PI * u2).cos()
+    }
+}
+
+fn randn(rows: usize, cols: usize, scale: f32, rng: &mut Rng) -> Mat {
+    let mut m = Mat::zeros(rows, cols);
+    for v in m.data.iter_mut() { *v = rng.gauss() * scale; }
+    m
+}
+
+struct SelfAttention {
+    wq: Mat,
+    wk: Mat,
+    wv: Mat,
+}
+
+impl SelfAttention {
+    fn new(d_model: usize, dk: usize, dv: usize, rng: &mut Rng) -> Self {
+        let s_qk = (2.0 / (d_model + dk) as f32).sqrt();
+        let s_v = (2.0 / (d_model + dv) as f32).sqrt();
+        SelfAttention {
+            wq: randn(d_model, dk, s_qk, rng),
+            wk: randn(d_model, dk, s_qk, rng),
+            wv: randn(d_model, dv, s_v, rng),
+        }
+    }
+
+    fn forward(&self, x: &Mat) -> (Mat, Mat) {
+        let q = x.matmul(&self.wq);
+        let k = x.matmul(&self.wk);
+        let v = x.matmul(&self.wv);
+        scaled_dot_product_attention(&q, &k, &v)
+    }
+}
+
+fn print_attention(weights: &Mat, tokens: &[&str]) {
+    print!("      ");
+    for t in tokens { print!("{:>7}", t); }
+    println!();
+    for i in 0..weights.rows {
+        print!("{:>6}", tokens[i]);
+        for j in 0..weights.cols { print!("{:>7.3}", weights.at(i, j)); }
+        println!();
+    }
+}
+
+fn ascii_heatmap(weights: &Mat, tokens: &[&str]) {
+    let chars = [' ', '\u{2591}', '\u{2592}', '\u{2593}', '\u{2588}'];
+    let mut w_max = 0.0f32;
+    for v in &weights.data { if *v > w_max { w_max = *v; } }
+    print!("      ");
+    for t in tokens { print!("{:>7}", t); }
+    println!();
+    for i in 0..weights.rows {
+        print!("{:>6}", tokens[i]);
+        for j in 0..weights.cols {
+            let level = ((weights.at(i, j) * (chars.len() - 1) as f32) / w_max) as usize;
+            let level = level.min(chars.len() - 1);
+            print!("     {} ", chars[level]);
+        }
+        println!();
+    }
+}
+
+fn softmax_vec(logits: &[f32]) -> Vec<f32> {
+    let mut m = f32::NEG_INFINITY;
+    for &x in logits { if x > m { m = x; } }
+    let exps: Vec<f32> = logits.iter().map(|x| (x - m).exp()).collect();
+    let s: f32 = exps.iter().sum();
+    exps.into_iter().map(|x| x / s).collect()
+}
+
+fn main() {
+    let sentence = ["The", "cat", "sat", "on", "the", "mat"];
+    let n_tokens = sentence.len();
+    let d_model: usize = 16;
+    let dk: usize = 8;
+    let dv: usize = 8;
+
+    println!("{}", "=".repeat(60));
+    println!("SELF-ATTENTION FROM SCRATCH (Rust port)");
+    println!("{}", "=".repeat(60));
+
+    let mut rng = Rng::new(42);
+    let x = randn(n_tokens, d_model, 1.0, &mut rng);
+    println!("\nSentence: {}", sentence.join(" "));
+    println!("Tokens: {}, d_model: {}, dk: {}, dv: {}", n_tokens, d_model, dk, dv);
+    println!("Input shape: ({}, {})", x.rows, x.cols);
+
+    let mut rng_w = Rng::new(42);
+    let attn = SelfAttention::new(d_model, dk, dv, &mut rng_w);
+    let (out, weights) = attn.forward(&x);
+
+    println!("\nOutput shape: ({}, {})", out.rows, out.cols);
+    println!("\nAttention weights:");
+    print_attention(&weights, &sentence);
+
+    println!("\nASCII heatmap (darker = higher attention):");
+    ascii_heatmap(&weights, &sentence);
+
+    println!("\n{}", "=".repeat(60));
+    println!("SOFTMAX DEMO");
+    println!("{}", "=".repeat(60));
+
+    let logits = [2.0f32, 1.0, 0.1];
+    let probs = softmax_vec(&logits);
+    println!("\nLogits:  {:?}", logits);
+    println!("Softmax: {:?}", probs.iter().map(|p| (p * 10000.0).round() / 10000.0).collect::<Vec<_>>());
+    println!("Sum:     {:.4}", probs.iter().sum::<f32>());
+
+    let large = [100.0f32, 200.0, 300.0];
+    let probs_l = softmax_vec(&large);
+    println!("\nLarge logits:  {:?}", large);
+    println!("Softmax:       {:?}", probs_l.iter().map(|p| (p * 10000.0).round() / 10000.0).collect::<Vec<_>>());
+    println!("Sum:           {:.4}", probs_l.iter().sum::<f32>());
+    println!("(numerically stable, no overflow)");
+
+    println!("\n{}", "=".repeat(60));
+    println!("MICROBENCH: 10K attention forwards");
+    println!("{}", "=".repeat(60));
+    let start = std::time::Instant::now();
+    let mut sink = 0.0f32;
+    for _ in 0..10_000 {
+        let (o, _) = attn.forward(&x);
+        sink += o.at(0, 0);
+    }
+    let elapsed = start.elapsed();
+    println!("10K forwards in {:.2}ms ({:.0}/sec)  sink={:.4}",
+        elapsed.as_secs_f64() * 1000.0,
+        10_000.0 / elapsed.as_secs_f64(),
+        sink,
+    );
+}

--- a/phases/07-transformers-deep-dive/03-multi-head-attention/code/main.rs
+++ b/phases/07-transformers-deep-dive/03-multi-head-attention/code/main.rs
@@ -1,0 +1,271 @@
+// Multi-head attention + grouped-query attention, stdlib only.
+// Topic: head split, per-head scaled dot-product attention, concat, output projection.
+// References (cited in spirit, not as deps):
+//   - Vaswani 2017:                  https://arxiv.org/abs/1706.03762
+//   - GQA paper (Ainslie 2023):      https://arxiv.org/abs/2305.13245
+//   - candle multi-head impl:        https://github.com/huggingface/candle/blob/main/candle-transformers/src/models/llama.rs
+//   - llm.c attention forward:       https://github.com/karpathy/llm.c/blob/master/train_gpt2.c
+//
+// Compile + run:  rustc --edition 2021 main.rs -o /tmp/mha && /tmp/mha
+
+struct Mat {
+    rows: usize,
+    cols: usize,
+    data: Vec<f32>,
+}
+
+impl Mat {
+    fn zeros(rows: usize, cols: usize) -> Self {
+        Mat { rows, cols, data: vec![0.0; rows * cols] }
+    }
+
+    #[inline] fn at(&self, i: usize, j: usize) -> f32 { self.data[i * self.cols + j] }
+    #[inline] fn set(&mut self, i: usize, j: usize, v: f32) { self.data[i * self.cols + j] = v; }
+
+    fn matmul(&self, b: &Mat) -> Mat {
+        assert_eq!(self.cols, b.rows);
+        let mut out = Mat::zeros(self.rows, b.cols);
+        for i in 0..self.rows {
+            for k in 0..self.cols {
+                let aik = self.at(i, k);
+                if aik == 0.0 { continue; }
+                let row_base = i * out.cols;
+                let bk_base = k * b.cols;
+                for j in 0..b.cols {
+                    out.data[row_base + j] += aik * b.data[bk_base + j];
+                }
+            }
+        }
+        out
+    }
+
+    fn transpose(&self) -> Mat {
+        let mut t = Mat::zeros(self.cols, self.rows);
+        for i in 0..self.rows {
+            for j in 0..self.cols { t.set(j, i, self.at(i, j)); }
+        }
+        t
+    }
+
+    fn scale_in_place(&mut self, s: f32) {
+        for v in self.data.iter_mut() { *v *= s; }
+    }
+}
+
+struct Rng { state: u64 }
+impl Rng {
+    fn new(seed: u64) -> Self { Rng { state: seed.wrapping_mul(0x9E37_79B9_7F4A_7C15) | 1 } }
+    fn next_u32(&mut self) -> u32 {
+        self.state = self.state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        (self.state >> 33) as u32
+    }
+    fn uniform(&mut self) -> f32 { (self.next_u32() as f32 + 1.0) / (u32::MAX as f32 + 2.0) }
+    fn gauss(&mut self) -> f32 {
+        let u1 = self.uniform();
+        let u2 = self.uniform();
+        (-2.0 * u1.ln()).sqrt() * (2.0 * std::f32::consts::PI * u2).cos()
+    }
+}
+
+fn randn(rows: usize, cols: usize, rng: &mut Rng) -> Mat {
+    let scale = (2.0 / (rows + cols) as f32).sqrt();
+    let mut m = Mat::zeros(rows, cols);
+    for v in m.data.iter_mut() { *v = rng.gauss() * scale; }
+    m
+}
+
+fn randn_unit(rows: usize, cols: usize, rng: &mut Rng) -> Mat {
+    let mut m = Mat::zeros(rows, cols);
+    for v in m.data.iter_mut() { *v = rng.gauss(); }
+    m
+}
+
+fn softmax_rows(m: &Mat) -> Mat {
+    let mut out = Mat::zeros(m.rows, m.cols);
+    for i in 0..m.rows {
+        let mut row_max = f32::NEG_INFINITY;
+        for j in 0..m.cols { if m.at(i, j) > row_max { row_max = m.at(i, j); } }
+        let mut sum = 0.0f32;
+        for j in 0..m.cols {
+            let e = (m.at(i, j) - row_max).exp();
+            out.set(i, j, e);
+            sum += e;
+        }
+        let inv = 1.0 / sum;
+        for j in 0..m.cols { let v = out.at(i, j) * inv; out.set(i, j, v); }
+    }
+    out
+}
+
+fn scaled_dot_product_attention(q: &Mat, k: &Mat, v: &Mat) -> (Mat, Mat) {
+    let dk = q.cols as f32;
+    let kt = k.transpose();
+    let mut scores = q.matmul(&kt);
+    scores.scale_in_place(1.0 / dk.sqrt());
+    let weights = softmax_rows(&scores);
+    let out = weights.matmul(v);
+    (out, weights)
+}
+
+// Split [n, d_model] into n_heads chunks of [n, d_head] along the last axis.
+fn split_heads(x: &Mat, n_heads: usize) -> Vec<Mat> {
+    assert_eq!(x.cols % n_heads, 0, "d_model {} not divisible by n_heads {}", x.cols, n_heads);
+    let d_head = x.cols / n_heads;
+    let mut heads = Vec::with_capacity(n_heads);
+    for h in 0..n_heads {
+        let mut hm = Mat::zeros(x.rows, d_head);
+        for i in 0..x.rows {
+            for j in 0..d_head {
+                hm.set(i, j, x.at(i, h * d_head + j));
+            }
+        }
+        heads.push(hm);
+    }
+    heads
+}
+
+// Concat n_heads chunks of [n, d_head] back to [n, n_heads * d_head].
+fn combine_heads(heads: &[Mat]) -> Mat {
+    let n = heads[0].rows;
+    let d_head = heads[0].cols;
+    let n_heads = heads.len();
+    let mut out = Mat::zeros(n, d_head * n_heads);
+    for (h, head) in heads.iter().enumerate() {
+        for i in 0..n {
+            for j in 0..d_head {
+                out.set(i, h * d_head + j, head.at(i, j));
+            }
+        }
+    }
+    out
+}
+
+fn multi_head_attention(
+    x: &Mat,
+    wq: &Mat, wk: &Mat, wv: &Mat, wo: &Mat,
+    n_heads: usize,
+) -> (Mat, Vec<Mat>) {
+    let q = x.matmul(wq);
+    let k = x.matmul(wk);
+    let v = x.matmul(wv);
+    let qh = split_heads(&q, n_heads);
+    let kh = split_heads(&k, n_heads);
+    let vh = split_heads(&v, n_heads);
+
+    let mut head_outs: Vec<Mat> = Vec::with_capacity(n_heads);
+    let mut per_head_weights: Vec<Mat> = Vec::with_capacity(n_heads);
+    for h in 0..n_heads {
+        let (o, w) = scaled_dot_product_attention(&qh[h], &kh[h], &vh[h]);
+        head_outs.push(o);
+        per_head_weights.push(w);
+    }
+    let concat = combine_heads(&head_outs);
+    (concat.matmul(wo), per_head_weights)
+}
+
+// GQA: Q has n_heads, K and V have n_kv_heads. Replicate each KV head across its group.
+fn grouped_query_attention(
+    x: &Mat,
+    wq: &Mat, wk: &Mat, wv: &Mat, wo: &Mat,
+    n_heads: usize, n_kv_heads: usize,
+) -> Mat {
+    assert_eq!(n_heads % n_kv_heads, 0, "n_heads must be a multiple of n_kv_heads");
+    let q = x.matmul(wq);
+    let k = x.matmul(wk);
+    let v = x.matmul(wv);
+    let qh = split_heads(&q, n_heads);
+    let kh_small = split_heads(&k, n_kv_heads);
+    let vh_small = split_heads(&v, n_kv_heads);
+    let repeat = n_heads / n_kv_heads;
+
+    let mut head_outs: Vec<Mat> = Vec::with_capacity(n_heads);
+    for i in 0..n_heads {
+        let kv_idx = i / repeat;
+        let (o, _) = scaled_dot_product_attention(&qh[i], &kh_small[kv_idx], &vh_small[kv_idx]);
+        head_outs.push(o);
+    }
+    let concat = combine_heads(&head_outs);
+    concat.matmul(wo)
+}
+
+fn print_head_weights(weights: &Mat, tokens: &[&str]) {
+    print!("      ");
+    for t in tokens { print!("{:>7}", t); }
+    println!();
+    for i in 0..weights.rows {
+        print!("{:>6}", tokens[i]);
+        for j in 0..weights.cols { print!("{:>7.3}", weights.at(i, j)); }
+        println!();
+    }
+}
+
+fn main() {
+    let tokens = ["the", "cat", "sat", "on", "the", "mat"];
+    let n = tokens.len();
+    let d_model: usize = 8;
+    let n_heads: usize = 2;
+
+    let mut rng = Rng::new(42);
+    let x = randn_unit(n, d_model, &mut rng);
+    let wq = randn(d_model, d_model, &mut rng);
+    let wk = randn(d_model, d_model, &mut rng);
+    let wv = randn(d_model, d_model, &mut rng);
+    let wo = randn(d_model, d_model, &mut rng);
+
+    let (out, weights) = multi_head_attention(&x, &wq, &wk, &wv, &wo, n_heads);
+
+    println!("=== multi-head attention: {} heads, d_model={}, d_head={} ===",
+        n_heads, d_model, d_model / n_heads);
+    println!("input  shape: ({}, {})", x.rows, x.cols);
+    println!("output shape: ({}, {})", out.rows, out.cols);
+    println!();
+    for (h, w) in weights.iter().enumerate() {
+        println!("-- head {} attention weights --", h);
+        print_head_weights(w, &tokens);
+        println!();
+    }
+
+    // GQA demo: 4 Q heads, 2 KV heads.
+    let d_model = 8usize;
+    let n_heads = 4usize;
+    let n_kv = 2usize;
+    let d_head = d_model / n_heads;
+    let kv_dim = d_head * n_kv;
+
+    let mut rng = Rng::new(7);
+    let x = randn_unit(n, d_model, &mut rng);
+    let wq = randn(d_model, d_model, &mut rng);
+    let wk = randn(d_model, kv_dim, &mut rng);
+    let wv = randn(d_model, kv_dim, &mut rng);
+    let wo = randn(d_model, d_model, &mut rng);
+
+    let out_gqa = grouped_query_attention(&x, &wq, &wk, &wv, &wo, n_heads, n_kv);
+    println!("=== GQA: {} Q heads, {} KV heads ===", n_heads, n_kv);
+    println!("output shape: ({}, {})", out_gqa.rows, out_gqa.cols);
+
+    let kv_full = n_heads * n * d_head * 2;
+    let kv_gqa = n_kv * n * d_head * 2;
+    println!("KV cache elements (MHA):  {}", kv_full);
+    println!("KV cache elements (GQA):  {}  ({}x smaller)", kv_gqa, kv_full / kv_gqa);
+
+    println!();
+    println!("=== microbench: 5K MHA forwards (n=6, d=8, 2 heads) ===");
+    let mut rng = Rng::new(13);
+    let x_b = randn_unit(n, d_model, &mut rng);
+    let wq_b = randn(d_model, d_model, &mut rng);
+    let wk_b = randn(d_model, d_model, &mut rng);
+    let wv_b = randn(d_model, d_model, &mut rng);
+    let wo_b = randn(d_model, d_model, &mut rng);
+    let start = std::time::Instant::now();
+    let mut sink = 0.0f32;
+    for _ in 0..5_000 {
+        let (o, _) = multi_head_attention(&x_b, &wq_b, &wk_b, &wv_b, &wo_b, 2);
+        sink += o.at(0, 0);
+    }
+    let elapsed = start.elapsed();
+    println!("5K forwards in {:.2}ms ({:.0}/sec)  sink={:.4}",
+        elapsed.as_secs_f64() * 1000.0,
+        5_000.0 / elapsed.as_secs_f64(),
+        sink,
+    );
+}

--- a/phases/07-transformers-deep-dive/04-positional-encoding/code/main.rs
+++ b/phases/07-transformers-deep-dive/04-positional-encoding/code/main.rs
@@ -1,0 +1,183 @@
+// Positional encodings: sinusoidal, RoPE, ALiBi. Stdlib only.
+// Topic: encode token position into queries, keys, or attention bias.
+// References (cited in spirit, not as deps):
+//   - Vaswani 2017 (sinusoidal):     https://arxiv.org/abs/1706.03762
+//   - Su et al. 2021 (RoPE):         https://arxiv.org/abs/2104.09864
+//   - Press et al. 2021 (ALiBi):     https://arxiv.org/abs/2108.12409
+//   - candle rope impl:              https://github.com/huggingface/candle/blob/main/candle-nn/src/rotary_emb.rs
+//
+// Compile + run:  rustc --edition 2021 main.rs -o /tmp/pe && /tmp/pe
+
+use std::f32::consts::PI;
+
+// Sinusoidal positional encoding table [n, d].
+fn sinusoidal_pe(n: usize, d: usize, base: f32) -> Vec<Vec<f32>> {
+    let mut pe = vec![vec![0.0f32; d]; n];
+    for pos in 0..n {
+        for i in 0..(d / 2) {
+            let theta = (pos as f32) / base.powf(2.0 * i as f32 / d as f32);
+            pe[pos][2 * i] = theta.sin();
+            pe[pos][2 * i + 1] = theta.cos();
+        }
+    }
+    pe
+}
+
+// Rotate even/odd pairs of x by angle pos * theta_i. Returns a new Vec.
+fn apply_rope(x: &[f32], pos: usize, base: f32) -> Vec<f32> {
+    let d = x.len();
+    let mut out = x.to_vec();
+    for i in 0..(d / 2) {
+        let theta = (pos as f32) / base.powf(2.0 * i as f32 / d as f32);
+        let c = theta.cos();
+        let s = theta.sin();
+        let a = x[2 * i];
+        let b = x[2 * i + 1];
+        out[2 * i] = a * c - b * s;
+        out[2 * i + 1] = a * s + b * c;
+    }
+    out
+}
+
+fn dot(a: &[f32], b: &[f32]) -> f32 {
+    a.iter().zip(b.iter()).map(|(x, y)| x * y).sum()
+}
+
+// ALiBi slopes: 2^(-8*(h+1)/n_heads) for h in 0..n_heads.
+fn alibi_slopes(n_heads: usize) -> Vec<f32> {
+    (0..n_heads)
+        .map(|h| 2.0f32.powf(-8.0 * (h + 1) as f32 / n_heads as f32))
+        .collect()
+}
+
+// ALiBi bias matrix for each head: -slope * |i - j|, with optional causal mask.
+fn alibi_bias(n_heads: usize, seq_len: usize, causal: bool) -> Vec<Vec<Vec<f32>>> {
+    let slopes = alibi_slopes(n_heads);
+    let mut out = Vec::with_capacity(n_heads);
+    for &m in &slopes {
+        let mut head = vec![vec![0.0f32; seq_len]; seq_len];
+        for i in 0..seq_len {
+            for j in 0..seq_len {
+                head[i][j] = if causal && j > i {
+                    f32::NEG_INFINITY
+                } else {
+                    -m * (i as i64 - j as i64).abs() as f32
+                };
+            }
+        }
+        out.push(head);
+    }
+    out
+}
+
+// Tiny LCG for deterministic Gaussian samples.
+struct Rng { state: u64 }
+impl Rng {
+    fn new(seed: u64) -> Self { Rng { state: seed.wrapping_mul(0x9E37_79B9_7F4A_7C15) | 1 } }
+    fn next_u32(&mut self) -> u32 {
+        self.state = self.state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        (self.state >> 33) as u32
+    }
+    fn uniform(&mut self) -> f32 { (self.next_u32() as f32 + 1.0) / (u32::MAX as f32 + 2.0) }
+    fn gauss(&mut self) -> f32 {
+        let u1 = self.uniform();
+        let u2 = self.uniform();
+        (-2.0 * u1.ln()).sqrt() * (2.0 * PI * u2).cos()
+    }
+}
+
+fn demo_sinusoidal() {
+    println!("=== sinusoidal positional encoding ===");
+    let pe = sinusoidal_pe(8, 8, 10000.0);
+    println!("first 4 positions, first 4 dims:");
+    for pos in 0..4 {
+        print!("  pos={}: ", pos);
+        for i in 0..4 {
+            print!(" {:+.3}", pe[pos][i]);
+        }
+        println!();
+    }
+    println!();
+}
+
+fn demo_rope_relative() {
+    println!("=== RoPE: dot product depends only on relative distance ===");
+    let mut rng = Rng::new(0);
+    let d = 16usize;
+    let q: Vec<f32> = (0..d).map(|_| rng.gauss()).collect();
+    let k: Vec<f32> = (0..d).map(|_| rng.gauss()).collect();
+
+    let pairs = [(3usize, 5usize), (7, 9), (100, 102), (1024, 1026)];
+    println!(" {:>6}  {:>6}  {:>4}  {:>18}", "pos_q", "pos_k", "gap", "<q_rot, k_rot>");
+    for (pq, pk) in pairs {
+        let q_rot = apply_rope(&q, pq, 10000.0);
+        let k_rot = apply_rope(&k, pk, 10000.0);
+        let d_prod = dot(&q_rot, &k_rot);
+        println!(" {:>6}  {:>6}  {:>4}  {:>18.6}", pq, pk, (pk as i64) - (pq as i64), d_prod);
+    }
+    println!("all rows with gap=2 share the same dot product.");
+    println!();
+}
+
+fn demo_rope_base_scaling() {
+    println!("=== RoPE base scaling (NTK-aware for long context) ===");
+    let mut rng = Rng::new(1);
+    let d = 8usize;
+    let q: Vec<f32> = (0..d).map(|_| rng.gauss()).collect();
+    let k: Vec<f32> = (0..d).map(|_| rng.gauss()).collect();
+
+    for base in [10_000.0f32, 100_000.0, 1_000_000.0] {
+        let q_rot = apply_rope(&q, 4096, base);
+        let k_rot = apply_rope(&k, 4098, base);
+        println!("  base={:>9}  score={:+.6}", base as u64, dot(&q_rot, &k_rot));
+    }
+    println!("larger base = slower rotation = longer context without phase wrap.");
+    println!();
+}
+
+fn demo_alibi() {
+    println!("=== ALiBi bias matrix ===");
+    let n_heads = 4usize;
+    let slopes = alibi_slopes(n_heads);
+    print!("slopes for {} heads:", n_heads);
+    for s in &slopes { print!(" {:.4}", s); }
+    println!();
+    let bias = alibi_bias(n_heads, 6, false);
+    println!("head 0 bias (closer tokens get smaller penalty):");
+    for row in &bias[0] {
+        print!(" ");
+        for v in row { print!(" {:+6.2}", v); }
+        println!();
+    }
+    println!();
+}
+
+fn demo_rope_microbench() {
+    println!("=== microbench: 50K RoPE rotations (d=128) ===");
+    let mut rng = Rng::new(2);
+    let d = 128usize;
+    let q: Vec<f32> = (0..d).map(|_| rng.gauss()).collect();
+    let start = std::time::Instant::now();
+    let mut sink = 0.0f32;
+    for pos in 0..50_000usize {
+        let r = apply_rope(&q, pos, 10_000.0);
+        sink += r[0];
+    }
+    let elapsed = start.elapsed();
+    println!("50K rotations in {:.2}ms ({:.0}/sec)  sink={:.4}",
+        elapsed.as_secs_f64() * 1000.0,
+        50_000.0 / elapsed.as_secs_f64(),
+        sink,
+    );
+}
+
+fn main() {
+    demo_sinusoidal();
+    demo_rope_relative();
+    demo_rope_base_scaling();
+    demo_alibi();
+    demo_rope_microbench();
+    println!();
+    println!("takeaway: RoPE encodes relative position in the dot product itself.");
+    println!("ALiBi skips embeddings entirely. sinusoidal is mostly historical now.");
+}

--- a/phases/10-llms-from-scratch/04-pre-training-mini-gpt/code/main.rs
+++ b/phases/10-llms-from-scratch/04-pre-training-mini-gpt/code/main.rs
@@ -1,0 +1,470 @@
+// Mini-GPT forward pass, stdlib only.
+// Topic: embedding + pos embedding, N transformer blocks (LayerNorm, MHA, FFN), LM head.
+// References (cited in spirit, not as deps):
+//   - Karpathy nanoGPT / llm.c:    https://github.com/karpathy/llm.c/blob/master/train_gpt2.c
+//   - candle gpt-2:                https://github.com/huggingface/candle/blob/main/candle-transformers/src/models/gpt2.rs
+//   - GPT-2 paper:                 https://cdn.openai.com/better-language-models/language_models_are_unsupervised_multitask_learners.pdf
+//
+// Compile + run:  rustc --edition 2021 main.rs -o /tmp/mini && /tmp/mini
+
+use std::f32::consts::PI;
+
+// Tensor3 = [n, d_model]. We keep batch=1 implicit, matching the lesson script.
+struct Mat {
+    rows: usize,
+    cols: usize,
+    data: Vec<f32>,
+}
+
+impl Mat {
+    fn zeros(rows: usize, cols: usize) -> Self {
+        Mat { rows, cols, data: vec![0.0; rows * cols] }
+    }
+    #[inline] fn at(&self, i: usize, j: usize) -> f32 { self.data[i * self.cols + j] }
+    #[inline] fn set(&mut self, i: usize, j: usize, v: f32) { self.data[i * self.cols + j] = v; }
+
+    fn matmul(&self, b: &Mat) -> Mat {
+        assert_eq!(self.cols, b.rows);
+        let mut out = Mat::zeros(self.rows, b.cols);
+        for i in 0..self.rows {
+            for k in 0..self.cols {
+                let aik = self.at(i, k);
+                if aik == 0.0 { continue; }
+                let row_base = i * out.cols;
+                let bk_base = k * b.cols;
+                for j in 0..b.cols {
+                    out.data[row_base + j] += aik * b.data[bk_base + j];
+                }
+            }
+        }
+        out
+    }
+
+    fn add_(&mut self, b: &Mat) {
+        assert_eq!(self.rows, b.rows);
+        assert_eq!(self.cols, b.cols);
+        for i in 0..self.data.len() { self.data[i] += b.data[i]; }
+    }
+
+    fn add_rowwise_(&mut self, bias: &[f32]) {
+        assert_eq!(self.cols, bias.len());
+        for i in 0..self.rows {
+            let base = i * self.cols;
+            for j in 0..self.cols { self.data[base + j] += bias[j]; }
+        }
+    }
+}
+
+struct Rng { state: u64 }
+impl Rng {
+    fn new(seed: u64) -> Self { Rng { state: seed.wrapping_mul(0x9E37_79B9_7F4A_7C15) | 1 } }
+    fn next_u32(&mut self) -> u32 {
+        self.state = self.state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        (self.state >> 33) as u32
+    }
+    fn uniform(&mut self) -> f32 { (self.next_u32() as f32 + 1.0) / (u32::MAX as f32 + 2.0) }
+    fn gauss(&mut self) -> f32 {
+        let u1 = self.uniform();
+        let u2 = self.uniform();
+        (-2.0 * u1.ln()).sqrt() * (2.0 * PI * u2).cos()
+    }
+    // sample categorical from probability vector (must sum to 1)
+    fn choice(&mut self, probs: &[f32]) -> usize {
+        let r = self.uniform();
+        let mut acc = 0.0;
+        for (i, p) in probs.iter().enumerate() {
+            acc += *p;
+            if r <= acc { return i; }
+        }
+        probs.len() - 1
+    }
+}
+
+fn randn_mat(rows: usize, cols: usize, scale: f32, rng: &mut Rng) -> Mat {
+    let mut m = Mat::zeros(rows, cols);
+    for v in m.data.iter_mut() { *v = rng.gauss() * scale; }
+    m
+}
+
+struct Embedding {
+    token_embed: Mat, // [vocab, d]
+    pos_embed: Mat,   // [max_seq, d]
+}
+
+impl Embedding {
+    fn new(vocab: usize, d: usize, max_seq: usize, rng: &mut Rng) -> Self {
+        Embedding {
+            token_embed: randn_mat(vocab, d, 0.02, rng),
+            pos_embed: randn_mat(max_seq, d, 0.02, rng),
+        }
+    }
+    fn forward(&self, ids: &[usize]) -> Mat {
+        let n = ids.len();
+        let d = self.token_embed.cols;
+        let mut out = Mat::zeros(n, d);
+        for (i, &t) in ids.iter().enumerate() {
+            for j in 0..d {
+                out.set(i, j, self.token_embed.at(t, j) + self.pos_embed.at(i, j));
+            }
+        }
+        out
+    }
+}
+
+struct LayerNorm {
+    gamma: Vec<f32>,
+    beta: Vec<f32>,
+    eps: f32,
+}
+
+impl LayerNorm {
+    fn new(d: usize) -> Self {
+        LayerNorm { gamma: vec![1.0; d], beta: vec![0.0; d], eps: 1e-5 }
+    }
+    fn forward(&self, x: &Mat) -> Mat {
+        let mut out = Mat::zeros(x.rows, x.cols);
+        let d = x.cols as f32;
+        for i in 0..x.rows {
+            let base = i * x.cols;
+            let mut mean = 0.0f32;
+            for j in 0..x.cols { mean += x.data[base + j]; }
+            mean /= d;
+            let mut var = 0.0f32;
+            for j in 0..x.cols {
+                let dx = x.data[base + j] - mean;
+                var += dx * dx;
+            }
+            var /= d;
+            let inv = 1.0 / (var + self.eps).sqrt();
+            for j in 0..x.cols {
+                let n = (x.data[base + j] - mean) * inv;
+                out.data[base + j] = self.gamma[j] * n + self.beta[j];
+            }
+        }
+        out
+    }
+}
+
+struct MultiHeadAttention {
+    n_heads: usize,
+    head_dim: usize,
+    wq: Mat,
+    wk: Mat,
+    wv: Mat,
+    wo: Mat,
+}
+
+impl MultiHeadAttention {
+    fn new(d: usize, n_heads: usize, rng: &mut Rng) -> Self {
+        assert_eq!(d % n_heads, 0);
+        MultiHeadAttention {
+            n_heads,
+            head_dim: d / n_heads,
+            wq: randn_mat(d, d, 0.02, rng),
+            wk: randn_mat(d, d, 0.02, rng),
+            wv: randn_mat(d, d, 0.02, rng),
+            wo: randn_mat(d, d, 0.02, rng),
+        }
+    }
+
+    // Causal MHA forward. mask = upper triangle of -1e9 baked into the inner loop.
+    fn forward(&self, x: &Mat) -> Mat {
+        let n = x.rows;
+        let d = x.cols;
+        let q = x.matmul(&self.wq);
+        let k = x.matmul(&self.wk);
+        let v = x.matmul(&self.wv);
+
+        let mut attn_concat = Mat::zeros(n, d);
+        let inv_sqrt = 1.0 / (self.head_dim as f32).sqrt();
+
+        for h in 0..self.n_heads {
+            let hoff = h * self.head_dim;
+            // Per-head scores [n, n]
+            let mut scores = vec![0.0f32; n * n];
+            for i in 0..n {
+                for j in 0..n {
+                    let mut s = 0.0f32;
+                    for kk in 0..self.head_dim {
+                        s += q.at(i, hoff + kk) * k.at(j, hoff + kk);
+                    }
+                    scores[i * n + j] = s * inv_sqrt;
+                    if j > i { scores[i * n + j] = -1e9; }
+                }
+            }
+            // softmax row-wise
+            for i in 0..n {
+                let row = &mut scores[i * n..(i + 1) * n];
+                let mut m = f32::NEG_INFINITY;
+                for &v in row.iter() { if v > m { m = v; } }
+                let mut s = 0.0f32;
+                for v in row.iter_mut() { *v = (*v - m).exp(); s += *v; }
+                let inv = 1.0 / s;
+                for v in row.iter_mut() { *v *= inv; }
+            }
+            // weights @ V for this head, write into concat columns [hoff .. hoff + head_dim]
+            for i in 0..n {
+                for kk in 0..self.head_dim {
+                    let mut s = 0.0f32;
+                    for j in 0..n {
+                        s += scores[i * n + j] * v.at(j, hoff + kk);
+                    }
+                    attn_concat.set(i, hoff + kk, s);
+                }
+            }
+        }
+
+        attn_concat.matmul(&self.wo)
+    }
+}
+
+struct FeedForward {
+    w1: Mat,
+    b1: Vec<f32>,
+    w2: Mat,
+    b2: Vec<f32>,
+}
+
+impl FeedForward {
+    fn new(d: usize, ff: usize, rng: &mut Rng) -> Self {
+        FeedForward {
+            w1: randn_mat(d, ff, 0.02, rng),
+            b1: vec![0.0; ff],
+            w2: randn_mat(ff, d, 0.02, rng),
+            b2: vec![0.0; d],
+        }
+    }
+    fn forward(&self, x: &Mat) -> Mat {
+        let mut h = x.matmul(&self.w1);
+        h.add_rowwise_(&self.b1);
+        for v in h.data.iter_mut() { if *v < 0.0 { *v = 0.0; } } // ReLU
+        let mut y = h.matmul(&self.w2);
+        y.add_rowwise_(&self.b2);
+        y
+    }
+}
+
+struct Block {
+    ln1: LayerNorm,
+    attn: MultiHeadAttention,
+    ln2: LayerNorm,
+    ffn: FeedForward,
+}
+
+impl Block {
+    fn new(d: usize, n_heads: usize, ff: usize, rng: &mut Rng) -> Self {
+        Block {
+            ln1: LayerNorm::new(d),
+            attn: MultiHeadAttention::new(d, n_heads, rng),
+            ln2: LayerNorm::new(d),
+            ffn: FeedForward::new(d, ff, rng),
+        }
+    }
+    fn forward(&self, x: &Mat) -> Mat {
+        // pre-LN, residual
+        let mut y = self.attn.forward(&self.ln1.forward(x));
+        y.add_(x);
+        let mut z = self.ffn.forward(&self.ln2.forward(&y));
+        z.add_(&y);
+        z
+    }
+}
+
+struct MiniGPT {
+    embedding: Embedding,
+    blocks: Vec<Block>,
+    ln_f: LayerNorm,
+    vocab: usize,
+    d_model: usize,
+    max_seq: usize,
+}
+
+impl MiniGPT {
+    fn new(vocab: usize, d: usize, n_heads: usize, n_layers: usize, max_seq: usize, ff: usize, rng: &mut Rng) -> Self {
+        let embedding = Embedding::new(vocab, d, max_seq, rng);
+        let blocks = (0..n_layers).map(|_| Block::new(d, n_heads, ff, rng)).collect();
+        let ln_f = LayerNorm::new(d);
+        MiniGPT { embedding, blocks, ln_f, vocab, d_model: d, max_seq }
+    }
+
+    fn forward(&self, ids: &[usize]) -> Mat {
+        assert!(ids.len() <= self.max_seq);
+        let mut x = self.embedding.forward(ids);
+        for b in &self.blocks { x = b.forward(&x); }
+        x = self.ln_f.forward(&x);
+        // LM head shares token embedding matrix: logits = x @ token_embed^T
+        // Compute directly into [n, vocab]. token_embed is [vocab, d_model].
+        let n = x.rows;
+        let mut logits = Mat::zeros(n, self.vocab);
+        for i in 0..n {
+            for t in 0..self.vocab {
+                let mut s = 0.0f32;
+                for j in 0..self.d_model {
+                    s += x.at(i, j) * self.embedding.token_embed.at(t, j);
+                }
+                logits.set(i, t, s);
+            }
+        }
+        logits
+    }
+
+    fn count_parameters(&self) -> usize {
+        let mut total = self.embedding.token_embed.data.len() + self.embedding.pos_embed.data.len();
+        for b in &self.blocks {
+            total += b.attn.wq.data.len() + b.attn.wk.data.len() + b.attn.wv.data.len() + b.attn.wo.data.len();
+            total += b.ffn.w1.data.len() + b.ffn.b1.len() + b.ffn.w2.data.len() + b.ffn.b2.len();
+            total += b.ln1.gamma.len() + b.ln1.beta.len() + b.ln2.gamma.len() + b.ln2.beta.len();
+        }
+        total += self.ln_f.gamma.len() + self.ln_f.beta.len();
+        total
+    }
+}
+
+fn cross_entropy_loss(logits: &Mat, targets: &[usize]) -> f32 {
+    let n = logits.rows;
+    let v = logits.cols;
+    let mut total = 0.0f32;
+    for i in 0..n {
+        let row = &logits.data[i * v..(i + 1) * v];
+        let mut m = f32::NEG_INFINITY;
+        for &x in row { if x > m { m = x; } }
+        let mut s = 0.0f32;
+        for &x in row { s += (x - m).exp(); }
+        let log_sum = s.ln();
+        let log_softmax_t = row[targets[i]] - m - log_sum;
+        total += -log_softmax_t;
+    }
+    total / n as f32
+}
+
+fn generate(model: &MiniGPT, prompt: &[usize], max_new: usize, temperature: f32, rng: &mut Rng) -> Vec<usize> {
+    let mut tokens: Vec<usize> = prompt.to_vec();
+    let max_seq = model.max_seq;
+    for _ in 0..max_new {
+        let start = if tokens.len() > max_seq { tokens.len() - max_seq } else { 0 };
+        let ctx = &tokens[start..];
+        let logits = model.forward(ctx);
+        let last_row = &logits.data[(ctx.len() - 1) * logits.cols..ctx.len() * logits.cols];
+        let scaled: Vec<f32> = last_row.iter().map(|x| x / temperature).collect();
+        let mut m = f32::NEG_INFINITY;
+        for &x in &scaled { if x > m { m = x; } }
+        let exps: Vec<f32> = scaled.iter().map(|x| (x - m).exp()).collect();
+        let s: f32 = exps.iter().sum();
+        let probs: Vec<f32> = exps.into_iter().map(|x| x / s).collect();
+        let next = rng.choice(&probs);
+        tokens.push(next);
+    }
+    tokens
+}
+
+fn parameter_breakdown() {
+    println!("GPT-2 family parameter counts (analytical)");
+    println!("{}", "=".repeat(65));
+    println!("{:<16} {:>6} {:>6} {:>6} {:>14}", "Model", "Layers", "Heads", "Dims", "Params");
+    println!("{}", "-".repeat(65));
+    let configs: [(&str, usize, usize, usize, usize, usize, usize); 4] = [
+        ("GPT-2 Small",  50257, 768,  12, 12, 1024, 3072),
+        ("GPT-2 Medium", 50257, 1024, 16, 24, 1024, 4096),
+        ("GPT-2 Large",  50257, 1280, 20, 36, 1024, 5120),
+        ("GPT-2 XL",     50257, 1600, 25, 48, 1024, 6400),
+    ];
+    for (name, vocab, dim, heads, layers, seq_len, ff) in configs {
+        let token_emb = vocab * dim;
+        let pos_emb = seq_len * dim;
+        let per_block_attn = 4 * dim * dim;
+        let per_block_ff = 2 * dim * ff + dim + ff;
+        let per_block_ln = 4 * dim;
+        let per_block = per_block_attn + per_block_ff + per_block_ln;
+        let final_ln = 2 * dim;
+        let total = token_emb + pos_emb + layers * per_block + final_ln;
+        println!("{:<16} {:>6} {:>6} {:>6} {:>14}", name, layers, heads, dim, total);
+    }
+    println!();
+}
+
+fn memory_estimate() {
+    println!("Inference memory (FP16)");
+    println!("{}", "=".repeat(65));
+    println!("{:<24} {:>10} {:>12} {:>10}", "Model", "Weights", "KV Cache", "Total");
+    println!("{}", "-".repeat(65));
+    let models: [(&str, f64, usize, usize, usize, usize); 4] = [
+        ("GPT-2 Small (124M)", 124e6,  12,  12,  64, 1024),
+        ("Llama 3 8B",          8e9,  32,  32, 128, 8192),
+        ("Llama 3 70B",        70e9,  80,  64, 128, 8192),
+        ("Llama 3 405B",      405e9, 126, 128, 128, 131072),
+    ];
+    let fmt = |b: f64| -> String {
+        if b >= 1e9 { format!("{:.1} GB", b / 1e9) } else { format!("{:.0} MB", b / 1e6) }
+    };
+    for (name, params, layers, heads, head_dim, max_seq) in models {
+        let weight_bytes = params * 2.0;
+        let kv_per_tok = 2.0 * layers as f64 * heads as f64 * head_dim as f64 * 2.0;
+        let kv_full = kv_per_tok * max_seq as f64;
+        let total = weight_bytes + kv_full;
+        println!("{:<24} {:>10} {:>12} {:>10}", name, fmt(weight_bytes), fmt(kv_full), fmt(total));
+    }
+    println!();
+}
+
+fn main() {
+    parameter_breakdown();
+    memory_estimate();
+
+    // Tiny demo on byte-level vocab.
+    let corpus: &str = "The transformer architecture has revolutionized natural language processing. \
+Attention mechanisms allow the model to focus on relevant parts of the input. \
+Self-attention computes relationships between all pairs of positions in a sequence.";
+
+    let tokens: Vec<usize> = corpus.bytes().map(|b| b as usize).collect();
+
+    println!("=== Mini-GPT forward pass demo ===");
+    let vocab = 256usize;
+    let d_model = 32usize;
+    let n_heads = 4usize;
+    let n_layers = 2usize;
+    let max_seq = 32usize;
+    let ff = d_model * 4;
+
+    let mut rng = Rng::new(42);
+    let model = MiniGPT::new(vocab, d_model, n_heads, n_layers, max_seq, ff, &mut rng);
+    println!("config: vocab={}, d={}, heads={}, layers={}, seq={}", vocab, d_model, n_heads, n_layers, max_seq);
+    println!("parameters: {}", model.count_parameters());
+
+    let input = &tokens[..max_seq.min(tokens.len() - 1)];
+    let target: Vec<usize> = tokens[1..1 + input.len()].to_vec();
+
+    let start = std::time::Instant::now();
+    let logits = model.forward(input);
+    let elapsed = start.elapsed();
+
+    println!("forward pass: {} tokens -> logits shape ({}, {})",
+        input.len(), logits.rows, logits.cols);
+    println!("forward latency: {:.2}ms", elapsed.as_secs_f64() * 1000.0);
+
+    let loss = cross_entropy_loss(&logits, &target);
+    println!("cross-entropy loss vs next-token target: {:.4}", loss);
+    println!("(random init loss ~ ln(vocab) = {:.4})", (vocab as f32).ln());
+
+    // Generation demo with a random model is gibberish, but exercises the autoregressive loop.
+    let prompt: Vec<usize> = "The ".bytes().map(|b| b as usize).collect();
+    let mut gen_rng = Rng::new(123);
+    let out = generate(&model, &prompt, 24, 1.0, &mut gen_rng);
+    let bytes: Vec<u8> = out.iter().map(|&t| t as u8).collect();
+    let s = String::from_utf8_lossy(&bytes);
+    println!("\ngenerated (random weights, expect gibberish):");
+    println!("  {:?}", s);
+
+    println!("\n=== microbench: 50 forwards (n=32, d=32, 2 layers) ===");
+    let start = std::time::Instant::now();
+    let mut sink = 0.0f32;
+    for _ in 0..50 {
+        let l = model.forward(input);
+        sink += l.at(0, 0);
+    }
+    let elapsed = start.elapsed();
+    println!("50 forwards in {:.2}ms ({:.1}/sec)  sink={:.4}",
+        elapsed.as_secs_f64() * 1000.0,
+        50.0 / elapsed.as_secs_f64(),
+        sink,
+    );
+}

--- a/phases/10-llms-from-scratch/04-pre-training-mini-gpt/code/main.rs
+++ b/phases/10-llms-from-scratch/04-pre-training-mini-gpt/code/main.rs
@@ -323,21 +323,26 @@ impl MiniGPT {
 fn cross_entropy_loss(logits: &Mat, targets: &[usize]) -> f32 {
     let n = logits.rows;
     let v = logits.cols;
+    assert_eq!(targets.len(), n, "targets length must equal logits rows");
     let mut total = 0.0f32;
     for i in 0..n {
         let row = &logits.data[i * v..(i + 1) * v];
+        let t = targets[i];
+        assert!(t < v, "target index out of range for logits cols");
         let mut m = f32::NEG_INFINITY;
         for &x in row { if x > m { m = x; } }
         let mut s = 0.0f32;
         for &x in row { s += (x - m).exp(); }
         let log_sum = s.ln();
-        let log_softmax_t = row[targets[i]] - m - log_sum;
+        let log_softmax_t = row[t] - m - log_sum;
         total += -log_softmax_t;
     }
     total / n as f32
 }
 
 fn generate(model: &MiniGPT, prompt: &[usize], max_new: usize, temperature: f32, rng: &mut Rng) -> Vec<usize> {
+    assert!(!prompt.is_empty(), "prompt must be non-empty");
+    assert!(temperature > 0.0, "temperature must be > 0");
     let mut tokens: Vec<usize> = prompt.to_vec();
     let max_seq = model.max_seq;
     for _ in 0..max_new {

--- a/phases/10-llms-from-scratch/12-inference-optimization/code/main.rs
+++ b/phases/10-llms-from-scratch/12-inference-optimization/code/main.rs
@@ -1,0 +1,565 @@
+// Inference optimization: KV cache + speculative decoding sketch. Stdlib only.
+// Topic: prefill vs decode, KV cache memory layout, prefix cache trie, draft-verify loop.
+// References (cited in spirit, not as deps):
+//   - vLLM PagedAttention (Kwon 2023):    https://arxiv.org/abs/2309.06180
+//   - Speculative decoding (Leviathan):   https://arxiv.org/abs/2211.17192
+//   - candle KV cache:                    https://github.com/huggingface/candle/blob/main/candle-transformers/src/models/llama.rs
+//   - llm.c inference notes:              https://github.com/karpathy/llm.c
+//
+// Compile + run:  rustc --edition 2021 main.rs -o /tmp/inf && /tmp/inf
+
+use std::collections::HashMap;
+use std::f32::consts::PI;
+
+// ---------- xorshift64 RNG (deterministic, good distribution in low bits) ----------
+struct Rng { state: u64 }
+impl Rng {
+    fn new(seed: u64) -> Self {
+        let mut s = seed;
+        if s == 0 { s = 0xdead_beef_cafe_babe; }
+        Rng { state: s }
+    }
+    fn next_u64(&mut self) -> u64 {
+        let mut x = self.state;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.state = x;
+        x
+    }
+    fn next_u32(&mut self) -> u32 { (self.next_u64() >> 32) as u32 }
+    fn uniform(&mut self) -> f32 { (self.next_u32() as f32 + 1.0) / (u32::MAX as f32 + 2.0) }
+    fn gauss(&mut self) -> f32 {
+        let u1 = self.uniform();
+        let u2 = self.uniform();
+        (-2.0 * u1.ln()).sqrt() * (2.0 * PI * u2).cos()
+    }
+    fn range(&mut self, hi: usize) -> usize { (self.next_u32() as usize) % hi }
+    fn choice(&mut self, probs: &[f32]) -> usize {
+        let r = self.uniform();
+        let mut acc = 0.0;
+        for (i, p) in probs.iter().enumerate() {
+            acc += *p;
+            if r <= acc { return i; }
+        }
+        probs.len() - 1
+    }
+}
+
+// ---------- KVCache: layered [num_layers, num_heads, max_seq, head_dim] ----------
+struct KVCache {
+    num_layers: usize,
+    num_heads: usize,
+    head_dim: usize,
+    max_seq_len: usize,
+    bytes_per_element: usize,
+    k: Vec<f32>,
+    v: Vec<f32>,
+    seq_len: usize,
+}
+
+impl KVCache {
+    fn new(num_layers: usize, num_heads: usize, head_dim: usize, max_seq_len: usize) -> Self {
+        let total = num_layers * num_heads * max_seq_len * head_dim;
+        KVCache {
+            num_layers, num_heads, head_dim, max_seq_len,
+            bytes_per_element: 2, // simulate fp16
+            k: vec![0.0; total],
+            v: vec![0.0; total],
+            seq_len: 0,
+        }
+    }
+
+    fn idx(&self, layer: usize, head: usize, pos: usize, dim: usize) -> usize {
+        ((layer * self.num_heads + head) * self.max_seq_len + pos) * self.head_dim + dim
+    }
+
+    // Write new K/V slices of shape [n_new, num_heads, head_dim] for one layer.
+    fn update(&mut self, layer: usize, new_k: &[f32], new_v: &[f32], n_new: usize) {
+        assert_eq!(new_k.len(), n_new * self.num_heads * self.head_dim);
+        let start = self.seq_len;
+        for t in 0..n_new {
+            for h in 0..self.num_heads {
+                for d in 0..self.head_dim {
+                    let src = (t * self.num_heads + h) * self.head_dim + d;
+                    let dst = self.idx(layer, h, start + t, d);
+                    self.k[dst] = new_k[src];
+                    self.v[dst] = new_v[src];
+                }
+            }
+        }
+    }
+
+    fn advance(&mut self, n: usize) { self.seq_len += n; }
+
+    fn capacity_bytes(&self) -> usize {
+        2 * self.k.len() * self.bytes_per_element
+    }
+    fn used_bytes(&self) -> usize {
+        let per_tok = 2 * self.num_layers * self.num_heads * self.head_dim * self.bytes_per_element;
+        per_tok * self.seq_len
+    }
+}
+
+// ---------- Prefix cache trie (PagedAttention-style prefix sharing) ----------
+struct TrieNode {
+    children: HashMap<usize, usize>, // token -> node idx
+    hit_count: usize,
+}
+
+struct PrefixCache {
+    nodes: Vec<TrieNode>,
+    max_entries: usize,
+    hits: usize,
+    misses: usize,
+}
+
+impl PrefixCache {
+    fn new(max_entries: usize) -> Self {
+        PrefixCache {
+            nodes: vec![TrieNode { children: HashMap::new(), hit_count: 0 }],
+            max_entries,
+            hits: 0,
+            misses: 0,
+        }
+    }
+
+    fn walk(&self, tokens: &[usize]) -> usize {
+        let mut node = 0usize;
+        let mut depth = 0usize;
+        for &t in tokens {
+            match self.nodes[node].children.get(&t) {
+                Some(&next) => { node = next; depth += 1; }
+                None => break,
+            }
+        }
+        depth
+    }
+
+    fn lookup(&mut self, tokens: &[usize]) -> usize {
+        let depth = self.walk(tokens);
+        if depth > 0 {
+            self.hits += 1;
+            let mut node = 0usize;
+            for &t in tokens.iter().take(depth) {
+                node = *self.nodes[node].children.get(&t).unwrap();
+                self.nodes[node].hit_count += 1;
+            }
+        } else {
+            self.misses += 1;
+        }
+        depth
+    }
+
+    fn insert(&mut self, tokens: &[usize]) -> usize {
+        let mut node = 0usize;
+        for (i, &t) in tokens.iter().enumerate() {
+            if !self.nodes[node].children.contains_key(&t) {
+                if self.nodes.len() >= self.max_entries { return i; }
+                let new_idx = self.nodes.len();
+                self.nodes.push(TrieNode { children: HashMap::new(), hit_count: 0 });
+                self.nodes[node].children.insert(t, new_idx);
+            }
+            node = *self.nodes[node].children.get(&t).unwrap();
+        }
+        tokens.len()
+    }
+
+    fn hit_rate(&self) -> f32 {
+        let total = self.hits + self.misses;
+        if total == 0 { 0.0 } else { self.hits as f32 / total as f32 }
+    }
+}
+
+// ---------- Batching simulators ----------
+#[derive(Clone)]
+struct Request {
+    arrival: usize,
+    output_tokens: usize,
+    tokens_generated: usize,
+    start: usize,
+    end: usize,
+}
+impl Request {
+    fn new(arrival: usize, output_tokens: usize) -> Self {
+        Request { arrival, output_tokens, tokens_generated: 0, start: 0, end: 0 }
+    }
+    fn done(&self) -> bool { self.tokens_generated >= self.output_tokens }
+}
+
+fn simulate_static_batching(mut reqs: Vec<Request>, batch_size: usize) -> Vec<Request> {
+    reqs.sort_by_key(|r| r.arrival);
+    let mut step = 0;
+    let mut completed = Vec::new();
+    let mut idx = 0;
+    while idx < reqs.len() {
+        let mut batch: Vec<Request> = Vec::new();
+        while idx < reqs.len() && batch.len() < batch_size {
+            let mut r = reqs[idx].clone();
+            r.start = step.max(r.arrival);
+            batch.push(r);
+            idx += 1;
+        }
+        if !batch.is_empty() {
+            step = step.max(batch.iter().map(|r| r.start).max().unwrap());
+            let max_out = batch.iter().map(|r| r.output_tokens).max().unwrap();
+            for mut r in batch.into_iter() {
+                r.tokens_generated = r.output_tokens;
+                r.end = step + max_out;
+                completed.push(r);
+            }
+            step += max_out;
+        }
+    }
+    completed
+}
+
+fn simulate_continuous_batching(mut reqs: Vec<Request>, batch_size: usize) -> Vec<Request> {
+    reqs.sort_by_key(|r| r.arrival);
+    let mut step = 0usize;
+    let mut completed = Vec::new();
+    let mut waiting: Vec<Request> = Vec::new();
+    let mut active: Vec<Request> = Vec::new();
+    let mut idx = 0;
+
+    while idx < reqs.len() || !active.is_empty() || !waiting.is_empty() {
+        while idx < reqs.len() && reqs[idx].arrival <= step {
+            waiting.push(reqs[idx].clone());
+            idx += 1;
+        }
+        while !waiting.is_empty() && active.len() < batch_size {
+            let mut r = waiting.remove(0);
+            r.start = step;
+            active.push(r);
+        }
+        if active.is_empty() {
+            if !waiting.is_empty() { step += 1; continue; }
+            if idx < reqs.len() { step = reqs[idx].arrival; continue; }
+            break;
+        }
+        for r in active.iter_mut() { r.tokens_generated += 1; }
+        let mut still: Vec<Request> = Vec::new();
+        for mut r in active.drain(..) {
+            if r.done() {
+                r.end = step + 1;
+                completed.push(r);
+            } else {
+                still.push(r);
+            }
+        }
+        active = still;
+        step += 1;
+    }
+    completed
+}
+
+struct BatchStats {
+    avg_latency: f32,
+    p50: f32,
+    p99: f32,
+    total_time: f32,
+    throughput: f32,
+}
+
+fn batch_stats(completed: &[Request]) -> BatchStats {
+    let mut lats: Vec<f32> = completed.iter().map(|r| (r.end - r.arrival) as f32).collect();
+    lats.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let avg = lats.iter().sum::<f32>() / lats.len() as f32;
+    let p50 = lats[lats.len() / 2];
+    let p99 = lats[((lats.len() as f32 * 0.99) as usize).min(lats.len() - 1)];
+    let total = completed.iter().map(|r| r.end).max().unwrap() as f32
+        - completed.iter().map(|r| r.arrival).min().unwrap() as f32;
+    let total_tokens: usize = completed.iter().map(|r| r.output_tokens).sum();
+    let thr = if total > 0.0 { total_tokens as f32 / total } else { 0.0 };
+    BatchStats { avg_latency: avg, p50, p99, total_time: total, throughput: thr }
+}
+
+// ---------- Speculative decoding sketch ----------
+struct DraftModel { vocab: usize, acceptance_rate: f32 }
+struct TargetModel { vocab: usize }
+
+impl DraftModel {
+    fn generate(&self, k: usize, rng: &mut Rng) -> Vec<usize> {
+        (0..k).map(|_| rng.range(self.vocab)).collect()
+    }
+}
+
+impl TargetModel {
+    // Returns a (uniform) probability vector. A real target would sample its true distribution.
+    fn uniform_probs(&self) -> Vec<f32> { vec![1.0 / self.vocab as f32; self.vocab] }
+}
+
+#[allow(dead_code)]
+struct SpecResult {
+    total_tokens: usize,
+    spec_cost: f32,
+    seq_cost: f32,
+    speedup: f32,
+    avg_accepted: f32,
+}
+
+fn speculative_decode(
+    draft: &DraftModel, target: &TargetModel,
+    context: &[usize], num_spec: usize,
+    draft_cost: f32, target_cost: f32, verify_cost: f32,
+    max_tokens: usize,
+    rng: &mut Rng,
+) -> SpecResult {
+    let mut ctx: Vec<usize> = context.to_vec();
+    let mut total_tokens = 0usize;
+    let mut total_cost = 0.0f32;
+    let mut accepted_counts: Vec<usize> = Vec::new();
+
+    while total_tokens < max_tokens {
+        let draft_tokens = draft.generate(num_spec, rng);
+        total_cost += draft_cost * num_spec as f32;
+
+        // One verify pass scores all k tokens.
+        total_cost += verify_cost;
+
+        let mut accepted = 0usize;
+        for &tok in &draft_tokens {
+            let r = rng.uniform();
+            if r < draft.acceptance_rate {
+                accepted += 1;
+                ctx.push(tok);
+                total_tokens += 1;
+            } else {
+                let probs = target.uniform_probs();
+                let resampled = rng.choice(&probs);
+                ctx.push(resampled);
+                total_tokens += 1;
+                break;
+            }
+        }
+        accepted_counts.push(accepted);
+
+        if accepted == num_spec {
+            // Bonus token from target's free-standing prediction.
+            let probs = target.uniform_probs();
+            let bonus = rng.choice(&probs);
+            ctx.push(bonus);
+            total_tokens += 1;
+        }
+    }
+    let seq_cost = total_tokens as f32 * target_cost;
+    let avg_accept = accepted_counts.iter().sum::<usize>() as f32 / accepted_counts.len() as f32;
+    SpecResult {
+        total_tokens,
+        spec_cost: total_cost,
+        seq_cost,
+        speedup: if total_cost > 0.0 { seq_cost / total_cost } else { 1.0 },
+        avg_accepted: avg_accept,
+    }
+}
+
+// ---------- KV cache memory analysis ----------
+#[allow(dead_code)]
+struct ModelCfg {
+    name: &'static str,
+    num_layers: usize,
+    num_kv_heads: usize,
+    head_dim: usize,
+    params_b: f64,
+}
+
+fn kv_cache_mem(cfg: &ModelCfg, seq_len: usize, bytes: usize) -> (usize, f64) {
+    let per_token = 2 * cfg.num_layers * cfg.num_kv_heads * cfg.head_dim * bytes;
+    let total = per_token * seq_len;
+    (per_token, total as f64 / (1024.0 * 1024.0 * 1024.0))
+}
+
+fn main() {
+    let mut rng = Rng::new(42);
+
+    // --- Step 1: KV cache memory analysis ---
+    println!("{}", "=".repeat(70));
+    println!("STEP 1: KV cache memory per model");
+    println!("{}", "=".repeat(70));
+    let configs: [ModelCfg; 5] = [
+        ModelCfg { name: "Llama-3-8B",   num_layers: 32, num_kv_heads: 8, head_dim: 128, params_b: 8.0 },
+        ModelCfg { name: "Llama-3-70B",  num_layers: 80, num_kv_heads: 8, head_dim: 128, params_b: 70.0 },
+        ModelCfg { name: "Llama-3-405B", num_layers: 126, num_kv_heads: 8, head_dim: 128, params_b: 405.0 },
+        ModelCfg { name: "Mistral-7B",   num_layers: 32, num_kv_heads: 8, head_dim: 128, params_b: 7.0 },
+        ModelCfg { name: "GPT-4-est",    num_layers: 120, num_kv_heads: 96, head_dim: 128, params_b: 1800.0 },
+    ];
+    println!("  {:<20} {:>12} {:>12} {:>12} {:>12}", "Model", "Per Token", "@ 4K ctx", "@ 32K ctx", "@ 128K ctx");
+    println!("  {}", "-".repeat(70));
+    for c in &configs {
+        let (pt, _) = kv_cache_mem(c, 1, 2);
+        let (_, g4) = kv_cache_mem(c, 4096, 2);
+        let (_, g32) = kv_cache_mem(c, 32768, 2);
+        let (_, g128) = kv_cache_mem(c, 131072, 2);
+        println!("  {:<20} {:>10}KB {:>10.2}GB {:>10.2}GB {:>10.2}GB",
+            c.name, pt / 1024, g4, g32, g128);
+    }
+
+    // --- Step 2: KV cache with simulated attention writes ---
+    println!("\n{}", "=".repeat(70));
+    println!("STEP 2: KV cache prefill + decode");
+    println!("{}", "=".repeat(70));
+    let num_heads = 4usize;
+    let head_dim = 16usize;
+    let seq_len = 8usize;
+    let mut cache = KVCache::new(1, num_heads, head_dim, 128);
+
+    // Fake K/V tensors for prefill.
+    let n_prefill = seq_len;
+    let kv_size = n_prefill * num_heads * head_dim;
+    let k: Vec<f32> = (0..kv_size).map(|_| rng.gauss()).collect();
+    let v: Vec<f32> = (0..kv_size).map(|_| rng.gauss()).collect();
+    cache.update(0, &k, &v, n_prefill);
+    cache.advance(n_prefill);
+    println!("  prefill: {} tokens cached, used={} bytes (cap={} bytes)",
+        cache.seq_len, cache.used_bytes(), cache.capacity_bytes());
+
+    // Decode: 4 steps, each appending 1 token's K/V.
+    for step in 0..4 {
+        let kv_size = num_heads * head_dim;
+        let k_new: Vec<f32> = (0..kv_size).map(|_| rng.gauss()).collect();
+        let v_new: Vec<f32> = (0..kv_size).map(|_| rng.gauss()).collect();
+        cache.update(0, &k_new, &v_new, 1);
+        cache.advance(1);
+        println!("  decode step {}: cache={} tokens, used={} bytes",
+            step + 1, cache.seq_len, cache.used_bytes());
+    }
+
+    // --- Step 3: static vs continuous batching ---
+    println!("\n{}", "=".repeat(70));
+    println!("STEP 3: static vs continuous batching");
+    println!("{}", "=".repeat(70));
+
+    let make_reqs = |seed: u64, n: usize| -> Vec<Request> {
+        let mut r = Rng::new(seed);
+        let mut out = Vec::with_capacity(n);
+        for _ in 0..n {
+            let arrival = r.range(20);
+            // Pareto-ish: heavy tail via inverse uniform.
+            let u = r.uniform().max(1e-3);
+            let out_len = ((1.0 / u.powf(1.0 / 1.5)) * 15.0) as usize + 5;
+            let out_len = out_len.min(200);
+            out.push(Request::new(arrival, out_len));
+        }
+        out
+    };
+    let batch_size = 8usize;
+    let s = simulate_static_batching(make_reqs(42, 30), batch_size);
+    let c = simulate_continuous_batching(make_reqs(42, 30), batch_size);
+    let ss = batch_stats(&s);
+    let cs = batch_stats(&c);
+    println!("  30 requests, batch_size={}", batch_size);
+    println!("  {:<14} {:>12} {:>12} {:>12}", "Metric", "Static", "Continuous", "Delta");
+    println!("  {}", "-".repeat(54));
+    let print_delta = |name: &str, sv: f32, cv: f32, smaller_better: bool| {
+        let delta = if smaller_better {
+            if sv > 0.0 { format!("{:+.1}%", (sv - cv) / sv * 100.0) } else { "n/a".to_string() }
+        } else {
+            if sv > 0.0 { format!("{:.2}x", cv / sv) } else { "n/a".to_string() }
+        };
+        println!("  {:<14} {:>12.1} {:>12.1} {:>12}", name, sv, cv, delta);
+    };
+    print_delta("avg_latency", ss.avg_latency, cs.avg_latency, true);
+    print_delta("p50_latency", ss.p50, cs.p50, true);
+    print_delta("p99_latency", ss.p99, cs.p99, true);
+    print_delta("total_time",  ss.total_time, cs.total_time, true);
+    print_delta("throughput",  ss.throughput, cs.throughput, false);
+
+    // --- Step 4: prefix cache ---
+    println!("\n{}", "=".repeat(70));
+    println!("STEP 4: prefix caching for shared system prompts");
+    println!("{}", "=".repeat(70));
+    let mut pc = PrefixCache::new(5000);
+    let prompts: Vec<Vec<usize>> = vec![
+        (100..200).collect(),
+        (200..350).collect(),
+        (400..480).collect(),
+    ];
+    for (i, p) in prompts.iter().enumerate() {
+        let inserted = pc.insert(p);
+        println!("  cached system prompt {}: {} tokens, {} new nodes inserted", i + 1, p.len(), inserted);
+    }
+
+    let mut hit_count = 0usize;
+    let mut tokens_saved = 0usize;
+    for _ in 0..100 {
+        let idx = rng.range(prompts.len());
+        let sys = &prompts[idx];
+        let user_len = 20 + rng.range(30);
+        let mut full = sys.clone();
+        full.extend((0..user_len).map(|_| 500 + rng.range(500)));
+        let depth = pc.lookup(&full);
+        if depth > 0 { hit_count += 1; tokens_saved += depth; }
+    }
+    println!("  hit rate: {:.1}%", pc.hit_rate() * 100.0);
+    println!("  tokens saved (prefix reuse): {}", tokens_saved);
+    println!("  avg saved per hit: {:.1}", tokens_saved as f32 / hit_count.max(1) as f32);
+
+    // --- Step 5: speculative decoding ---
+    println!("\n{}", "=".repeat(70));
+    println!("STEP 5: speculative decoding speedup (sketch)");
+    println!("{}", "=".repeat(70));
+    let vocab = 500usize;
+    let trials = 10usize;
+    let strategies: [(&str, f32, usize); 3] = [
+        ("draft-target (8B->70B)", 0.78, 5),
+        ("EAGLE",                  0.85, 6),
+        ("n-gram lookup",          0.50, 4),
+    ];
+    println!("  {:<24} {:>14} {:>12} {:>10}", "Strategy", "AcceptRate", "AvgAccept", "Speedup");
+    println!("  {}", "-".repeat(64));
+    for (name, acc, k) in strategies {
+        let mut speedups = 0.0f32;
+        let mut accept_rates = 0.0f32;
+        let mut avg_accepts = 0.0f32;
+        for _ in 0..trials {
+            let draft = DraftModel { vocab, acceptance_rate: acc };
+            let target = TargetModel { vocab };
+            let ctx: Vec<usize> = (0..10).map(|_| rng.range(vocab)).collect();
+            let r = speculative_decode(&draft, &target, &ctx, k, 1.0, 10.0, 12.0, 100, &mut rng);
+            speedups += r.speedup;
+            accept_rates += r.avg_accepted / k as f32;
+            avg_accepts += r.avg_accepted;
+        }
+        println!("  {:<24} {:>13.1}% {:>12.2} {:>9.2}x",
+            name,
+            accept_rates / trials as f32 * 100.0,
+            avg_accepts / trials as f32,
+            speedups / trials as f32,
+        );
+    }
+
+    // --- Step 6: ops:byte ---
+    println!("\n{}", "=".repeat(70));
+    println!("STEP 6: ops:byte and memory vs compute bound");
+    println!("{}", "=".repeat(70));
+    let a100_tflops = 312.0f32;
+    let a100_bandwidth_tbs = 2.0f32;
+    let crossover = a100_tflops / a100_bandwidth_tbs;
+    println!("  A100 specs: {} TFLOPS, {} TB/s bandwidth, crossover ops:byte = {:.0}",
+        a100_tflops, a100_bandwidth_tbs, crossover);
+    let scenarios: [(&str, usize); 7] = [
+        ("Prefill, batch=1, seq=4096", 4096),
+        ("Decode, batch=1",   1),
+        ("Decode, batch=8",   8),
+        ("Decode, batch=32",  32),
+        ("Decode, batch=128", 128),
+        ("Decode, batch=256", 256),
+        ("Decode, batch=512", 512),
+    ];
+    println!("  {:<32} {:>10} {:>12} {:>12}", "Scenario", "Ops:Byte", "Bound", "Utilization");
+    println!("  {}", "-".repeat(70));
+    for (name, opb) in scenarios {
+        let bound = if opb as f32 >= crossover { "Compute" } else { "Memory" };
+        let util = if bound == "Memory" { opb as f32 / crossover * 100.0 } else { 100.0 };
+        println!("  {:<32} {:>10} {:>12} {:>11.1}%", name, opb, bound, util);
+    }
+
+    println!("\n{}", "=".repeat(70));
+    println!("SUMMARY");
+    println!("{}", "=".repeat(70));
+    println!("  1. KV cache trades memory for compute; per-token cost scales with layers x kv_heads x head_dim.");
+    println!("  2. Continuous batching keeps the GPU busy as requests retire mid-batch.");
+    println!("  3. Prefix caching shares KV entries across shared system prompts.");
+    println!("  4. Speculative decoding amortizes verification across k draft tokens.");
+    println!("  5. Decode is memory bound at small batch; raise batch until ops:byte clears crossover.");
+}

--- a/phases/10-llms-from-scratch/12-inference-optimization/code/main.rs
+++ b/phases/10-llms-from-scratch/12-inference-optimization/code/main.rs
@@ -77,7 +77,10 @@ impl KVCache {
     // Write new K/V slices of shape [n_new, num_heads, head_dim] for one layer.
     fn update(&mut self, layer: usize, new_k: &[f32], new_v: &[f32], n_new: usize) {
         assert_eq!(new_k.len(), n_new * self.num_heads * self.head_dim);
+        assert_eq!(new_v.len(), n_new * self.num_heads * self.head_dim);
+        assert!(layer < self.num_layers, "layer index out of range");
         let start = self.seq_len;
+        assert!(start + n_new <= self.max_seq_len, "KV cache capacity exceeded");
         for t in 0..n_new {
             for h in 0..self.num_heads {
                 for d in 0..self.head_dim {
@@ -319,6 +322,7 @@ fn speculative_decode(
 
         let mut accepted = 0usize;
         for &tok in &draft_tokens {
+            if total_tokens >= max_tokens { break; }
             let r = rng.uniform();
             if r < draft.acceptance_rate {
                 accepted += 1;
@@ -334,7 +338,7 @@ fn speculative_decode(
         }
         accepted_counts.push(accepted);
 
-        if accepted == num_spec {
+        if accepted == num_spec && total_tokens < max_tokens {
             // Bonus token from target's free-standing prediction.
             let probs = target.uniform_probs();
             let bonus = rng.choice(&probs);


### PR DESCRIPTION
## Summary

Adds idiomatic Rust ports to 5 lessons where systems-level memory layout adds genuine pedagogical value over the existing Python references.

- **Phase 07 / 02 self-attention-from-scratch**: scaled dot-product attention on row-major `Vec<f32>` tiles, ASCII heatmap, softmax stability demo, 10K-forward microbench.
- **Phase 07 / 03 multi-head-attention**: MHA with explicit `split_heads`/`combine_heads`, plus a Grouped-Query Attention variant showing the MHA-vs-GQA KV cache ratio.
- **Phase 07 / 04 positional-encoding**: sinusoidal table, RoPE even/odd-pair rotation (numerically demonstrates the relative-distance dot-product property), ALiBi linear bias.
- **Phase 10 / 04 pre-training-mini-gpt**: end-to-end forward pass (token + pos embedding, N pre-LN blocks with causal MHA + ReLU FFN, tied LM head). Random-init loss matches `ln(vocab)` as expected.
- **Phase 10 / 12 inference-optimization**: per-model KV cache memory table, layered KVCache with explicit `[layer, head, pos, dim]` indexing, static-vs-continuous batching simulator, prefix-cache trie, speculative-decoding draft/verify sketch, ops:byte memory-vs-compute table.

Every file is single-file `rustc --edition 2021 main.rs -o /tmp/X && /tmp/X`, stdlib only, with a 4-6 line header citing the references that informed each port (candle, llm.c, original papers).

## Test plan

- [x] `rustc --edition 2021` compiles each `main.rs` cleanly (no errors, no warnings)
- [x] Each binary runs end to end and prints sensible output
- [x] `python scripts/audit_lessons.py` clean (435 lessons, 0 issues)
- [x] `python scripts/build_catalog.py` rebuilt catalog.json
- [x] Atomic per-lesson commits (5 lesson commits + 1 catalog rebuild)