### PR TITLE
feat: julia ports for 8 math + deep-learning lessons

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -6,7 +6,7 @@
     "skills": 378,
     "prompts": 99,
     "agents": 0,
-    "code_files": 435
+    "code_files": 443
   },
   "phases": [
     {
@@ -306,7 +306,8 @@
           "has_quiz": true,
           "has_notebook": false,
           "code_files": [
-            "derivatives.py"
+            "derivatives.py",
+            "main.jl"
           ],
           "outputs": [
             {
@@ -333,7 +334,8 @@
           "has_quiz": true,
           "has_notebook": false,
           "code_files": [
-            "autodiff.py"
+            "autodiff.py",
+            "main.jl"
           ],
           "outputs": [
             {
@@ -356,6 +358,7 @@
           "has_quiz": true,
           "has_notebook": false,
           "code_files": [
+            "main.jl",
             "probability.py"
           ],
           "outputs": [
@@ -406,6 +409,7 @@
           "has_quiz": true,
           "has_notebook": false,
           "code_files": [
+            "main.jl",
             "optimizers.py"
           ],
           "outputs": [
@@ -1261,6 +1265,7 @@
           "has_quiz": true,
           "has_notebook": false,
           "code_files": [
+            "main.jl",
             "perceptron.py"
           ],
           "outputs": [
@@ -1312,6 +1317,7 @@
           "has_quiz": true,
           "has_notebook": false,
           "code_files": [
+            "main.jl",
             "main.py"
           ],
           "outputs": [
@@ -1335,6 +1341,7 @@
           "has_quiz": true,
           "has_notebook": false,
           "code_files": [
+            "main.jl",
             "main.py"
           ],
           "outputs": [
@@ -1358,6 +1365,7 @@
           "has_quiz": true,
           "has_notebook": false,
           "code_files": [
+            "main.jl",
             "main.py"
           ],
           "outputs": [

--- a/phases/01-math-foundations/04-calculus-for-ml/code/main.jl
+++ b/phases/01-math-foundations/04-calculus-for-ml/code/main.jl
@@ -1,0 +1,278 @@
+# Calculus for ML in Julia. Numerical + analytical derivatives,
+# multivariate gradients, gradient descent, Hessian curvature,
+# Taylor expansion, and a tiny linear regression trained by SGD.
+# Stdlib only. Sources:
+#   https://docs.julialang.org/en/v1/manual/functions/
+#   https://docs.julialang.org/en/v1/stdlib/LinearAlgebra/
+#   https://docs.julialang.org/en/v1/manual/arrays/
+
+using Random
+using LinearAlgebra
+using Printf
+
+
+function numerical_derivative(f, x::Float64; h::Float64=1e-7)::Float64
+    return (f(x + h) - f(x - h)) / (2h)
+end
+
+
+function numerical_gradient(f, point::Vector{Float64}; h::Float64=1e-7)::Vector{Float64}
+    n = length(point)
+    grad = zeros(Float64, n)
+    for i in 1:n
+        plus = copy(point)
+        minus = copy(point)
+        plus[i] += h
+        minus[i] -= h
+        grad[i] = (f(plus) - f(minus)) / (2h)
+    end
+    return grad
+end
+
+
+function gradient_descent_1d(df, x0::Float64; lr::Float64=0.1, steps::Int=20)
+    x = x0
+    history = Tuple{Int, Float64, Float64}[]
+    for step in 0:(steps - 1)
+        g = df(x)
+        x -= lr * g
+        push!(history, (step, x, x * x))
+    end
+    return x, history
+end
+
+
+function hessian_2d(f, x::Float64, y::Float64; h::Float64=1e-5)
+    fxx = (f(x + h, y) - 2 * f(x, y) + f(x - h, y)) / (h * h)
+    fyy = (f(x, y + h) - 2 * f(x, y) + f(x, y - h)) / (h * h)
+    fxy = (f(x + h, y + h) - f(x + h, y - h) - f(x - h, y + h) + f(x - h, y - h)) / (4 * h * h)
+    return Float64[fxx fxy; fxy fyy]
+end
+
+
+function hessian_eigenvalues(H::Matrix{Float64})
+    # Symmetric Hessian has real eigenvalues. Use stdlib eigvals via the LinearAlgebra dependency.
+    return eigvals(Symmetric(H))
+end
+
+
+function taylor_approx(f, f_prime, f_double_prime, x0::Float64, h::Float64; order::Int=2)::Float64
+    result = f(x0)
+    if order >= 1
+        result += f_prime(x0) * h
+    end
+    if order >= 2
+        result += 0.5 * f_double_prime(x0) * h * h
+    end
+    return result
+end
+
+
+function demo_numerical_vs_analytical()
+    println("=" ^ 55)
+    println("NUMERICAL vs ANALYTICAL DERIVATIVES")
+    println("=" ^ 55)
+
+    cases = [
+        ("x^2", x -> x^2, x -> 2x),
+        ("x^3", x -> x^3, x -> 3 * x^2),
+        ("sin(x)", x -> sin(x), x -> cos(x)),
+        ("e^x", x -> exp(x), x -> exp(x)),
+        ("1/x", x -> 1 / x, x -> -1 / x^2),
+    ]
+
+    x = 2.0
+    println("\nAt x = $x:")
+    @printf("%-12s %12s %12s %12s\n", "Function", "Numerical", "Analytical", "Error")
+    println("-" ^ 50)
+    for (name, f, df) in cases
+        num = numerical_derivative(f, x)
+        ana = df(x)
+        err = abs(num - ana)
+        @printf("%-12s %12.6f %12.6f %12.2e\n", name, num, ana, err)
+    end
+end
+
+
+function demo_gradient()
+    println("\n" * "=" ^ 55)
+    println("GRADIENT (VECTOR OF PARTIAL DERIVATIVES)")
+    println("=" ^ 55)
+
+    f = p -> p[1]^2 + 3 * p[1] * p[2] + p[2]^2
+
+    point = Float64[1.0, 2.0]
+    grad = numerical_gradient(f, point)
+    analytical = Float64[2 * point[1] + 3 * point[2], 3 * point[1] + 2 * point[2]]
+
+    println("\nf(x, y) = x^2 + 3xy + y^2")
+    println("At point ($(point[1]), $(point[2])):")
+    @printf("  Numerical gradient:  [%.4f, %.4f]\n", grad[1], grad[2])
+    @printf("  Analytical gradient: [%.1f, %.1f]\n", analytical[1], analytical[2])
+end
+
+
+function demo_gradient_descent_1d()
+    println("\n" * "=" ^ 55)
+    println("GRADIENT DESCENT: f(x) = x^2")
+    println("=" ^ 55)
+
+    x = 5.0
+    lr = 0.1
+    println("\nStart: x=$x, lr=$lr")
+    for step in 0:19
+        g = 2x
+        x -= lr * g
+        if step % 4 == 0 || step == 19
+            @printf("  step %2d  x=%8.4f  f(x)=%10.6f\n", step, x, x * x)
+        end
+    end
+    @printf("Minimum found at x=%.6f (true minimum: x=0)\n", x)
+end
+
+
+function demo_gradient_descent_2d()
+    println("\n" * "=" ^ 55)
+    println("GRADIENT DESCENT: f(x, y) = x^2 + y^2")
+    println("=" ^ 55)
+
+    f = p -> p[1]^2 + p[2]^2
+    point = Float64[4.0, 3.0]
+    lr = 0.1
+    @printf("\nStart: (%.1f, %.1f), lr=%.2f\n", point[1], point[2], lr)
+    for step in 0:29
+        g = numerical_gradient(f, point)
+        point .-= lr .* g
+        if step % 5 == 0 || step == 29
+            @printf("  step %2d  (%7.4f, %7.4f)  f=%.6f\n", step, point[1], point[2], f(point))
+        end
+    end
+    @printf("Minimum found at (%.4f, %.4f) (true: (0, 0))\n", point[1], point[2])
+end
+
+
+function demo_hessian()
+    println("\n" * "=" ^ 55)
+    println("HESSIAN MATRIX: SADDLE POINT vs MINIMUM")
+    println("=" ^ 55)
+
+    saddle = (x, y) -> x^2 - y^2
+    bowl = (x, y) -> x^2 + y^2
+    rosenbrock = (x, y) -> (1 - x)^2 + 100 * (y - x^2)^2
+
+    println("\nf(x, y) = x^2 - y^2 (saddle function)")
+    H = hessian_2d(saddle, 0.0, 0.0)
+    evals = hessian_eigenvalues(H)
+    println("  Hessian at (0, 0):")
+    @printf("    [%6.2f  %6.2f]\n", H[1, 1], H[1, 2])
+    @printf("    [%6.2f  %6.2f]\n", H[2, 1], H[2, 2])
+    @printf("  Eigenvalues: %.2f, %.2f\n", evals[1], evals[2])
+    println("  Mixed signs => SADDLE POINT")
+
+    println("\nf(x, y) = x^2 + y^2 (bowl function)")
+    H = hessian_2d(bowl, 0.0, 0.0)
+    evals = hessian_eigenvalues(H)
+    println("  Hessian at (0, 0):")
+    @printf("    [%6.2f  %6.2f]\n", H[1, 1], H[1, 2])
+    @printf("    [%6.2f  %6.2f]\n", H[2, 1], H[2, 2])
+    @printf("  Eigenvalues: %.2f, %.2f\n", evals[1], evals[2])
+    println("  Both positive => LOCAL MINIMUM")
+
+    println("\nRosenbrock f(x, y) = (1-x)^2 + 100(y - x^2)^2")
+    H = hessian_2d(rosenbrock, 1.0, 1.0)
+    evals = hessian_eigenvalues(H)
+    println("  Hessian at minimum (1, 1):")
+    @printf("    [%8.2f  %8.2f]\n", H[1, 1], H[1, 2])
+    @printf("    [%8.2f  %8.2f]\n", H[2, 1], H[2, 2])
+    @printf("  Eigenvalues: %.2f, %.2f\n", evals[1], evals[2])
+    println("  Both positive => LOCAL MINIMUM (confirmed)")
+end
+
+
+function demo_taylor()
+    println("\n" * "=" ^ 55)
+    println("TAYLOR SERIES APPROXIMATION")
+    println("=" ^ 55)
+
+    x0 = 1.0
+    println("\nApproximating f(x) = e^x near x0 = $x0")
+    @printf("%8s  %14s  %10s  %10s  %10s\n", "h", "True f(x0+h)", "Order 0", "Order 1", "Order 2")
+    println("-" ^ 60)
+    for h in [0.1, 0.5, 1.0, 2.0]
+        true_val = exp(x0 + h)
+        t0 = taylor_approx(exp, exp, exp, x0, h; order=0)
+        t1 = taylor_approx(exp, exp, exp, x0, h; order=1)
+        t2 = taylor_approx(exp, exp, exp, x0, h; order=2)
+        @printf("%8.1f  %14.6f  %10.6f  %10.6f  %10.6f\n", h, true_val, t0, t1, t2)
+    end
+
+    println("\nApproximating f(x) = sin(x) near x0 = 0")
+    @printf("%8s  %14s  %10s  %10s  %10s\n", "h", "True sin(h)", "Order 0", "Order 1", "Order 2")
+    println("-" ^ 60)
+    for h in [0.1, 0.5, 1.0, 2.0]
+        true_val = sin(h)
+        t0 = taylor_approx(sin, cos, x -> -sin(x), 0.0, h; order=0)
+        t1 = taylor_approx(sin, cos, x -> -sin(x), 0.0, h; order=1)
+        t2 = taylor_approx(sin, cos, x -> -sin(x), 0.0, h; order=2)
+        @printf("%8.1f  %14.6f  %10.6f  %10.6f  %10.6f\n", h, true_val, t0, t1, t2)
+    end
+
+    println("\nKey insight: more terms = better approximation near x0,")
+    println("but all Taylor approximations diverge far from x0.")
+end
+
+
+function demo_linear_regression()
+    println("\n" * "=" ^ 55)
+    println("GRADIENT DESCENT: LINEAR REGRESSION y = 2x + 1")
+    println("=" ^ 55)
+
+    Random.seed!(42)
+    w = randn()
+    b = randn()
+    lr = 0.01
+
+    xs = Float64[1, 2, 3, 4, 5]
+    ys = Float64[3, 5, 7, 9, 11]
+    n = length(xs)
+
+    for epoch in 0:199
+        total_loss = 0.0
+        dw = 0.0
+        db = 0.0
+        for i in 1:n
+            pred = w * xs[i] + b
+            err = pred - ys[i]
+            total_loss += err * err
+            dw += 2 * err * xs[i]
+            db += 2 * err
+        end
+        dw /= n
+        db /= n
+        total_loss /= n
+        w -= lr * dw
+        b -= lr * db
+        if epoch % 40 == 0 || epoch == 199
+            @printf("  epoch %3d  w=%.4f  b=%.4f  loss=%.6f\n", epoch, w, b, total_loss)
+        end
+    end
+
+    @printf("\nLearned: y = %.2fx + %.2f\n", w, b)
+    println("Actual:  y = 2.00x + 1.00")
+end
+
+
+function main()
+    demo_numerical_vs_analytical()
+    demo_gradient()
+    demo_gradient_descent_1d()
+    demo_gradient_descent_2d()
+    demo_hessian()
+    demo_taylor()
+    demo_linear_regression()
+end
+
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    main()
+end

--- a/phases/01-math-foundations/05-chain-rule-and-autodiff/code/main.jl
+++ b/phases/01-math-foundations/05-chain-rule-and-autodiff/code/main.jl
@@ -1,0 +1,382 @@
+# Toy reverse-mode autodiff in Julia. Builds a computation graph from
+# operator overloads on a mutable Value type, runs a topological sort,
+# then walks backward applying local chain-rule closures.
+# Stdlib only. Sources:
+#   https://docs.julialang.org/en/v1/manual/methods/
+#   https://docs.julialang.org/en/v1/manual/constructors/
+#   https://docs.julialang.org/en/v1/base/base/#Base.@kwdef
+
+using Random
+using Printf
+
+import Base: +, -, *, /, ^
+
+
+mutable struct Value
+    data::Float64
+    grad::Float64
+    backward!::Function
+    children::Vector{Value}
+    op::String
+end
+
+Value(x::Real) = Value(Float64(x), 0.0, () -> nothing, Value[], "leaf")
+Value(x::Real, children::Vector{Value}, op::String) =
+    Value(Float64(x), 0.0, () -> nothing, children, op)
+
+
+function Base.show(io::IO, v::Value)
+    @printf(io, "Value(data=%.4f, grad=%.4f)", v.data, v.grad)
+end
+
+
+function +(a::Value, b::Value)
+    out = Value(a.data + b.data, Value[a, b], "+")
+    out.backward! = () -> begin
+        a.grad += out.grad
+        b.grad += out.grad
+    end
+    return out
+end
++(a::Value, b::Real) = a + Value(b)
++(a::Real, b::Value) = Value(a) + b
+
+
+function *(a::Value, b::Value)
+    out = Value(a.data * b.data, Value[a, b], "*")
+    out.backward! = () -> begin
+        a.grad += b.data * out.grad
+        b.grad += a.data * out.grad
+    end
+    return out
+end
+*(a::Value, b::Real) = a * Value(b)
+*(a::Real, b::Value) = Value(a) * b
+
+
+-(a::Value) = a * Value(-1.0)
+-(a::Value, b::Value) = a + (-b)
+-(a::Value, b::Real) = a + Value(-b)
+-(a::Real, b::Value) = Value(a) + (-b)
+
+
+function ^(a::Value, n::Real)
+    nf = Float64(n)
+    out = Value(a.data ^ nf, Value[a], "^$nf")
+    out.backward! = () -> begin
+        a.grad += nf * a.data ^ (nf - 1) * out.grad
+    end
+    return out
+end
+
+
+function /(a::Value, b::Value)
+    return a * (b ^ -1)
+end
+/(a::Value, b::Real) = a * Value(1 / b)
+/(a::Real, b::Value) = Value(a) * (b ^ -1)
+
+
+function relu(a::Value)
+    out = Value(max(0.0, a.data), Value[a], "relu")
+    out.backward! = () -> begin
+        a.grad += (out.data > 0 ? 1.0 : 0.0) * out.grad
+    end
+    return out
+end
+
+
+function _tanh(a::Value)
+    t = tanh(a.data)
+    out = Value(t, Value[a], "tanh")
+    out.backward! = () -> begin
+        a.grad += (1 - t * t) * out.grad
+    end
+    return out
+end
+
+
+function _exp(a::Value)
+    e = exp(a.data)
+    out = Value(e, Value[a], "exp")
+    out.backward! = () -> begin
+        a.grad += e * out.grad
+    end
+    return out
+end
+
+
+function _log(a::Value)
+    out = Value(log(a.data), Value[a], "log")
+    out.backward! = () -> begin
+        a.grad += (1 / a.data) * out.grad
+    end
+    return out
+end
+
+
+function backward!(root::Value)
+    topo = Value[]
+    visited = Set{UInt}()
+    function build_topo(v::Value)
+        oid = objectid(v)
+        if !(oid in visited)
+            push!(visited, oid)
+            for c in v.children
+                build_topo(c)
+            end
+            push!(topo, v)
+        end
+    end
+    build_topo(root)
+    root.grad = 1.0
+    for v in reverse(topo)
+        v.backward!()
+    end
+end
+
+
+function demo_basic()
+    println("=== Basic: y = relu(x1 * x2 + 1) ===")
+    x1 = Value(2.0)
+    x2 = Value(3.0)
+    y = relu(x1 * x2 + 1.0)
+    backward!(y)
+    println("  x1 = 2.0, x2 = 3.0")
+    @printf("  y = %.4f\n", y.data)
+    @printf("  dy/dx1 = %.4f  (expected 3.0)\n", x1.grad)
+    @printf("  dy/dx2 = %.4f  (expected 2.0)\n", x2.grad)
+    @assert abs(x1.grad - 3.0) < 1e-6
+    @assert abs(x2.grad - 2.0) < 1e-6
+    println("  PASSED\n")
+end
+
+
+function demo_power()
+    println("=== Power: y = x^3, dy/dx at x=2 ===")
+    x = Value(2.0)
+    y = x ^ 3
+    backward!(y)
+    @printf("  x = 2.0\n")
+    @printf("  y = %.4f  (expected 8.0)\n", y.data)
+    @printf("  dy/dx = %.4f  (expected 12.0 = 3*x^2)\n", x.grad)
+    @assert abs(x.grad - 12.0) < 1e-6
+    println("  PASSED\n")
+end
+
+
+function demo_complex()
+    println("=== Complex: f = relu(a*b + c) ===")
+    a = Value(2.0)
+    b = Value(-3.0)
+    c = Value(10.0)
+    f = relu(a * b + c)
+    backward!(f)
+    @printf("  a=2, b=-3, c=10\n")
+    @printf("  f = %.4f  (expected 4.0)\n", f.data)
+    @printf("  df/da = %.4f  (expected -3.0)\n", a.grad)
+    @printf("  df/db = %.4f  (expected 2.0)\n",  b.grad)
+    @printf("  df/dc = %.4f  (expected 1.0)\n",  c.grad)
+    @assert abs(a.grad + 3.0) < 1e-6
+    @assert abs(b.grad - 2.0) < 1e-6
+    @assert abs(c.grad - 1.0) < 1e-6
+    println("  PASSED\n")
+end
+
+
+function demo_neuron()
+    println("=== Single neuron: y = relu(w1*x1 + w2*x2 + b) ===")
+    w1 = Value(0.5)
+    w2 = Value(-1.5)
+    x1 = Value(3.0)
+    x2 = Value(2.0)
+    b = Value(0.1)
+    y = relu(w1 * x1 + w2 * x2 + b)
+    backward!(y)
+    pre = w1.data * x1.data + w2.data * x2.data + b.data
+    @printf("  w1=%.1f w2=%.1f x1=%.1f x2=%.1f b=%.1f\n", w1.data, w2.data, x1.data, x2.data, b.data)
+    @printf("  pre_act = %.4f\n", pre)
+    @printf("  y = %.4f\n", y.data)
+    @printf("  dy/dw1=%.4f dy/dw2=%.4f dy/dx1=%.4f dy/dx2=%.4f dy/db=%.4f\n",
+            w1.grad, w2.grad, x1.grad, x2.grad, b.grad)
+    if pre > 0
+        @assert abs(w1.grad - x1.data) < 1e-6
+        @assert abs(b.grad - 1.0) < 1e-6
+        println("  PASSED (relu active)\n")
+    else
+        @assert abs(w1.grad) < 1e-6
+        println("  PASSED (relu inactive)\n")
+    end
+end
+
+
+function demo_exp_log()
+    println("=== Exp and Log operations ===")
+    x = Value(2.0)
+    y = _exp(x)
+    backward!(y)
+    @printf("  exp(2.0) = %.4f  (expected %.4f)\n", y.data, exp(2.0))
+    @printf("  d/dx exp(x) at x=2 = %.4f  (expected %.4f)\n", x.grad, exp(2.0))
+    @assert abs(x.grad - exp(2.0)) < 1e-4
+    println("  PASSED\n")
+
+    x = Value(3.0)
+    y = _log(x)
+    backward!(y)
+    @printf("  log(3.0) = %.4f  (expected %.4f)\n", y.data, log(3.0))
+    @printf("  d/dx log(x) at x=3 = %.4f  (expected %.4f)\n", x.grad, 1 / 3)
+    @assert abs(x.grad - 1 / 3) < 1e-4
+    println("  PASSED\n")
+end
+
+
+function gradient_check(build_expr, x_val::Float64; h::Float64=1e-7)
+    x = Value(x_val)
+    y = build_expr(x)
+    backward!(y)
+    autodiff_grad = x.grad
+
+    y_plus = build_expr(Value(x_val + h)).data
+    y_minus = build_expr(Value(x_val - h)).data
+    numerical_grad = (y_plus - y_minus) / (2h)
+
+    return autodiff_grad, numerical_grad, abs(autodiff_grad - numerical_grad)
+end
+
+
+function demo_gradient_check()
+    println("=== Gradient Checking ===")
+    cases = [
+        ("x^3 + 2x + 1", x -> x ^ 3 + x * 2 + 1.0),
+        ("tanh(x^2)", x -> _tanh(x ^ 2)),
+        ("(x+1) / (x^2+1)", x -> (x + 1.0) * ((x ^ 2 + 1.0) ^ -1)),
+        ("exp(x) * x", x -> _exp(x) * x),
+        ("log(x^2 + 1)", x -> _log(x ^ 2 + 1.0)),
+    ]
+    @printf("  %-22s %12s %12s %12s\n", "Expression", "Autodiff", "Numerical", "Diff")
+    println("  " * "-" ^ 60)
+    all_passed = true
+    for (name, expr) in cases
+        ad, num, diff = gradient_check(expr, 0.5)
+        status = diff < 1e-5 ? "OK" : "FAIL"
+        if diff >= 1e-5
+            all_passed = false
+        end
+        @printf("  %-22s %12.8f %12.8f %12.2e  %s\n", name, ad, num, diff, status)
+    end
+    println(all_passed ? "  ALL CHECKS PASSED\n" : "  SOME CHECKS FAILED\n")
+end
+
+
+# Tiny MLP using our autodiff.
+struct Neuron
+    w::Vector{Value}
+    b::Value
+end
+
+function Neuron(n_inputs::Int)
+    w = [Value(rand() * 2 - 1) for _ in 1:n_inputs]
+    return Neuron(w, Value(0.0))
+end
+
+function (n::Neuron)(x::Vector{Value})
+    act = n.b
+    for i in eachindex(x)
+        act = act + n.w[i] * x[i]
+    end
+    return _tanh(act)
+end
+
+parameters(n::Neuron) = vcat(n.w, [n.b])
+
+
+struct Layer
+    neurons::Vector{Neuron}
+end
+
+Layer(n_in::Int, n_out::Int) = Layer([Neuron(n_in) for _ in 1:n_out])
+(l::Layer)(x::Vector{Value}) = [n(x) for n in l.neurons]
+parameters(l::Layer) = vcat([parameters(n) for n in l.neurons]...)
+
+
+struct MLP
+    layers::Vector{Layer}
+end
+
+function MLP(sizes::Vector{Int})
+    layers = Layer[]
+    for i in 1:(length(sizes) - 1)
+        push!(layers, Layer(sizes[i], sizes[i + 1]))
+    end
+    return MLP(layers)
+end
+
+function (m::MLP)(x::Vector{Value})
+    out = x
+    for layer in m.layers
+        out = layer(out)
+    end
+    return length(out) == 1 ? out[1] : out
+end
+
+parameters(m::MLP) = vcat([parameters(l) for l in m.layers]...)
+
+
+function demo_mlp_training()
+    println("=== Mini MLP Training on XOR ===")
+    Random.seed!(42)
+    model = MLP(Int[2, 4, 1])
+
+    xs = [[Value(0.0), Value(0.0)], [Value(0.0), Value(1.0)],
+          [Value(1.0), Value(0.0)], [Value(1.0), Value(1.0)]]
+    ys = Float64[-1.0, 1.0, 1.0, -1.0]
+
+    for step in 0:99
+        loss = Value(0.0)
+        for (x, y) in zip(xs, ys)
+            pred = model(x)
+            diff = pred + Value(-y)
+            loss = loss + diff * diff
+        end
+
+        for p in parameters(model)
+            p.grad = 0.0
+        end
+        backward!(loss)
+
+        lr = 0.05
+        for p in parameters(model)
+            p.data -= lr * p.grad
+        end
+
+        if step % 20 == 0 || step == 99
+            @printf("  step %3d  loss = %.4f\n", step, loss.data)
+        end
+    end
+
+    println("\n  Predictions after training:")
+    for (x, y) in zip(xs, ys)
+        pred = model(x)
+        sign = pred.data > 0 ? "+" : "-"
+        @printf("    input=[%.0f,%.0f]  target=%+.0f  pred=%+.3f (%s)\n",
+                x[1].data, x[2].data, y, pred.data, sign)
+    end
+    println("  DONE\n")
+end
+
+
+function main()
+    demo_basic()
+    demo_power()
+    demo_complex()
+    demo_neuron()
+    demo_exp_log()
+    demo_gradient_check()
+    demo_mlp_training()
+    println("All demos passed.")
+end
+
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    main()
+end

--- a/phases/01-math-foundations/06-probability-and-distributions/code/main.jl
+++ b/phases/01-math-foundations/06-probability-and-distributions/code/main.jl
@@ -19,7 +19,12 @@ function combinations(n::Int, k::Int)::Int
 end
 
 
-conditional_probability(p_a_and_b::Float64, p_b::Float64) = p_a_and_b / p_b
+function conditional_probability(p_a_and_b::Float64, p_b::Float64)
+    if p_b == 0.0
+        throw(ArgumentError("conditional_probability: P(B) is zero; cannot divide"))
+    end
+    return p_a_and_b / p_b
+end
 
 
 bernoulli_pmf(k::Int, p::Float64) = k == 1 ? p : (1 - p)
@@ -81,7 +86,11 @@ end
 function sample_normal_box_muller(rng::AbstractRNG, mu::Float64, sigma::Float64, n::Int)
     samples = Float64[]
     for _ in 1:n
+        # rand(rng) is in [0, 1); guard against u1 == 0 so log(u1) stays finite.
         u1 = rand(rng)
+        while u1 == 0.0
+            u1 = rand(rng)
+        end
         u2 = rand(rng)
         z = sqrt(-2 * log(u1)) * cos(2pi * u2)
         push!(samples, mu + sigma * z)

--- a/phases/01-math-foundations/06-probability-and-distributions/code/main.jl
+++ b/phases/01-math-foundations/06-probability-and-distributions/code/main.jl
@@ -1,0 +1,275 @@
+# Probability + distributions in Julia. Hand-written PMFs, PDFs,
+# samplers (Bernoulli, Categorical, Uniform, Normal via Box-Muller),
+# softmax + log-softmax + cross-entropy, marginals, central limit demo.
+# Stdlib only. Sources:
+#   https://docs.julialang.org/en/v1/stdlib/Random/
+#   https://docs.julialang.org/en/v1/manual/missing/
+#   https://en.wikipedia.org/wiki/Box-Muller_transform
+
+using Random
+using Statistics
+using Printf
+
+
+factorial_int(n::Int)::Int = n <= 1 ? 1 : prod(2:n)
+
+
+function combinations(n::Int, k::Int)::Int
+    return factorial_int(n) ÷ (factorial_int(k) * factorial_int(n - k))
+end
+
+
+conditional_probability(p_a_and_b::Float64, p_b::Float64) = p_a_and_b / p_b
+
+
+bernoulli_pmf(k::Int, p::Float64) = k == 1 ? p : (1 - p)
+
+
+categorical_pmf(k::Int, probs::Vector{Float64}) = probs[k + 1]
+
+
+function poisson_pmf(k::Int, lam::Float64)
+    return (lam ^ k) * exp(-lam) / factorial_int(k)
+end
+
+
+function uniform_pdf(x::Float64, a::Float64, b::Float64)
+    return a <= x <= b ? 1.0 / (b - a) : 0.0
+end
+
+
+function normal_pdf(x::Float64, mu::Float64, sigma::Float64)
+    coeff = 1.0 / (sigma * sqrt(2pi))
+    exponent = -0.5 * ((x - mu) / sigma) ^ 2
+    return coeff * exp(exponent)
+end
+
+
+function expected_value(values::Vector{Float64}, probs::Vector{Float64})::Float64
+    return sum(values .* probs)
+end
+
+
+function variance_of(values::Vector{Float64}, probs::Vector{Float64})::Float64
+    mu = expected_value(values, probs)
+    return sum(probs .* (values .- mu) .^ 2)
+end
+
+
+function sample_bernoulli(rng::AbstractRNG, p::Float64, n::Int)
+    return [rand(rng) < p ? 1 : 0 for _ in 1:n]
+end
+
+
+function sample_categorical(rng::AbstractRNG, probs::Vector{Float64}, n::Int)
+    cumulative = cumsum(probs)
+    samples = Int[]
+    for _ in 1:n
+        r = rand(rng)
+        idx = findfirst(c -> r <= c, cumulative)
+        push!(samples, idx === nothing ? length(probs) - 1 : idx - 1)
+    end
+    return samples
+end
+
+
+function sample_uniform(rng::AbstractRNG, a::Float64, b::Float64, n::Int)
+    return [a + (b - a) * rand(rng) for _ in 1:n]
+end
+
+
+function sample_normal_box_muller(rng::AbstractRNG, mu::Float64, sigma::Float64, n::Int)
+    samples = Float64[]
+    for _ in 1:n
+        u1 = rand(rng)
+        u2 = rand(rng)
+        z = sqrt(-2 * log(u1)) * cos(2pi * u2)
+        push!(samples, mu + sigma * z)
+    end
+    return samples
+end
+
+
+function softmax(logits::Vector{Float64})
+    m = maximum(logits)
+    exps = exp.(logits .- m)
+    return exps ./ sum(exps)
+end
+
+
+function log_softmax(logits::Vector{Float64})
+    m = maximum(logits)
+    shifted = logits .- m
+    log_sum_exp = m + log(sum(exp.(shifted)))
+    return logits .- log_sum_exp
+end
+
+
+function cross_entropy_loss(logits::Vector{Float64}, target_index::Int)
+    return -log_softmax(logits)[target_index + 1]
+end
+
+
+function joint_to_marginals(joint::Matrix{Float64})
+    marginal_x = vec(sum(joint, dims=2))
+    marginal_y = vec(sum(joint, dims=1))
+    return marginal_x, marginal_y
+end
+
+
+function check_independence(joint::Matrix{Float64},
+                            marginal_x::Vector{Float64},
+                            marginal_y::Vector{Float64};
+                            tol::Float64=1e-9)::Bool
+    for i in eachindex(marginal_x), j in eachindex(marginal_y)
+        if abs(joint[i, j] - marginal_x[i] * marginal_y[j]) > tol
+            return false
+        end
+    end
+    return true
+end
+
+
+function demonstrate_clt(rng::AbstractRNG, n_per_sample::Int, n_averages::Int)
+    averages = Float64[]
+    for _ in 1:n_averages
+        samples = rand(rng, n_per_sample)
+        push!(averages, mean(samples))
+    end
+    return averages
+end
+
+
+function main()
+    rng = MersenneTwister(42)
+
+    println("=" ^ 60)
+    println("PROBABILITY AND DISTRIBUTIONS")
+    println("=" ^ 60)
+
+    println("\n--- Conditional Probability ---")
+    p_king_given_face = conditional_probability(4 / 52, 12 / 52)
+    @printf("P(King | Face card) = %.4f\n", p_king_given_face)
+
+    println("\n--- PMF: Bernoulli (p=0.7) ---")
+    for k in 0:1
+        @printf("  P(X=%d) = %.4f\n", k, bernoulli_pmf(k, 0.7))
+    end
+
+    println("\n--- PMF: Categorical ---")
+    cat_probs = Float64[0.1, 0.3, 0.4, 0.2]
+    for k in 0:(length(cat_probs) - 1)
+        @printf("  P(X=%d) = %.4f\n", k, categorical_pmf(k, cat_probs))
+    end
+
+    println("\n--- PMF: Poisson (lambda=3) ---")
+    for k in 0:9
+        @printf("  P(X=%d) = %.4f\n", k, poisson_pmf(k, 3.0))
+    end
+
+    println("\n--- PDF: Normal (mu=0, sigma=1) ---")
+    for x in -3.0:1.0:3.0
+        @printf("  f(%+.0f) = %.4f\n", x, normal_pdf(x, 0.0, 1.0))
+    end
+
+    println("\n--- Expected Value & Variance ---")
+    die_values = Float64[1, 2, 3, 4, 5, 6]
+    die_probs = fill(1 / 6, 6)
+    mu = expected_value(die_values, die_probs)
+    var = variance_of(die_values, die_probs)
+    @printf("  Fair die: E[X] = %.4f, Var(X) = %.4f, SD = %.4f\n", mu, var, sqrt(var))
+
+    println("\n--- Sampling: Bernoulli (p=0.3, n=20) ---")
+    bern = sample_bernoulli(rng, 0.3, 20)
+    println("  Samples: $bern")
+    @printf("  Empirical mean: %.4f (expected 0.3)\n", mean(bern))
+
+    println("\n--- Sampling: Categorical ---")
+    cat_samples = sample_categorical(rng, Float64[0.1, 0.3, 0.4, 0.2], 1000)
+    counts = [count(==(i), cat_samples) for i in 0:3]
+    println("  Counts from 1000 samples: $counts")
+    println("  Empirical: $(round.(counts ./ 1000, digits=4))")
+    println("  Expected:  [0.1, 0.3, 0.4, 0.2]")
+
+    println("\n--- Sampling: Normal (Box-Muller) ---")
+    norm = sample_normal_box_muller(rng, 0.0, 1.0, 10000)
+    sample_mean = mean(norm)
+    sample_var = var_of_samples(norm)
+    println("  10000 samples from N(0, 1):")
+    @printf("  Sample mean: %.4f (expected 0)\n", sample_mean)
+    @printf("  Sample var:  %.4f (expected 1)\n", sample_var)
+
+    println("\n--- Softmax ---")
+    logits = Float64[2.0, 1.0, 0.1]
+    probs = softmax(logits)
+    println("  Logits:  $logits")
+    println("  Softmax: $(round.(probs, digits=4))")
+    @printf("  Sum:     %.4f\n", sum(probs))
+
+    println("\n--- Softmax with large logits (stability test) ---")
+    large_logits = Float64[100, 101, 102]
+    probs_large = softmax(large_logits)
+    println("  Logits:  $large_logits")
+    println("  Softmax: $(round.(probs_large, digits=4))")
+    println("  (No overflow because we subtract max before exp)")
+
+    println("\n--- Log Probabilities ---")
+    lp = log_softmax(logits)
+    println("  Logits:      $logits")
+    println("  Log-softmax: $(round.(lp, digits=4))")
+    println("  Verify exp:  $(round.(exp.(lp), digits=4))")
+
+    println("\n--- Cross-Entropy Loss ---")
+    ce = cross_entropy_loss(Float64[2.0, 1.0, 0.1], 0)
+    println("  Logits: [2.0, 1.0, 0.1], target: 0")
+    @printf("  Cross-entropy loss: %.4f\n", ce)
+
+    println("\n--- Why log probabilities matter ---")
+    word_prob = 0.01
+    n_words = 50
+    raw_product = word_prob ^ n_words
+    log_sum = n_words * log(word_prob)
+    @printf("  P(word)^%d = %.2e\n", n_words, raw_product)
+    @printf("  Log sum: %.4f (stable)\n", log_sum)
+    @printf("  Recovered: %.2e\n", exp(log_sum))
+
+    println("\n--- Joint & Marginal Distributions ---")
+    joint = Float64[0.40 0.10; 0.05 0.45]
+    mx, my = joint_to_marginals(joint)
+    println("  Joint (weather x umbrella):")
+    @printf("    Sun, no umbrella: %.2f\n", joint[1, 1])
+    @printf("    Sun, umbrella:    %.2f\n", joint[1, 2])
+    @printf("    Rain, no umbrella: %.2f\n", joint[2, 1])
+    @printf("    Rain, umbrella:    %.2f\n", joint[2, 2])
+    println("  Marginal X (weather):  $mx")
+    println("  Marginal Y (umbrella): $my")
+    println("  Independent? $(check_independence(joint, mx, my))")
+
+    println("\n--- Central Limit Theorem ---")
+    println("  Averaging uniform [0, 1) samples:")
+    for n in [1, 2, 5, 30]
+        avgs = demonstrate_clt(rng, n, 10000)
+        @printf("    n=%2d: mean=%.4f, std=%.4f\n", n, mean(avgs), std_of_samples(avgs))
+    end
+    println("  As n grows, std shrinks and distribution approaches normal.")
+
+    println("\n" * "=" ^ 60)
+    println("All probability computations complete.")
+    println("=" ^ 60)
+end
+
+
+function var_of_samples(xs::Vector{Float64})::Float64
+    m = mean(xs)
+    return sum((xs .- m) .^ 2) / length(xs)
+end
+
+
+function std_of_samples(xs::Vector{Float64})::Float64
+    return sqrt(var_of_samples(xs))
+end
+
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    main()
+end

--- a/phases/01-math-foundations/08-optimization/code/main.jl
+++ b/phases/01-math-foundations/08-optimization/code/main.jl
@@ -1,0 +1,302 @@
+# Optimization in Julia. GradientDescent, SGD+Momentum, and Adam
+# implemented as mutable structs with a common `step!` method.
+# Driven on the Rosenbrock and saddle-point functions to show
+# convergence, divergence, and saddle escape behavior.
+# Stdlib only. Sources:
+#   https://docs.julialang.org/en/v1/manual/types/#Composite-Types
+#   https://arxiv.org/abs/1412.6980  (Adam: Kingma & Ba)
+
+using Printf
+
+
+abstract type Optimizer end
+
+
+mutable struct GradientDescent <: Optimizer
+    lr::Float64
+end
+GradientDescent(; lr::Float64=0.001) = GradientDescent(lr)
+
+function step!(opt::GradientDescent, params::Vector{Float64}, grads::Vector{Float64})
+    return params .- opt.lr .* grads
+end
+
+
+mutable struct SGDMomentum <: Optimizer
+    lr::Float64
+    momentum::Float64
+    velocity::Vector{Float64}
+end
+SGDMomentum(; lr::Float64=0.001, momentum::Float64=0.9) =
+    SGDMomentum(lr, momentum, Float64[])
+
+function step!(opt::SGDMomentum, params::Vector{Float64}, grads::Vector{Float64})
+    if isempty(opt.velocity)
+        opt.velocity = zeros(length(params))
+    end
+    opt.velocity .= opt.momentum .* opt.velocity .+ grads
+    return params .- opt.lr .* opt.velocity
+end
+
+
+mutable struct Adam <: Optimizer
+    lr::Float64
+    beta1::Float64
+    beta2::Float64
+    epsilon::Float64
+    m::Vector{Float64}
+    v::Vector{Float64}
+    t::Int
+end
+Adam(; lr::Float64=0.001, beta1::Float64=0.9, beta2::Float64=0.999,
+     epsilon::Float64=1e-8) =
+    Adam(lr, beta1, beta2, epsilon, Float64[], Float64[], 0)
+
+function step!(opt::Adam, params::Vector{Float64}, grads::Vector{Float64})
+    if isempty(opt.m)
+        opt.m = zeros(length(params))
+        opt.v = zeros(length(params))
+    end
+    opt.t += 1
+    opt.m .= opt.beta1 .* opt.m .+ (1 - opt.beta1) .* grads
+    opt.v .= opt.beta2 .* opt.v .+ (1 - opt.beta2) .* grads .^ 2
+    m_hat = opt.m ./ (1 - opt.beta1 ^ opt.t)
+    v_hat = opt.v ./ (1 - opt.beta2 ^ opt.t)
+    return params .- opt.lr .* m_hat ./ (sqrt.(v_hat) .+ opt.epsilon)
+end
+
+
+rosenbrock(p::Vector{Float64})::Float64 = (1 - p[1]) ^ 2 + 100 * (p[2] - p[1] ^ 2) ^ 2
+
+
+function rosenbrock_grad(p::Vector{Float64})::Vector{Float64}
+    x, y = p[1], p[2]
+    df_dx = -2 * (1 - x) + 200 * (y - x ^ 2) * (-2 * x)
+    df_dy = 200 * (y - x ^ 2)
+    return Float64[df_dx, df_dy]
+end
+
+
+function optimize(opt::Optimizer, f, grad_f, start::Vector{Float64}; steps::Int=5000)
+    params = copy(start)
+    history = Vector{Vector{Float64}}()
+    push!(history, copy(params))
+    for _ in 1:steps
+        grads = grad_f(params)
+        if any(g -> !isfinite(g) || abs(g) > 1e15, grads)
+            break
+        end
+        params = step!(opt, params, grads)
+        if any(p -> !isfinite(p) || abs(p) > 1e15, params)
+            break
+        end
+        push!(history, copy(params))
+    end
+    return history
+end
+
+
+function distance_to_minimum(p::Vector{Float64}, target::Tuple{Float64, Float64}=(1.0, 1.0))::Float64
+    return sqrt((p[1] - target[1]) ^ 2 + (p[2] - target[2]) ^ 2)
+end
+
+
+function find_convergence_step(history, f; threshold::Float64=1e-4)::Int
+    for (i, params) in enumerate(history)
+        if f(params) < threshold
+            return i - 1
+        end
+    end
+    return length(history)
+end
+
+
+function print_trajectory(name::String, history, f; steps_to_show::Int=10)
+    total = length(history) - 1
+    interval = max(1, total ÷ steps_to_show)
+    println("\n" * "=" ^ 60)
+    println("  $name")
+    println("=" ^ 60)
+    @printf("  %6s  %10s  %10s  %14s  %8s\n", "Step", "x", "y", "Loss", "Dist")
+    println("  " * "-" ^ 52)
+    for i in 0:interval:total
+        p = history[i + 1]
+        loss = f(p)
+        dist = distance_to_minimum(p)
+        @printf("  %6d  %10.6f  %10.6f  %14.8f  %8.4f\n", i, p[1], p[2], loss, dist)
+    end
+    if total % interval != 0
+        p = history[end]
+        loss = f(p)
+        dist = distance_to_minimum(p)
+        @printf("  %6d  %10.6f  %10.6f  %14.8f  %8.4f\n", total, p[1], p[2], loss, dist)
+    end
+end
+
+
+function print_ascii_convergence(results, f; steps::Int=5000)
+    println("\n" * "=" ^ 60)
+    println("  CONVERGENCE COMPARISON (log10 loss over steps)")
+    println("=" ^ 60)
+    width = 50
+    sample_points = 40
+    interval = max(1, steps ÷ sample_points)
+    for (name, history) in results
+        losses = Float64[]
+        i = 0
+        while i <= min(length(history) - 1, steps)
+            push!(losses, f(history[i + 1]))
+            i += interval
+        end
+        isempty(losses) && continue
+        max_log = 5.0
+        min_log = -8.0
+        log_range = max_log - min_log
+        bars = Int[]
+        for loss in losses
+            ll = log10(loss + 1e-15)
+            ll = clamp(ll, min_log, max_log)
+            normalized = (ll - min_log) / log_range
+            push!(bars, Int(round(normalized * (width - 1))))
+        end
+        println("\n  $name:")
+        println("  loss 1e-8 " * "."^width * " 1e+5")
+        for (idx, pos) in enumerate(bars)
+            step_num = (idx - 1) * interval
+            line = fill(' ', width)
+            line[clamp(pos + 1, 1, width)] = '*'
+            println("  " * lpad(string(step_num), 5) * " |" * String(line) * "|")
+        end
+        final_loss = f(history[end])
+        conv_step = find_convergence_step(history, f)
+        conv_msg = conv_step < length(history) ? "step $conv_step" : "did not converge"
+        @printf("  final loss: %.2e, converged (< 1e-4): %s\n", final_loss, conv_msg)
+    end
+end
+
+
+function demo_comparison()
+    println("OPTIMIZATION METHODS COMPARISON")
+    println("Minimizing the Rosenbrock function: f(x, y) = (1-x)^2 + 100(y-x^2)^2")
+    println("Global minimum at (1, 1) where f = 0")
+    @printf("Starting point: (-1.0, 1.0), f = %.1f\n", rosenbrock(Float64[-1.0, 1.0]))
+
+    start = Float64[-1.0, 1.0]
+    steps = 5000
+
+    configs = [
+        ("Gradient Descent", GradientDescent(lr=0.0005)),
+        ("SGD + Momentum",   SGDMomentum(lr=0.0001, momentum=0.9)),
+        ("Adam",             Adam(lr=0.01)),
+    ]
+
+    results = Tuple{String, Vector{Vector{Float64}}}[]
+    for (name, opt) in configs
+        history = optimize(opt, rosenbrock, rosenbrock_grad, start; steps=steps)
+        push!(results, (name, history))
+        print_trajectory(name, history, rosenbrock)
+    end
+
+    print_ascii_convergence(results, rosenbrock; steps=steps)
+
+    println("\n" * "=" ^ 60)
+    println("  FINAL RESULTS")
+    println("=" ^ 60)
+    @printf("  %-22s  %10s  %10s  %14s\n", "Method", "x", "y", "Loss")
+    println("  " * "-" ^ 58)
+    for (name, history) in results
+        final = history[end]
+        loss = rosenbrock(final)
+        @printf("  %-22s  %10.6f  %10.6f  %14.8f\n", name, final[1], final[2], loss)
+    end
+    println("\n  Target: x=1.000000, y=1.000000, loss=0.00000000")
+end
+
+
+function demo_learning_rate_effect()
+    println("\n\n" * "=" ^ 60)
+    println("  LEARNING RATE EFFECT ON GRADIENT DESCENT")
+    println("=" ^ 60)
+    start = Float64[-1.0, 1.0]
+    rates = [0.0001, 0.0005, 0.001, 0.005]
+    @printf("\n  %8s  %10s  %10s  %14s  %s\n", "LR", "Final x", "Final y", "Loss", "Status")
+    println("  " * "-" ^ 60)
+    for lr in rates
+        gd = GradientDescent(lr=lr)
+        history = optimize(gd, rosenbrock, rosenbrock_grad, start; steps=5000)
+        final = history[end]
+        loss = rosenbrock(final)
+        diverged = !isfinite(loss) || loss > 1e10
+        status = diverged ? "DIVERGED" : (loss < 0.01 ? "converged" : "slow")
+        if diverged
+            @printf("  %8.4f  %10s  %10s  %14s  %s\n", lr, "nan", "nan", "inf", status)
+        else
+            @printf("  %8.4f  %10.6f  %10.6f  %14.8f  %s\n", lr, final[1], final[2], loss, status)
+        end
+    end
+end
+
+
+function demo_momentum_effect()
+    println("\n\n" * "=" ^ 60)
+    println("  MOMENTUM EFFECT ON SGD")
+    println("=" ^ 60)
+    start = Float64[-1.0, 1.0]
+    betas = [0.0, 0.5, 0.9, 0.99]
+    @printf("\n  %6s  %10s  %10s  %14s\n", "Beta", "Final x", "Final y", "Loss")
+    println("  " * "-" ^ 46)
+    for beta in betas
+        sgd = SGDMomentum(lr=0.0001, momentum=beta)
+        history = optimize(sgd, rosenbrock, rosenbrock_grad, start; steps=5000)
+        final = history[end]
+        loss = rosenbrock(final)
+        if !isfinite(loss)
+            @printf("  %6.2f  %10s  %10s  %14s\n", beta, "nan", "nan", "inf")
+        else
+            @printf("  %6.2f  %10.6f  %10.6f  %14.8f\n", beta, final[1], final[2], loss)
+        end
+    end
+end
+
+
+function demo_saddle_point()
+    println("\n\n" * "=" ^ 60)
+    println("  SADDLE POINT ESCAPE: f(x, y) = x^2 - y^2")
+    println("=" ^ 60)
+
+    saddle(p::Vector{Float64}) = p[1] ^ 2 - p[2] ^ 2
+    saddle_grad(p::Vector{Float64}) = Float64[2 * p[1], -2 * p[2]]
+
+    start = Float64[0.01, 0.01]
+    steps = 200
+
+    configs = [
+        ("Gradient Descent", GradientDescent(lr=0.01)),
+        ("SGD + Momentum",   SGDMomentum(lr=0.01, momentum=0.9)),
+        ("Adam",             Adam(lr=0.01)),
+    ]
+
+    println("\n  Start: x=0.01, y=0.01 (near saddle at origin)")
+    @printf("\n  %-22s  %10s  %10s  %12s  %s\n", "Method", "x", "y", "f(x, y)", "Escaped?")
+    println("  " * "-" ^ 62)
+    for (name, opt) in configs
+        history = optimize(opt, saddle, saddle_grad, start; steps=steps)
+        final = history[end]
+        val = saddle(final)
+        escaped = abs(final[2]) > 1.0 ? "yes" : "no"
+        @printf("  %-22s  %10.6f  %10.6f  %12.6f  %s\n", name, final[1], final[2], val, escaped)
+    end
+end
+
+
+function main()
+    demo_comparison()
+    demo_learning_rate_effect()
+    demo_momentum_effect()
+    demo_saddle_point()
+end
+
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    main()
+end

--- a/phases/03-deep-learning-core/01-the-perceptron/code/main.jl
+++ b/phases/03-deep-learning-core/01-the-perceptron/code/main.jl
@@ -1,0 +1,231 @@
+# Perceptron + 1-hidden-layer MLP in Julia. Single-layer Rosenblatt
+# perceptron for AND/OR/NOT, then a hand-wired XOR network to show
+# why the perceptron fails on XOR, then a trained 2-2-1 sigmoid MLP
+# with manual backpropagation.
+# Stdlib only. Sources:
+#   https://en.wikipedia.org/wiki/Perceptron
+#   https://docs.julialang.org/en/v1/manual/types/#Composite-Types
+
+using Random
+using Printf
+
+
+mutable struct Perceptron
+    weights::Vector{Float64}
+    bias::Float64
+    lr::Float64
+end
+
+Perceptron(n_inputs::Int; lr::Float64=0.1) =
+    Perceptron(zeros(Float64, n_inputs), 0.0, lr)
+
+
+function predict(p::Perceptron, inputs::Vector{Float64})::Int
+    return sum(p.weights .* inputs) + p.bias >= 0 ? 1 : 0
+end
+
+
+function train!(p::Perceptron, data::Vector{Tuple{Vector{Float64}, Int}}; epochs::Int=100)
+    for epoch in 1:epochs
+        errors = 0
+        for (inputs, target) in data
+            pred = predict(p, inputs)
+            err = target - pred
+            if err != 0
+                errors += 1
+                p.weights .+= p.lr * err .* inputs
+                p.bias += p.lr * err
+            end
+        end
+        if errors == 0
+            println("Converged at epoch $epoch")
+            return
+        end
+    end
+    println("Did not converge after $epochs epochs")
+end
+
+
+function test_gate(name::String, n_inputs::Int, data::Vector{Tuple{Vector{Float64}, Int}})
+    println("=== $name ===")
+    p = Perceptron(n_inputs)
+    train!(p, data)
+    println("  Weights: $(p.weights), Bias: $(p.bias)")
+    for (inputs, expected) in data
+        result = predict(p, inputs)
+        status = result == expected ? "OK" : "WRONG"
+        println("  $inputs -> $result (expected $expected) $status")
+    end
+    println()
+end
+
+
+# Hand-wired XOR via OR + NAND + AND. Demonstrates that a 2-layer
+# network of perceptrons can compute XOR even though a single one cannot.
+function xor_network(x1::Float64, x2::Float64)::Int
+    or_neuron = Perceptron(2)
+    or_neuron.weights = Float64[1.0, 1.0]
+    or_neuron.bias = -0.5
+
+    nand_neuron = Perceptron(2)
+    nand_neuron.weights = Float64[-1.0, -1.0]
+    nand_neuron.bias = 1.5
+
+    and_neuron = Perceptron(2)
+    and_neuron.weights = Float64[1.0, 1.0]
+    and_neuron.bias = -1.5
+
+    h1 = predict(or_neuron, Float64[x1, x2])
+    h2 = predict(nand_neuron, Float64[x1, x2])
+    return predict(and_neuron, Float64[h1, h2])
+end
+
+
+# Tiny trained MLP: 2 inputs -> 2 hidden sigmoid neurons -> 1 sigmoid output.
+mutable struct TwoLayerNetwork
+    w_hidden::Matrix{Float64}    # 2x2
+    b_hidden::Vector{Float64}    # 2
+    w_output::Vector{Float64}    # 2
+    b_output::Float64
+    lr::Float64
+    # caches for backprop
+    last_input::Vector{Float64}
+    hidden_out::Vector{Float64}
+    output::Float64
+end
+
+function TwoLayerNetwork(; lr::Float64=2.0, seed::Int=0)
+    rng = MersenneTwister(seed)
+    return TwoLayerNetwork(
+        rand(rng, 2, 2) .* 2 .- 1,
+        rand(rng, 2) .* 2 .- 1,
+        rand(rng, 2) .* 2 .- 1,
+        rand(rng) * 2 - 1,
+        lr,
+        Float64[],
+        zeros(Float64, 2),
+        0.0,
+    )
+end
+
+
+sigmoid(x::Float64)::Float64 = 1.0 / (1.0 + exp(-clamp(x, -500.0, 500.0)))
+
+
+function forward!(net::TwoLayerNetwork, inputs::Vector{Float64})::Float64
+    net.last_input = inputs
+    for i in 1:2
+        z = net.w_hidden[i, 1] * inputs[1] + net.w_hidden[i, 2] * inputs[2] + net.b_hidden[i]
+        net.hidden_out[i] = sigmoid(z)
+    end
+    z_out = net.w_output[1] * net.hidden_out[1] + net.w_output[2] * net.hidden_out[2] + net.b_output
+    net.output = sigmoid(z_out)
+    return net.output
+end
+
+
+function backward!(net::TwoLayerNetwork, target::Float64)
+    err = target - net.output
+    d_output = err * net.output * (1 - net.output)
+    saved_w_output = copy(net.w_output)
+    hidden_deltas = zeros(Float64, 2)
+    for i in 1:2
+        h = net.hidden_out[i]
+        hidden_deltas[i] = d_output * saved_w_output[i] * h * (1 - h)
+    end
+    for i in 1:2
+        net.w_output[i] += net.lr * d_output * net.hidden_out[i]
+    end
+    net.b_output += net.lr * d_output
+    for i in 1:2, j in 1:2
+        net.w_hidden[i, j] += net.lr * hidden_deltas[i] * net.last_input[j]
+    end
+    for i in 1:2
+        net.b_hidden[i] += net.lr * hidden_deltas[i]
+    end
+end
+
+
+function train!(net::TwoLayerNetwork, data::Vector{Tuple{Vector{Float64}, Float64}};
+                epochs::Int=10000)
+    for epoch in 0:(epochs - 1)
+        total_err = 0.0
+        for (inputs, target) in data
+            out = forward!(net, inputs)
+            total_err += (target - out) ^ 2
+            backward!(net, target)
+        end
+        if epoch % 2000 == 0
+            @printf("  Epoch %d, error: %.4f\n", epoch, total_err)
+        end
+    end
+end
+
+
+function main()
+    and_data = Tuple{Vector{Float64}, Int}[
+        (Float64[0, 0], 0),
+        (Float64[0, 1], 0),
+        (Float64[1, 0], 0),
+        (Float64[1, 1], 1),
+    ]
+    or_data = Tuple{Vector{Float64}, Int}[
+        (Float64[0, 0], 0),
+        (Float64[0, 1], 1),
+        (Float64[1, 0], 1),
+        (Float64[1, 1], 1),
+    ]
+    not_data = Tuple{Vector{Float64}, Int}[
+        (Float64[0], 1),
+        (Float64[1], 0),
+    ]
+    xor_data = Tuple{Vector{Float64}, Int}[
+        (Float64[0, 0], 0),
+        (Float64[0, 1], 1),
+        (Float64[1, 0], 1),
+        (Float64[1, 1], 0),
+    ]
+
+    test_gate("AND Gate", 2, and_data)
+    test_gate("OR Gate", 2, or_data)
+    test_gate("NOT Gate", 1, not_data)
+
+    println("=== XOR Gate (single perceptron - will fail) ===")
+    p_xor = Perceptron(2)
+    train!(p_xor, xor_data; epochs=1000)
+    for (inputs, expected) in xor_data
+        result = predict(p_xor, inputs)
+        status = result == expected ? "OK" : "WRONG"
+        println("  $inputs -> $result (expected $expected) $status")
+    end
+    println()
+
+    println("=== XOR Gate (multi-layer network - works) ===")
+    for (inputs, expected) in xor_data
+        result = xor_network(inputs[1], inputs[2])
+        status = result == expected ? "OK" : "WRONG"
+        println("  $inputs -> $result (expected $expected) $status")
+    end
+    println()
+
+    println("=== XOR Gate (trained 2-layer network with backpropagation) ===")
+    xor_train = Tuple{Vector{Float64}, Float64}[
+        (Float64[0, 0], 0.0),
+        (Float64[0, 1], 1.0),
+        (Float64[1, 0], 1.0),
+        (Float64[1, 1], 0.0),
+    ]
+    net = TwoLayerNetwork(lr=2.0)
+    train!(net, xor_train; epochs=10000)
+    println()
+    for (inputs, expected) in xor_train
+        result = forward!(net, inputs)
+        predicted = result >= 0.5 ? 1 : 0
+        @printf("  %s -> %.4f (rounded: %d, expected %d)\n", inputs, result, predicted, Int(expected))
+    end
+end
+
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    main()
+end

--- a/phases/03-deep-learning-core/03-backpropagation/code/main.jl
+++ b/phases/03-deep-learning-core/03-backpropagation/code/main.jl
@@ -85,7 +85,7 @@ end
 
 
 mse_loss(pred::Vector{Float64}, target::Vector{Float64})::Float64 =
-    sum((pred .- target) .^ 2)
+    0.5 * sum((pred .- target) .^ 2)
 
 
 function train_xor!()
@@ -213,10 +213,10 @@ function gradient_check_demo()
     loss_minus = mse_loss(net.a2, y)
     net.w1[i, j] = saved
     numerical = (loss_plus - loss_minus) / (2h)
-    analytical = 2 * dw1[i, j]  # mse here is sum of squares, gradient of (a-y)^2 is 2(a-y); our backward used err, so multiply by 2 to match.
+    analytical = dw1[i, j]  # mse_loss is 0.5*sum((a-y)^2); backward uses err=a-y, so dw1 matches directly.
     @printf("  w1[%d,%d]: analytical=%.6f  numerical=%.6f  diff=%.2e\n",
             i, j, analytical, numerical, abs(analytical - numerical))
-    println("  (Note: backward() uses err=a-y, so the analytical grad of sum((a-y)^2) is 2*dw1.)")
+    println("  (backward() uses err=a-y, matching the 0.5*sum((a-y)^2) convention; grads align directly.)")
 end
 
 

--- a/phases/03-deep-learning-core/03-backpropagation/code/main.jl
+++ b/phases/03-deep-learning-core/03-backpropagation/code/main.jl
@@ -1,0 +1,232 @@
+# Backpropagation in Julia. Derives the chain rule for a 2-layer MLP
+# step by step on paper, then trains it on XOR + circle classification.
+# All gradients computed manually — no autodiff library.
+# Stdlib only. Sources:
+#   https://en.wikipedia.org/wiki/Backpropagation
+#   https://docs.julialang.org/en/v1/manual/arrays/#Broadcasting
+
+using Random
+using Printf
+
+
+sigmoid(x::Float64)::Float64 = 1.0 / (1.0 + exp(-clamp(x, -500.0, 500.0)))
+sigmoid_d(s::Float64)::Float64 = s * (1 - s)
+
+
+mutable struct MLP
+    # First (hidden) layer: w1[i, j] = weight from input j to hidden unit i.
+    w1::Matrix{Float64}
+    b1::Vector{Float64}
+    # Output layer.
+    w2::Matrix{Float64}
+    b2::Vector{Float64}
+    lr::Float64
+    # Caches for backprop.
+    last_x::Vector{Float64}
+    z1::Vector{Float64}
+    a1::Vector{Float64}
+    z2::Vector{Float64}
+    a2::Vector{Float64}
+end
+
+
+function MLP(sizes::Vector{Int}; lr::Float64=1.0, seed::Int=42)
+    @assert length(sizes) == 3 "this MLP is fixed to 1 hidden layer"
+    rng = MersenneTwister(seed)
+    n_in, n_hid, n_out = sizes
+    # He-like init scaled for sigmoid.
+    scale_w1 = sqrt(2.0 / n_in)
+    scale_w2 = sqrt(2.0 / n_hid)
+    return MLP(
+        randn(rng, n_hid, n_in) .* scale_w1,
+        zeros(Float64, n_hid),
+        randn(rng, n_out, n_hid) .* scale_w2,
+        zeros(Float64, n_out),
+        lr,
+        Float64[], zeros(Float64, n_hid), zeros(Float64, n_hid),
+        zeros(Float64, n_out), zeros(Float64, n_out),
+    )
+end
+
+
+function forward!(m::MLP, x::Vector{Float64})::Vector{Float64}
+    m.last_x = x
+    m.z1 = m.w1 * x .+ m.b1
+    m.a1 = sigmoid.(m.z1)
+    m.z2 = m.w2 * m.a1 .+ m.b2
+    m.a2 = sigmoid.(m.z2)
+    return m.a2
+end
+
+
+# Compute gradients for one (x, y) pair under squared-error loss.
+# Returns the gradients without applying them so the caller can
+# accumulate over a batch then call apply_grads!.
+function backward(m::MLP, target::Vector{Float64})
+    err = m.a2 .- target
+    # d_loss/d_z2 = err .* sigmoid'(a2)
+    delta2 = err .* sigmoid_d.(m.a2)
+    grad_w2 = delta2 * m.a1'
+    grad_b2 = delta2
+    # Backprop into hidden layer.
+    delta1 = (m.w2' * delta2) .* sigmoid_d.(m.a1)
+    grad_w1 = delta1 * m.last_x'
+    grad_b1 = delta1
+    return grad_w1, grad_b1, grad_w2, grad_b2
+end
+
+
+function apply_grads!(m::MLP, gw1, gb1, gw2, gb2)
+    m.w1 .-= m.lr .* gw1
+    m.b1 .-= m.lr .* gb1
+    m.w2 .-= m.lr .* gw2
+    m.b2 .-= m.lr .* gb2
+end
+
+
+mse_loss(pred::Vector{Float64}, target::Vector{Float64})::Float64 =
+    sum((pred .- target) .^ 2)
+
+
+function train_xor!()
+    println("=" ^ 50)
+    println("Training on XOR")
+    println("=" ^ 50)
+    net = MLP(Int[2, 4, 1]; lr=1.0, seed=42)
+    xor_data = Tuple{Vector{Float64}, Vector{Float64}}[
+        (Float64[0, 0], Float64[0]),
+        (Float64[0, 1], Float64[1]),
+        (Float64[1, 0], Float64[1]),
+        (Float64[1, 1], Float64[0]),
+    ]
+    for epoch in 0:999
+        total_loss = 0.0
+        # Batch gradient: sum gradients across the four examples.
+        gw1 = zeros(size(net.w1))
+        gb1 = zeros(size(net.b1))
+        gw2 = zeros(size(net.w2))
+        gb2 = zeros(size(net.b2))
+        for (x, y) in xor_data
+            pred = forward!(net, x)
+            total_loss += mse_loss(pred, y)
+            dw1, db1, dw2, db2 = backward(net, y)
+            gw1 .+= dw1
+            gb1 .+= db1
+            gw2 .+= dw2
+            gb2 .+= db2
+        end
+        apply_grads!(net, gw1, gb1, gw2, gb2)
+        if epoch % 100 == 0
+            @printf("Epoch %4d | Loss: %.6f\n", epoch, total_loss)
+        end
+    end
+    println("\nXOR Results:")
+    for (x, y) in xor_data
+        pred = forward!(net, x)
+        cls = pred[1] > 0.5 ? 1 : 0
+        @printf("  %s -> %.4f (rounded: %d, expected %d)\n", x, pred[1], cls, Int(y[1]))
+    end
+end
+
+
+function generate_circle_data(rng::AbstractRNG; n::Int=100)
+    data = Tuple{Vector{Float64}, Vector{Float64}}[]
+    for _ in 1:n
+        x1 = rand(rng) * 3 - 1.5
+        x2 = rand(rng) * 3 - 1.5
+        label = x1 * x1 + x2 * x2 < 1.0 ? 1.0 : 0.0
+        push!(data, (Float64[x1, x2], Float64[label]))
+    end
+    return data
+end
+
+
+function train_circle!()
+    println("\n" * "=" ^ 50)
+    println("Training on Circle Classification")
+    println("=" ^ 50)
+    rng = MersenneTwister(7)
+    net = MLP(Int[2, 8, 1]; lr=0.5, seed=7)
+    data = generate_circle_data(rng; n=80)
+
+    for epoch in 0:1999
+        # Shuffle each epoch for SGD.
+        order = randperm(rng, length(data))
+        total = 0.0
+        for idx in order
+            x, y = data[idx]
+            pred = forward!(net, x)
+            total += mse_loss(pred, y)
+            dw1, db1, dw2, db2 = backward(net, y)
+            apply_grads!(net, dw1, db1, dw2, db2)
+        end
+        if epoch % 200 == 0
+            correct = 0
+            for (x, y) in data
+                pred = forward!(net, x)
+                cls = pred[1] > 0.5 ? 1.0 : 0.0
+                if cls == y[1]
+                    correct += 1
+                end
+            end
+            acc = correct / length(data) * 100
+            @printf("Epoch %4d | Loss: %.4f | Accuracy: %.1f%%\n", epoch, total, acc)
+        end
+    end
+
+    println("\nSample Circle Results:")
+    test_points = [
+        (Float64[0.0, 0.0], "inside"),
+        (Float64[0.5, 0.5], "inside"),
+        (Float64[1.2, 1.2], "outside"),
+        (Float64[0.0, 1.2], "outside"),
+        (Float64[-0.3, 0.3], "inside"),
+    ]
+    for (p, region) in test_points
+        pred = forward!(net, p)
+        cls = pred[1] > 0.5 ? "inside" : "outside"
+        status = cls == region ? "OK" : "WRONG"
+        @printf("  %s -> %.4f (%s, expected %s) %s\n", p, pred[1], cls, region, status)
+    end
+end
+
+
+function gradient_check_demo()
+    println("\n" * "=" ^ 50)
+    println("Gradient check: backprop vs numerical")
+    println("=" ^ 50)
+    net = MLP(Int[2, 3, 1]; lr=0.1, seed=1)
+    x = Float64[0.6, -0.4]
+    y = Float64[1.0]
+    forward!(net, x)
+    dw1, db1, dw2, db2 = backward(net, y)
+
+    # Pick a weight in w1 and compare backprop grad with finite-difference grad.
+    h = 1e-5
+    i, j = 1, 1
+    saved = net.w1[i, j]
+    net.w1[i, j] = saved + h
+    forward!(net, x)
+    loss_plus = mse_loss(net.a2, y)
+    net.w1[i, j] = saved - h
+    forward!(net, x)
+    loss_minus = mse_loss(net.a2, y)
+    net.w1[i, j] = saved
+    numerical = (loss_plus - loss_minus) / (2h)
+    analytical = 2 * dw1[i, j]  # mse here is sum of squares, gradient of (a-y)^2 is 2(a-y); our backward used err, so multiply by 2 to match.
+    @printf("  w1[%d,%d]: analytical=%.6f  numerical=%.6f  diff=%.2e\n",
+            i, j, analytical, numerical, abs(analytical - numerical))
+    println("  (Note: backward() uses err=a-y, so the analytical grad of sum((a-y)^2) is 2*dw1.)")
+end
+
+
+function main()
+    train_xor!()
+    train_circle!()
+    gradient_check_demo()
+end
+
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    main()
+end

--- a/phases/03-deep-learning-core/04-activation-functions/code/main.jl
+++ b/phases/03-deep-learning-core/04-activation-functions/code/main.jl
@@ -37,7 +37,8 @@ leaky_relu_d(x::Float64; alpha::Float64=0.01)::Float64 = x > 0 ? 1.0 : alpha
 
 
 function gelu(x::Float64)::Float64
-    return 0.5 * x * (1 + tanh(sqrt(2 / pi) * (x + 0.044715 * x ^ 3)))
+    # Exact form x * Phi(x); keeps gelu and gelu_d consistent for backprop.
+    return 0.5 * x * (1 + erf_approx(x / sqrt(2.0)))
 end
 
 function gelu_d(x::Float64)::Float64
@@ -80,18 +81,21 @@ function gradient_scan(name::String, deriv; start::Float64=-5.0, stop::Float64=5
 end
 
 
-function vanishing_gradient_experiment(act, name::String; n_layers::Int=10, n_inputs::Int=5)
+function vanishing_gradient_experiment(act, act_d, name::String; n_layers::Int=10, n_inputs::Int=5)
     rng = MersenneTwister(42)
     values = randn(rng, n_inputs)
+    # Track the running product of |f'(z)| across layers — this is the
+    # quantity that actually vanishes during backprop, not the signal.
+    chain_grad = 1.0
     println("\n$name through $n_layers layers:")
     for layer in 1:n_layers
         weights = randn(rng, n_inputs)
         z = sum(weights .* values)
         activated = act(z)
-        magnitude = abs(activated)
-        bar_len = isfinite(magnitude) ? clamp(Int(round(magnitude * 20)), 0, 60) : 0
+        chain_grad *= abs(act_d(z))
+        bar_len = isfinite(chain_grad) ? clamp(Int(round(chain_grad * 20)), 0, 60) : 0
         bar = "#" ^ bar_len
-        @printf("  Layer %2d: magnitude = %.6f %s\n", layer, magnitude, bar)
+        @printf("  Layer %2d: |grad chain| = %.6f %s\n", layer, chain_grad, bar)
         values = fill(activated, n_inputs)
     end
 end
@@ -250,9 +254,9 @@ function main()
     println("\n" * "=" ^ 60)
     println("STEP 3: Vanishing Gradient Experiment")
     println("=" ^ 60)
-    vanishing_gradient_experiment(sigmoid, "Sigmoid")
-    vanishing_gradient_experiment(relu, "ReLU")
-    vanishing_gradient_experiment(gelu, "GELU")
+    vanishing_gradient_experiment(sigmoid, sigmoid_d, "Sigmoid")
+    vanishing_gradient_experiment(relu, relu_d, "ReLU")
+    vanishing_gradient_experiment(gelu, gelu_d, "GELU")
 
     println("\n" * "=" ^ 60)
     println("STEP 4: Dead Neuron Detection")

--- a/phases/03-deep-learning-core/04-activation-functions/code/main.jl
+++ b/phases/03-deep-learning-core/04-activation-functions/code/main.jl
@@ -1,0 +1,291 @@
+# Activation functions in Julia. Sigmoid, tanh, ReLU, leaky ReLU,
+# GELU, Swish — each with hand-derived analytical gradients.
+# Plus dead-neuron detection on ReLU and a vanishing-gradient demo.
+# Trains a tiny 2-h-1 MLP with each activation on circle data.
+# Stdlib only. Sources:
+#   https://docs.julialang.org/en/v1/base/math/  (tanh, erf, sqrt)
+#   https://arxiv.org/abs/1606.08415  (GELU: Hendrycks & Gimpel)
+
+using Random
+using Printf
+
+
+# Hand-rolled erf via Abramowitz & Stegun 7.1.26 (max error ~1.5e-7).
+# Stdlib only — Julia 1.x Base does not ship erf.
+function erf_approx(x::Float64)::Float64
+    sign_x = x < 0 ? -1.0 : 1.0
+    ax = abs(x)
+    a1, a2, a3, a4, a5 = 0.254829592, -0.284496736, 1.421413741, -1.453152027, 1.061405429
+    p = 0.3275911
+    t = 1.0 / (1.0 + p * ax)
+    y = 1.0 - (((((a5 * t + a4) * t) + a3) * t + a2) * t + a1) * t * exp(-ax * ax)
+    return sign_x * y
+end
+
+
+sigmoid(x::Float64)::Float64 = 1.0 / (1.0 + exp(-clamp(x, -500.0, 500.0)))
+sigmoid_d(x::Float64)::Float64 = (s = sigmoid(x); s * (1 - s))
+
+tanh_act(x::Float64)::Float64 = tanh(x)
+tanh_d(x::Float64)::Float64 = (t = tanh(x); 1 - t * t)
+
+relu(x::Float64)::Float64 = max(0.0, x)
+relu_d(x::Float64)::Float64 = x > 0 ? 1.0 : 0.0
+
+leaky_relu(x::Float64; alpha::Float64=0.01)::Float64 = x > 0 ? x : alpha * x
+leaky_relu_d(x::Float64; alpha::Float64=0.01)::Float64 = x > 0 ? 1.0 : alpha
+
+
+function gelu(x::Float64)::Float64
+    return 0.5 * x * (1 + tanh(sqrt(2 / pi) * (x + 0.044715 * x ^ 3)))
+end
+
+function gelu_d(x::Float64)::Float64
+    phi = 0.5 * (1 + erf_approx(x / sqrt(2.0)))
+    pdf = exp(-0.5 * x * x) / sqrt(2pi)
+    return phi + x * pdf
+end
+
+
+swish(x::Float64)::Float64 = x * sigmoid(x)
+function swish_d(x::Float64)::Float64
+    s = sigmoid(x)
+    return s + x * s * (1 - s)
+end
+
+
+function softmax(xs::Vector{Float64})::Vector{Float64}
+    m = maximum(xs)
+    exps = exp.(xs .- m)
+    return exps ./ sum(exps)
+end
+
+
+function gradient_scan(name::String, deriv; start::Float64=-5.0, stop::Float64=5.0, n::Int=100)
+    step = (stop - start) / n
+    near_zero = 0
+    healthy = 0
+    for i in 0:(n - 1)
+        x = start + i * step
+        g = deriv(x)
+        if abs(g) < 0.01
+            near_zero += 1
+        else
+            healthy += 1
+        end
+    end
+    pct_dead = near_zero / n * 100
+    @printf("%-15s: %3d healthy, %3d near-zero (%.0f%% dead zone)\n",
+            name, healthy, near_zero, pct_dead)
+end
+
+
+function vanishing_gradient_experiment(act, name::String; n_layers::Int=10, n_inputs::Int=5)
+    rng = MersenneTwister(42)
+    values = randn(rng, n_inputs)
+    println("\n$name through $n_layers layers:")
+    for layer in 1:n_layers
+        weights = randn(rng, n_inputs)
+        z = sum(weights .* values)
+        activated = act(z)
+        magnitude = abs(activated)
+        bar_len = isfinite(magnitude) ? clamp(Int(round(magnitude * 20)), 0, 60) : 0
+        bar = "#" ^ bar_len
+        @printf("  Layer %2d: magnitude = %.6f %s\n", layer, magnitude, bar)
+        values = fill(activated, n_inputs)
+    end
+end
+
+
+function dead_neuron_detector(; n_inputs::Int=5, hidden_size::Int=20, n_samples::Int=1000)
+    rng = MersenneTwister(0)
+    weights = randn(rng, hidden_size, n_inputs)
+    biases = randn(rng, hidden_size)
+    fire_counts = zeros(Int, hidden_size)
+
+    for _ in 1:n_samples
+        inputs = randn(rng, n_inputs)
+        for n_idx in 1:hidden_size
+            z = sum(weights[n_idx, :] .* inputs) + biases[n_idx]
+            if relu(z) > 0
+                fire_counts[n_idx] += 1
+            end
+        end
+    end
+
+    dead = count(==(0), fire_counts)
+    rarely = count(c -> 0 < c < n_samples * 0.05, fire_counts)
+    healthy = hidden_size - dead - rarely
+    println("\nDead Neuron Report ($hidden_size neurons, $n_samples samples):")
+    println("  Dead (never fired):     $dead")
+    println("  Barely alive (<5%):     $rarely")
+    println("  Healthy:                $healthy")
+    @printf("  Dead neuron rate:       %.1f%%\n", dead / hidden_size * 100)
+    for (i, c) in enumerate(fire_counts)
+        status = c == 0 ? "DEAD" : (c < n_samples * 0.05 ? "WEAK" : "OK")
+        bar = "#" ^ (c * 40 ÷ n_samples)
+        @printf("  Neuron %2d: %4d/%d fires [%-4s] %s\n", i - 1, c, n_samples, status, bar)
+    end
+end
+
+
+function make_circle_data(; n::Int=200, seed::Int=42)
+    rng = MersenneTwister(seed)
+    data = Tuple{Vector{Float64}, Float64}[]
+    for _ in 1:n
+        x = rand(rng) * 4 - 2
+        y = rand(rng) * 4 - 2
+        label = x * x + y * y < 1.5 ? 1.0 : 0.0
+        push!(data, (Float64[x, y], label))
+    end
+    return data
+end
+
+
+mutable struct ActivationNetwork
+    act::Function
+    act_d::Function
+    lr::Float64
+    hidden_size::Int
+    w1::Matrix{Float64}
+    b1::Vector{Float64}
+    w2::Vector{Float64}
+    b2::Float64
+    # caches
+    x::Vector{Float64}
+    z1::Vector{Float64}
+    h::Vector{Float64}
+    z2::Float64
+    out::Float64
+end
+
+function ActivationNetwork(act, act_d; hidden_size::Int=8, lr::Float64=0.1, seed::Int=0)
+    rng = MersenneTwister(seed)
+    return ActivationNetwork(
+        act, act_d, lr, hidden_size,
+        randn(rng, hidden_size, 2) .* 0.5,
+        zeros(Float64, hidden_size),
+        randn(rng, hidden_size) .* 0.5,
+        0.0,
+        Float64[], zeros(Float64, hidden_size), zeros(Float64, hidden_size),
+        0.0, 0.0,
+    )
+end
+
+
+function forward!(net::ActivationNetwork, x::Vector{Float64})::Float64
+    net.x = x
+    for i in 1:net.hidden_size
+        z = net.w1[i, 1] * x[1] + net.w1[i, 2] * x[2] + net.b1[i]
+        net.z1[i] = z
+        net.h[i] = net.act(z)
+    end
+    net.z2 = sum(net.w2 .* net.h) + net.b2
+    net.out = sigmoid(net.z2)
+    return net.out
+end
+
+
+function backward!(net::ActivationNetwork, target::Float64)
+    err = net.out - target
+    d_out = err * net.out * (1 - net.out)
+    for i in 1:net.hidden_size
+        d_h = d_out * net.w2[i] * net.act_d(net.z1[i])
+        net.w2[i] -= net.lr * d_out * net.h[i]
+        net.w1[i, 1] -= net.lr * d_h * net.x[1]
+        net.w1[i, 2] -= net.lr * d_h * net.x[2]
+        net.b1[i] -= net.lr * d_h
+    end
+    net.b2 -= net.lr * d_out
+end
+
+
+function train!(net::ActivationNetwork, data::Vector{Tuple{Vector{Float64}, Float64}};
+                epochs::Int=200)
+    losses = Float64[]
+    for epoch in 0:(epochs - 1)
+        total = 0.0
+        correct = 0
+        for (x, y) in data
+            pred = forward!(net, x)
+            backward!(net, y)
+            total += (pred - y) ^ 2
+            if (pred >= 0.5) == (y >= 0.5)
+                correct += 1
+            end
+        end
+        avg = total / length(data)
+        acc = correct / length(data) * 100
+        push!(losses, avg)
+        if epoch % 50 == 0 || epoch == epochs - 1
+            @printf("    Epoch %3d: loss=%.4f, accuracy=%.1f%%\n", epoch, avg, acc)
+        end
+    end
+    return losses
+end
+
+
+function main()
+    println("=" ^ 60)
+    println("STEP 1: Activation Function Values")
+    println("=" ^ 60)
+    for x in [-2.0, -1.0, -0.5, 0.0, 0.5, 1.0, 2.0]
+        @printf("  x=%5.1f  sigmoid=%.4f  tanh=%.4f  relu=%.4f  gelu=%.4f  swish=%.4f\n",
+                x, sigmoid(x), tanh_act(x), relu(x), gelu(x), swish(x))
+    end
+
+    println("\n  softmax([2.0, 1.0, 0.1]) = $(round.(softmax(Float64[2.0, 1.0, 0.1]), digits=6))")
+    println("  softmax([10, 10, 10])    = $(round.(softmax(Float64[10, 10, 10]), digits=6))")
+
+    println("\n" * "=" ^ 60)
+    println("STEP 2: Gradient Dead Zones")
+    println("=" ^ 60)
+    gradient_scan("Sigmoid", sigmoid_d)
+    gradient_scan("Tanh", tanh_d)
+    gradient_scan("ReLU", relu_d)
+    gradient_scan("Leaky ReLU", leaky_relu_d)
+    gradient_scan("GELU", gelu_d)
+    gradient_scan("Swish", swish_d)
+
+    println("\n" * "=" ^ 60)
+    println("STEP 3: Vanishing Gradient Experiment")
+    println("=" ^ 60)
+    vanishing_gradient_experiment(sigmoid, "Sigmoid")
+    vanishing_gradient_experiment(relu, "ReLU")
+    vanishing_gradient_experiment(gelu, "GELU")
+
+    println("\n" * "=" ^ 60)
+    println("STEP 4: Dead Neuron Detection")
+    println("=" ^ 60)
+    dead_neuron_detector()
+
+    println("\n" * "=" ^ 60)
+    println("STEP 5: Training Comparison (Circle Dataset)")
+    println("=" ^ 60)
+    data = make_circle_data()
+    configs = [
+        ("Sigmoid", sigmoid, sigmoid_d),
+        ("ReLU", relu, relu_d),
+        ("GELU", gelu, gelu_d),
+    ]
+    results = Dict{String, Vector{Float64}}()
+    for (name, act, act_d) in configs
+        println("\n--- Training with $name ---")
+        net = ActivationNetwork(act, act_d; hidden_size=8, lr=0.1)
+        losses = train!(net, data; epochs=200)
+        results[name] = losses
+    end
+
+    println("\n=== Final Loss Comparison ===")
+    for (name, _, _) in configs
+        losses = results[name]
+        improvement = losses[1] > 0 ? (1 - losses[end] / losses[1]) * 100 : 0.0
+        @printf("  %-10s: start=%.4f -> end=%.4f (improvement: %.1f%%)\n",
+                name, losses[1], losses[end], improvement)
+    end
+end
+
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    main()
+end

--- a/phases/03-deep-learning-core/05-loss-functions/code/main.jl
+++ b/phases/03-deep-learning-core/05-loss-functions/code/main.jl
@@ -1,0 +1,324 @@
+# Loss functions in Julia. MSE, MAE, binary cross-entropy,
+# categorical cross-entropy + softmax, and focal loss for imbalanced
+# classification — each with its analytical gradient.
+# Stdlib only. Sources:
+#   https://arxiv.org/abs/1708.02002  (Focal loss: Lin et al.)
+#   https://docs.julialang.org/en/v1/base/math/
+
+using Random
+using Statistics
+using Printf
+
+
+function mse(preds::Vector{Float64}, targets::Vector{Float64})::Float64
+    @assert length(preds) == length(targets)
+    return sum((preds .- targets) .^ 2) / length(preds)
+end
+
+
+function mse_grad(preds::Vector{Float64}, targets::Vector{Float64})::Vector{Float64}
+    @assert length(preds) == length(targets)
+    n = length(preds)
+    return 2.0 .* (preds .- targets) ./ n
+end
+
+
+function mae(preds::Vector{Float64}, targets::Vector{Float64})::Float64
+    @assert length(preds) == length(targets)
+    return sum(abs.(preds .- targets)) / length(preds)
+end
+
+
+function mae_grad(preds::Vector{Float64}, targets::Vector{Float64})::Vector{Float64}
+    @assert length(preds) == length(targets)
+    n = length(preds)
+    return sign.(preds .- targets) ./ n
+end
+
+
+function binary_cross_entropy(preds::Vector{Float64}, targets::Vector{Float64};
+                              eps::Float64=1e-15)::Float64
+    @assert length(preds) == length(targets)
+    n = length(preds)
+    total = 0.0
+    for i in 1:n
+        p = clamp(preds[i], eps, 1 - eps)
+        t = targets[i]
+        total += -(t * log(p) + (1 - t) * log(1 - p))
+    end
+    return total / n
+end
+
+
+function bce_grad(preds::Vector{Float64}, targets::Vector{Float64};
+                  eps::Float64=1e-15)::Vector{Float64}
+    n = length(preds)
+    grads = zeros(Float64, n)
+    for i in 1:n
+        p = clamp(preds[i], eps, 1 - eps)
+        t = targets[i]
+        grads[i] = (-(t / p) + (1 - t) / (1 - p)) / n
+    end
+    return grads
+end
+
+
+function softmax(logits::Vector{Float64})::Vector{Float64}
+    m = maximum(logits)
+    exps = exp.(logits .- m)
+    return exps ./ sum(exps)
+end
+
+
+# target_index is 0-indexed to mirror the Python lesson.
+function categorical_cross_entropy(logits::Vector{Float64}, target_index::Int;
+                                   eps::Float64=1e-15)::Float64
+    probs = softmax(logits)
+    p = max(eps, probs[target_index + 1])
+    return -log(p)
+end
+
+
+function cce_grad(logits::Vector{Float64}, target_index::Int)::Vector{Float64}
+    probs = softmax(logits)
+    grads = copy(probs)
+    grads[target_index + 1] -= 1.0
+    return grads
+end
+
+
+# Focal loss for binary classification (sigmoid outputs).
+# Down-weights easy examples by (1 - p_t)^gamma so the model
+# focuses on hard ones; useful for class imbalance.
+function focal_loss(preds::Vector{Float64}, targets::Vector{Float64};
+                    gamma::Float64=2.0, alpha::Float64=0.25,
+                    eps::Float64=1e-15)::Float64
+    @assert length(preds) == length(targets)
+    n = length(preds)
+    total = 0.0
+    for i in 1:n
+        p = clamp(preds[i], eps, 1 - eps)
+        t = targets[i]
+        pt = t * p + (1 - t) * (1 - p)
+        at = t * alpha + (1 - t) * (1 - alpha)
+        total += -at * (1 - pt) ^ gamma * log(pt)
+    end
+    return total / n
+end
+
+
+function focal_grad(preds::Vector{Float64}, targets::Vector{Float64};
+                    gamma::Float64=2.0, alpha::Float64=0.25,
+                    eps::Float64=1e-15)::Vector{Float64}
+    n = length(preds)
+    grads = zeros(Float64, n)
+    for i in 1:n
+        p = clamp(preds[i], eps, 1 - eps)
+        t = targets[i]
+        pt = t * p + (1 - t) * (1 - p)
+        at = t * alpha + (1 - t) * (1 - alpha)
+        # d(pt)/d(p) = 2t - 1 (1 if t==1, -1 if t==0).
+        dpt_dp = 2 * t - 1
+        # d/dp [-(1-pt)^gamma * log(pt)] applied via chain rule.
+        base = (1 - pt) ^ (gamma - 1)
+        term = base * (gamma * log(pt) - (1 - pt) / pt)
+        grads[i] = at * term * dpt_dp / n
+    end
+    return grads
+end
+
+
+function sigmoid(x::Float64)::Float64
+    return 1.0 / (1.0 + exp(-clamp(x, -500.0, 500.0)))
+end
+
+
+function make_circle_data(; n::Int=200, seed::Int=42)
+    rng = MersenneTwister(seed)
+    data = Tuple{Vector{Float64}, Float64}[]
+    for _ in 1:n
+        x = rand(rng) * 4 - 2
+        y = rand(rng) * 4 - 2
+        label = x * x + y * y < 1.5 ? 1.0 : 0.0
+        push!(data, (Float64[x, y], label))
+    end
+    return data
+end
+
+
+mutable struct LossNetwork
+    loss_type::Symbol  # :mse or :bce
+    lr::Float64
+    hidden_size::Int
+    w1::Matrix{Float64}
+    b1::Vector{Float64}
+    w2::Vector{Float64}
+    b2::Float64
+    x::Vector{Float64}
+    z1::Vector{Float64}
+    h::Vector{Float64}
+    out::Float64
+end
+
+function LossNetwork(loss_type::Symbol; hidden_size::Int=8, lr::Float64=0.1, seed::Int=0)
+    rng = MersenneTwister(seed)
+    return LossNetwork(
+        loss_type, lr, hidden_size,
+        randn(rng, hidden_size, 2) .* 0.5,
+        zeros(Float64, hidden_size),
+        randn(rng, hidden_size) .* 0.5,
+        0.0,
+        Float64[], zeros(Float64, hidden_size), zeros(Float64, hidden_size), 0.0,
+    )
+end
+
+
+function forward!(net::LossNetwork, x::Vector{Float64})::Float64
+    net.x = x
+    for i in 1:net.hidden_size
+        z = net.w1[i, 1] * x[1] + net.w1[i, 2] * x[2] + net.b1[i]
+        net.z1[i] = z
+        net.h[i] = max(0.0, z)
+    end
+    z2 = sum(net.w2 .* net.h) + net.b2
+    net.out = sigmoid(z2)
+    return net.out
+end
+
+
+function backward!(net::LossNetwork, target::Float64)
+    eps = 1e-15
+    p = clamp(net.out, eps, 1 - eps)
+    d_loss = net.loss_type == :mse ? 2.0 * (net.out - target) :
+                                     -(target / p) + (1 - target) / (1 - p)
+    d_sig = net.out * (1 - net.out)
+    d_out = d_loss * d_sig
+    for i in 1:net.hidden_size
+        d_relu = net.z1[i] > 0 ? 1.0 : 0.0
+        d_h = d_out * net.w2[i] * d_relu
+        net.w2[i] -= net.lr * d_out * net.h[i]
+        net.w1[i, 1] -= net.lr * d_h * net.x[1]
+        net.w1[i, 2] -= net.lr * d_h * net.x[2]
+        net.b1[i] -= net.lr * d_h
+    end
+    net.b2 -= net.lr * d_out
+end
+
+
+function compute_loss(net::LossNetwork, pred::Float64, target::Float64)::Float64
+    eps = 1e-15
+    p = clamp(pred, eps, 1 - eps)
+    return net.loss_type == :mse ? (pred - target) ^ 2 :
+           -(target * log(p) + (1 - target) * log(1 - p))
+end
+
+
+function train!(net::LossNetwork, data::Vector{Tuple{Vector{Float64}, Float64}};
+                epochs::Int=200)
+    history = Tuple{Float64, Float64}[]
+    for epoch in 0:(epochs - 1)
+        total = 0.0
+        correct = 0
+        for (x, y) in data
+            pred = forward!(net, x)
+            backward!(net, y)
+            total += compute_loss(net, pred, y)
+            if (pred >= 0.5) == (y >= 0.5)
+                correct += 1
+            end
+        end
+        avg = total / length(data)
+        acc = correct / length(data) * 100
+        push!(history, (avg, acc))
+        if epoch % 50 == 0 || epoch == epochs - 1
+            @printf("    Epoch %3d: loss=%.4f, accuracy=%.1f%%\n", epoch, avg, acc)
+        end
+    end
+    return history
+end
+
+
+function main()
+    println("=" ^ 60)
+    println("STEP 1: MSE Loss")
+    println("=" ^ 60)
+    preds = Float64[0.9, 0.1, 0.7, 0.4]
+    targets = Float64[1.0, 0.0, 1.0, 0.0]
+    println("  Predictions: $preds")
+    println("  Targets:     $targets")
+    @printf("  MSE Loss:    %.6f\n", mse(preds, targets))
+    println("  MSE Grads:   $(round.(mse_grad(preds, targets), digits=4))")
+
+    println("\n" * "=" ^ 60)
+    println("STEP 2: MAE Loss")
+    println("=" ^ 60)
+    @printf("  MAE Loss:    %.6f\n", mae(preds, targets))
+    println("  MAE Grads:   $(round.(mae_grad(preds, targets), digits=4))")
+
+    println("\n" * "=" ^ 60)
+    println("STEP 3: Binary Cross-Entropy")
+    println("=" ^ 60)
+    @printf("  BCE Loss:    %.6f\n", binary_cross_entropy(preds, targets))
+    println("  BCE Grads:   $(round.(bce_grad(preds, targets), digits=4))")
+
+    println("\n  CE loss at different confidence levels (true label = 1):")
+    for conf in [0.01, 0.1, 0.5, 0.9, 0.99]
+        ce = -log(max(1e-15, conf))
+        ms = (conf - 1.0) ^ 2
+        @printf("    p=%.2f: CE=%.4f, MSE=%.4f, ratio=%.1fx\n", conf, ce, ms, ce / max(0.0001, ms))
+    end
+
+    println("\n" * "=" ^ 60)
+    println("STEP 4: Categorical Cross-Entropy + Softmax")
+    println("=" ^ 60)
+    logits = Float64[2.0, 1.0, 0.1, -1.0, 3.0]
+    target_idx = 4   # 0-indexed; 5th class
+    probs = softmax(logits)
+    println("  Logits:  $logits")
+    println("  Softmax: $(round.(probs, digits=4))")
+    println("  Target class: $target_idx")
+    @printf("  CCE Loss: %.6f\n", categorical_cross_entropy(logits, target_idx))
+    println("  Gradient: $(round.(cce_grad(logits, target_idx), digits=4))")
+
+    println("\n" * "=" ^ 60)
+    println("STEP 5: Focal Loss (handles class imbalance)")
+    println("=" ^ 60)
+    # Show focal loss down-weighting easy correct examples vs hard ones.
+    println("  Effect of focal modulator (1 - pt)^gamma for true label = 1:")
+    for p in [0.05, 0.5, 0.95]
+        pt = p
+        modulator = (1 - pt) ^ 2.0
+        ce = -log(max(1e-15, pt))
+        focal = modulator * ce
+        @printf("    p=%.2f  CE=%.4f  modulator=(1-pt)^2=%.4f  Focal=%.4f\n", p, ce, modulator, focal)
+    end
+
+    # Mixed batch: half-correct preds, gamma=2, alpha=0.25.
+    @printf("\n  Batch focal loss (gamma=2, alpha=0.25): %.6f\n",
+            focal_loss(preds, targets))
+    println("  Batch focal grads: $(round.(focal_grad(preds, targets), digits=4))")
+    @printf("\n  Batch BCE for comparison: %.6f\n", binary_cross_entropy(preds, targets))
+
+    println("\n" * "=" ^ 60)
+    println("STEP 6: MSE vs BCE on Classification")
+    println("=" ^ 60)
+    data = make_circle_data()
+    for loss_type in [:mse, :bce]
+        println("\n--- Training with $(uppercase(string(loss_type))) ---")
+        net = LossNetwork(loss_type; hidden_size=8, lr=0.1)
+        history = train!(net, data; epochs=200)
+        final_loss, final_acc = history[end]
+        @printf("  Final: loss=%.4f, accuracy=%.1f%%\n", final_loss, final_acc)
+    end
+
+    println("\n=== Key Takeaway ===")
+    println("  Cross-entropy converges faster on classification because its")
+    println("  gradient stays strong when predictions are wrong. MSE flattens")
+    println("  near 0 and 1 due to sigmoid saturation. Focal loss adds a")
+    println("  modulator that further focuses on hard examples.")
+end
+
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    main()
+end

--- a/phases/03-deep-learning-core/05-loss-functions/code/main.jl
+++ b/phases/03-deep-learning-core/05-loss-functions/code/main.jl
@@ -161,6 +161,8 @@ mutable struct LossNetwork
 end
 
 function LossNetwork(loss_type::Symbol; hidden_size::Int=8, lr::Float64=0.1, seed::Int=0)
+    loss_type in (:mse, :bce) ||
+        throw(ArgumentError("LossNetwork: loss_type must be :mse or :bce, got :$loss_type"))
     rng = MersenneTwister(seed)
     return LossNetwork(
         loss_type, lr, hidden_size,


### PR DESCRIPTION
## Summary

Adds idiomatic, stdlib-only Julia ports for 8 lessons that previously shipped Python only:

Phase 1 (math foundations):
- `phases/01-math-foundations/04-calculus-for-ml` — numerical + analytical derivatives, gradients, gradient descent, Hessian, Taylor expansion, tiny linear regression
- `phases/01-math-foundations/05-chain-rule-and-autodiff` — toy reverse-mode autodiff via `mutable struct Value` with closure-based backward, gradient checking, tiny MLP on XOR
- `phases/01-math-foundations/06-probability-and-distributions` — Bernoulli/Categorical/Poisson PMFs, Normal/Uniform PDFs, Box-Muller sampler, softmax + log-softmax + cross-entropy, marginals, CLT
- `phases/01-math-foundations/08-optimization` — `GradientDescent`, `SGDMomentum`, `Adam` as mutable structs with shared `step!` dispatch; Rosenbrock convergence + saddle-point escape

Phase 3 (deep learning core):
- `phases/03-deep-learning-core/01-the-perceptron` — Rosenblatt perceptron + hand-wired XOR via OR/NAND/AND + trained 2-2-1 sigmoid MLP
- `phases/03-deep-learning-core/03-backpropagation` — matrix-form forward/backward on a 2-layer MLP, XOR + circle classification, gradient check
- `phases/03-deep-learning-core/04-activation-functions` — sigmoid/tanh/ReLU/leaky ReLU/GELU/swish with analytical derivatives, dead-zone scan, vanishing-gradient demo, dead-neuron detection, training comparison (erf hand-rolled via Abramowitz & Stegun)
- `phases/03-deep-learning-core/05-loss-functions` — MSE, MAE, BCE, categorical CE + softmax, focal loss (Lin et al.) with hand-derived gradients, MSE vs BCE training comparison

All files:
- Stdlib only (`Random`, `LinearAlgebra`, `Statistics`, `Printf`)
- 4-6 line top-of-file header with sources cited
- Idiomatic Julia: broadcasting (`.`), multiple dispatch, type annotations on hot paths
- `function main()` + `if abspath(PROGRAM_FILE) == @__FILE__ ... end` guard
- 2315 LOC total across 8 files

`scripts/audit_lessons.py` passes (0 issues). `scripts/build_catalog.py` rebuilt — `code_files` went 435 → 443 (one `main.jl` per lesson). Atomic per-lesson commit, plus one catalog rebuild commit. 9 commits total.

## Test plan

- [ ] `python3 scripts/audit_lessons.py` exits 0
- [ ] `julia phases/01-math-foundations/04-calculus-for-ml/code/main.jl` prints derivatives, gradient descent traces, Taylor table, regression
- [ ] `julia phases/01-math-foundations/05-chain-rule-and-autodiff/code/main.jl` prints autodiff sanity checks, gradient check passes, MLP loss drops
- [ ] `julia phases/01-math-foundations/06-probability-and-distributions/code/main.jl` prints PMFs, PDFs, sampler stats, CLT, marginals
- [ ] `julia phases/01-math-foundations/08-optimization/code/main.jl` prints Rosenbrock convergence (Adam wins, GD slow, SGD+M middling) + saddle escape
- [ ] `julia phases/03-deep-learning-core/01-the-perceptron/code/main.jl` prints AND/OR/NOT convergence, XOR perceptron fails, hand-wired + trained MLP solve XOR
- [ ] `julia phases/03-deep-learning-core/03-backpropagation/code/main.jl` prints XOR loss curve, circle accuracy >85%, gradient check diff < 1e-5
- [ ] `julia phases/03-deep-learning-core/04-activation-functions/code/main.jl` prints activation values, dead-zone scan, vanishing-grad demo, dead-neuron report, training comparison
- [ ] `julia phases/03-deep-learning-core/05-loss-functions/code/main.jl` prints MSE/MAE/BCE/CCE/focal numbers + MSE-vs-BCE training comparison
- [ ] `python3 scripts/build_catalog.py` produces no diff (already committed)