### PR TITLE
feat(phase17): TypeScript ports of 6 infrastructure/production lessons (pass 4)

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -6,7 +6,7 @@
     "skills": 378,
     "prompts": 99,
     "agents": 0,
-    "code_files": 435
+    "code_files": 441
   },
   "phases": [
     {
@@ -10875,7 +10875,8 @@
           "has_quiz": true,
           "has_notebook": true,
           "code_files": [
-            "main.py"
+            "main.py",
+            "main.ts"
           ],
           "outputs": [
             {
@@ -10908,7 +10909,8 @@
           "has_quiz": true,
           "has_notebook": true,
           "code_files": [
-            "main.py"
+            "main.py",
+            "main.ts"
           ],
           "outputs": [
             {
@@ -10939,7 +10941,8 @@
           "has_quiz": true,
           "has_notebook": true,
           "code_files": [
-            "main.py"
+            "main.py",
+            "main.ts"
           ],
           "outputs": [
             {
@@ -10969,7 +10972,8 @@
           "has_quiz": true,
           "has_notebook": true,
           "code_files": [
-            "main.py"
+            "main.py",
+            "main.ts"
           ],
           "outputs": [
             {
@@ -11058,7 +11062,8 @@
           "has_quiz": true,
           "has_notebook": true,
           "code_files": [
-            "main.py"
+            "main.py",
+            "main.ts"
           ],
           "outputs": [
             {
@@ -11092,7 +11097,8 @@
           "has_quiz": true,
           "has_notebook": true,
           "code_files": [
-            "main.py"
+            "main.py",
+            "main.ts"
           ],
           "outputs": [
             {

--- a/phases/17-infrastructure-and-production/13-llm-observability/code/main.ts
+++ b/phases/17-infrastructure-and-production/13-llm-observability/code/main.ts
@@ -1,0 +1,351 @@
+/**
+ * Observability — OpenTelemetry-shaped GenAI tracer + retention simulator (TypeScript).
+ *
+ * Two halves:
+ *   1. Minimal in-memory tracer using the OpenTelemetry GenAI Semantic Convention
+ *      attribute names (gen_ai.system, gen_ai.request.model, gen_ai.usage.*).
+ *      No SDK. Just a structured log emitter you can ship to Helicone/Phoenix/Langfuse
+ *      by swapping the exporter.
+ *   2. The same 1M-trace day retention simulator as main.py, with the five
+ *      sampling strategies and 2026 price approximations.
+ *
+ * Citations: see docs/en.md for OpenTelemetry GenAI conventions, Arize AX zero-copy
+ * pricing claim, Langfuse/Helicone tier comparison.
+ *
+ * Runs on Node 20+ stdlib. No npm deps.
+ */
+
+import { randomUUID, createHash } from "node:crypto";
+
+// -- Tracer ----------------------------------------------------------------
+
+// OpenTelemetry GenAI Semantic Conventions (2025 spec).
+// https://opentelemetry.io/docs/specs/semconv/gen-ai/
+type GenAIAttributes = {
+  "gen_ai.system": string;
+  "gen_ai.request.model": string;
+  "gen_ai.operation.name": "chat" | "text_completion" | "embeddings";
+  "gen_ai.usage.input_tokens"?: number;
+  "gen_ai.usage.output_tokens"?: number;
+  "gen_ai.response.model"?: string;
+  "gen_ai.response.finish_reasons"?: string[];
+  "gen_ai.response.id"?: string;
+  // Optional but useful for cost / cache analysis.
+  "gen_ai.usage.cached_input_tokens"?: number;
+  "gen_ai.request.temperature"?: number;
+};
+
+type SpanStatus = "OK" | "ERROR";
+
+type Span = {
+  traceId: string;
+  spanId: string;
+  parentSpanId?: string;
+  name: string;
+  startNs: bigint;
+  endNs?: bigint;
+  status: SpanStatus;
+  attributes: GenAIAttributes & Record<string, unknown>;
+  events: SpanEvent[];
+};
+
+type SpanEvent = {
+  ts: bigint;
+  name: string;
+  attributes?: Record<string, unknown>;
+};
+
+// Exporter contract: how a real shipper (Helicone, OpenLLMetry, Phoenix) would
+// receive a finished span. Swap this with a real OTLP HTTP exporter in prod.
+type SpanExporter = (span: Readonly<Span>) => void;
+
+class GenAITracer {
+  private active: Span[] = [];
+  private readonly exporter: SpanExporter;
+
+  constructor(exporter: SpanExporter) {
+    this.exporter = exporter;
+  }
+
+  startSpan(name: string, attributes: GenAIAttributes): Span {
+    const parent = this.active[this.active.length - 1];
+    const span: Span = {
+      traceId: parent ? parent.traceId : randomUUID().replace(/-/g, ""),
+      spanId: randomUUID().replace(/-/g, "").slice(0, 16),
+      parentSpanId: parent?.spanId,
+      name,
+      startNs: process.hrtime.bigint(),
+      status: "OK",
+      attributes: { ...attributes },
+      events: [],
+    };
+    this.active.push(span);
+    return span;
+  }
+
+  addEvent(span: Span, name: string, attributes?: Record<string, unknown>): void {
+    span.events.push({ ts: process.hrtime.bigint(), name, attributes });
+  }
+
+  endSpan(span: Span, status: SpanStatus = "OK"): void {
+    span.endNs = process.hrtime.bigint();
+    span.status = status;
+    // Remove from active stack regardless of strict ordering.
+    const idx = this.active.lastIndexOf(span);
+    if (idx >= 0) this.active.splice(idx, 1);
+    this.exporter(span);
+  }
+}
+
+// Console exporter (development). A real exporter would batch and POST to OTLP.
+function consoleExporter(span: Readonly<Span>): void {
+  const durMs =
+    span.endNs !== undefined
+      ? Number(span.endNs - span.startNs) / 1_000_000
+      : 0;
+  const obj = {
+    trace_id: span.traceId,
+    span_id: span.spanId,
+    parent_span_id: span.parentSpanId,
+    name: span.name,
+    duration_ms: Number(durMs.toFixed(3)),
+    status: span.status,
+    attributes: span.attributes,
+    events: span.events.map((e) => ({
+      name: e.name,
+      attributes: e.attributes,
+    })),
+  };
+  console.log(JSON.stringify(obj));
+}
+
+// Sampling exporter — wraps another exporter. Matches the rule set in the
+// retention simulator below: keep all errors + high-cost, sample success at p.
+function makeSamplingExporter(
+  inner: SpanExporter,
+  successRate: number,
+  rng: () => number = Math.random,
+): SpanExporter {
+  return (span) => {
+    const isError = span.status === "ERROR";
+    const inTokens = (span.attributes["gen_ai.usage.input_tokens"] as number) ?? 0;
+    const outTokens =
+      (span.attributes["gen_ai.usage.output_tokens"] as number) ?? 0;
+    const totalTokens = inTokens + outTokens;
+    const isHighCost = totalTokens > 8000;
+    if (isError || isHighCost) {
+      inner(span);
+      return;
+    }
+    if (rng() < successRate) inner(span);
+  };
+}
+
+// -- Mocked LLM call (no network) ------------------------------------------
+
+type MockProvider = "openai" | "anthropic" | "self-hosted";
+
+type MockLLMResult = {
+  text: string;
+  inputTokens: number;
+  outputTokens: number;
+  cachedInputTokens: number;
+  finishReason: "stop" | "length" | "content_filter";
+  responseId: string;
+};
+
+function mockLLMCall(
+  provider: MockProvider,
+  model: string,
+  prompt: string,
+  forceError = false,
+): MockLLMResult {
+  if (forceError) {
+    throw new Error(`${provider}/${model}: simulated rate_limit_exceeded`);
+  }
+  // Toy token counter — 4 chars/token, deterministic per prompt.
+  const inputTokens = Math.max(1, Math.floor(prompt.length / 4));
+  const seed = parseInt(
+    createHash("sha256").update(prompt).digest("hex").slice(0, 8),
+    16,
+  );
+  const outputTokens = 80 + (seed % 220);
+  const cachedInputTokens = prompt.includes("system prompt cached")
+    ? Math.floor(inputTokens * 0.9)
+    : 0;
+  return {
+    text: `[mock ${provider}/${model}] echo: ${prompt.slice(0, 40)}`,
+    inputTokens,
+    outputTokens,
+    cachedInputTokens,
+    finishReason: outputTokens > 250 ? "length" : "stop",
+    responseId: `resp_${seed.toString(16)}`,
+  };
+}
+
+function traceLLMCall(
+  tracer: GenAITracer,
+  provider: MockProvider,
+  model: string,
+  prompt: string,
+  forceError = false,
+): MockLLMResult | undefined {
+  const span = tracer.startSpan("chat.completion", {
+    "gen_ai.system": provider,
+    "gen_ai.request.model": model,
+    "gen_ai.operation.name": "chat",
+    "gen_ai.request.temperature": 0.7,
+  });
+  tracer.addEvent(span, "prompt.user", { length: prompt.length });
+  try {
+    const result = mockLLMCall(provider, model, prompt, forceError);
+    span.attributes["gen_ai.response.model"] = model;
+    span.attributes["gen_ai.usage.input_tokens"] = result.inputTokens;
+    span.attributes["gen_ai.usage.output_tokens"] = result.outputTokens;
+    span.attributes["gen_ai.usage.cached_input_tokens"] =
+      result.cachedInputTokens;
+    span.attributes["gen_ai.response.finish_reasons"] = [result.finishReason];
+    span.attributes["gen_ai.response.id"] = result.responseId;
+    tracer.endSpan(span, "OK");
+    return result;
+  } catch (err) {
+    span.attributes["error.type"] = "rate_limit_exceeded";
+    tracer.addEvent(span, "exception", { message: String(err) });
+    tracer.endSpan(span, "ERROR");
+    return undefined;
+  }
+}
+
+// -- Retention / cost simulator -------------------------------------------
+
+const BYTES_PER_TRACE = 4500;
+const COST_PER_GB_MONTH = 0.023; // S3 standard 2026 approx
+const OBSERVABILITY_INGEST_PER_GB = 0.5; // Datadog-class
+const ARIZE_AX_PER_GB = 0.005; // zero-copy Iceberg claim
+
+type Strategy = {
+  name: string;
+  sampleRate: number;
+  keepErrors: boolean;
+  keepHighCost: boolean;
+};
+
+const STRATEGIES: Strategy[] = [
+  { name: "100% retain", sampleRate: 1.0, keepErrors: true, keepHighCost: true },
+  { name: "10% random sample", sampleRate: 0.1, keepErrors: false, keepHighCost: false },
+  { name: "5% success + 100% errors", sampleRate: 0.05, keepErrors: true, keepHighCost: false },
+  { name: "5% success + errors + $$$", sampleRate: 0.05, keepErrors: true, keepHighCost: true },
+  { name: "1% aggregates only", sampleRate: 0.01, keepErrors: true, keepHighCost: true },
+];
+
+// Mulberry32 PRNG — deterministic, no deps.
+function makeRng(seed: number): () => number {
+  let s = seed >>> 0;
+  return function () {
+    s = (s + 0x6d2b79f5) >>> 0;
+    let t = s;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+type SimResult = {
+  name: string;
+  retained: number;
+  lost: number;
+  gbPerDay: number;
+  s3Month: number;
+  monolithicMonth: number;
+  arizeMonth: number;
+};
+
+function simulateDay(strategy: Strategy, tracesPerDay = 1_000_000): SimResult {
+  const rng = makeRng(7);
+  let retained = 0;
+  let lost = 0;
+  for (let i = 0; i < tracesPerDay; i++) {
+    const isError = rng() < 0.02;
+    const isHighCost = rng() < 0.01;
+    let keep = rng() < strategy.sampleRate;
+    if (strategy.keepErrors && isError) keep = true;
+    if (strategy.keepHighCost && isHighCost) keep = true;
+    if (keep) retained++;
+    else lost++;
+  }
+  const bytesRetained = retained * BYTES_PER_TRACE;
+  const gb = bytesRetained / 1e9;
+  return {
+    name: strategy.name,
+    retained,
+    lost,
+    gbPerDay: gb,
+    s3Month: gb * 30 * COST_PER_GB_MONTH,
+    monolithicMonth: gb * 30 * OBSERVABILITY_INGEST_PER_GB,
+    arizeMonth: gb * 30 * ARIZE_AX_PER_GB,
+  };
+}
+
+function pad(s: string | number, n: number, left = true): string {
+  const str = String(s);
+  if (str.length >= n) return str;
+  const padding = " ".repeat(n - str.length);
+  return left ? padding + str : str + padding;
+}
+
+function reportRow(r: SimResult): void {
+  console.log(
+    `${pad(r.name, 30, false)}  ` +
+      `retained=${pad(r.retained, 7)}  ` +
+      `lost=${pad(r.lost, 7)}  ` +
+      `${pad(r.gbPerDay.toFixed(2), 6)} GB/day  ` +
+      `mono=$${pad(r.monolithicMonth.toFixed(2), 8)}  ` +
+      `arize=$${pad(r.arizeMonth.toFixed(2), 6)}  ` +
+      `s3=$${pad(r.s3Month.toFixed(2), 5)}`,
+  );
+}
+
+// -- Demo ------------------------------------------------------------------
+
+function tracerDemo(): void {
+  console.log("--- GenAI tracer (OpenTelemetry attribute shape) ---");
+  const tracer = new GenAITracer(consoleExporter);
+  traceLLMCall(tracer, "openai", "gpt-4o-mini", "What is the capital of France?");
+  traceLLMCall(tracer, "anthropic", "claude-3-5-sonnet", "Summarise system prompt cached document");
+  // Simulate an error path.
+  traceLLMCall(tracer, "self-hosted", "llama-3-70b", "boom", true);
+
+  console.log("\n--- Sampling exporter: 5% success + 100% errors + high-cost ---");
+  const sampled = new GenAITracer(
+    makeSamplingExporter(consoleExporter, 0.05, makeRng(42)),
+  );
+  for (let i = 0; i < 5; i++) {
+    traceLLMCall(sampled, "openai", "gpt-4o-mini", `query ${i}`);
+  }
+  traceLLMCall(sampled, "openai", "gpt-4o-mini", "ratelimit", true);
+}
+
+function retentionDemo(): void {
+  console.log("\n" + "=".repeat(120));
+  console.log(
+    "OBSERVABILITY SAMPLING — 1M traces/day, 2026 price approximations",
+  );
+  console.log("=".repeat(120));
+  for (const s of STRATEGIES) reportRow(simulateDay(s));
+  console.log(
+    "\nRead: 100% retention on Datadog-class costs hundreds of $/day.",
+  );
+  console.log(
+    "5% success + 100% errors + high-cost keeps signal, cuts 90% of bill.",
+  );
+  console.log(
+    "Arize AX zero-copy pattern wins at scale when you already have a data lake.",
+  );
+}
+
+function main(): void {
+  tracerDemo();
+  retentionDemo();
+}
+
+main();

--- a/phases/17-infrastructure-and-production/14-prompt-semantic-caching/code/main.ts
+++ b/phases/17-infrastructure-and-production/14-prompt-semantic-caching/code/main.ts
@@ -1,0 +1,410 @@
+/**
+ * Prompt + semantic caching — TypeScript port.
+ *
+ * Three pieces:
+ *   1. LRU cache with TTL (the L2 prompt-prefix layer's interface — provider does
+ *      this; we model it).
+ *   2. Semantic cache with cosine-similarity threshold (L1 layer). Uses a
+ *      deterministic word-hash "embedding" so the demo is reproducible and
+ *      requires no model. Swap embed() with a real embedding call in prod.
+ *   3. Two-layer simulator matching main.py, exercising the parallel-write
+ *      anti-pattern with 5-min vs 1-hour TTL premiums.
+ *
+ * Pricing snapshot: 2026-04, captured from docs.anthropic.com / platform.openai.com
+ * via docs/en.md. Verify rate cards before quoting.
+ *
+ * Citations:
+ *   - Anthropic prompt-caching: docs.anthropic.com/en/docs/build-with-claude/prompt-caching
+ *   - OpenAI prompt-caching: platform.openai.com/docs/guides/prompt-caching
+ *   - ProjectDiscovery 7%→74% by moving dynamic content out of prefix
+ *     https://projectdiscovery.io/blog/how-we-cut-llm-cost-with-prompt-caching
+ *
+ * Runs on Node 20+ stdlib. No npm deps.
+ */
+
+import { createHash } from "node:crypto";
+
+// -- Pricing constants (2026-04) -------------------------------------------
+
+const BASE_INPUT = 3.0; // $/M input tokens (Claude Sonnet class)
+const BASE_OUTPUT = 15.0; // $/M output tokens
+const CACHED_INPUT = 0.3; // ~10x cheaper read
+const CACHE_WRITE_5MIN = 1.25 * BASE_INPUT;
+const CACHE_WRITE_1HR = 2.0 * BASE_INPUT;
+
+// -- LRU cache with TTL ----------------------------------------------------
+
+// Map preserves insertion order in JS; we exploit that for LRU.
+class LRUCache<K, V> {
+  private readonly map = new Map<K, { value: V; expiresAt: number }>();
+  private readonly capacity: number;
+  private readonly ttlMs: number;
+  private readonly now: () => number;
+
+  constructor(capacity: number, ttlMs: number, now: () => number = Date.now) {
+    if (capacity <= 0) throw new Error("capacity must be positive");
+    this.capacity = capacity;
+    this.ttlMs = ttlMs;
+    this.now = now;
+  }
+
+  get(key: K): V | undefined {
+    const entry = this.map.get(key);
+    if (!entry) return undefined;
+    if (entry.expiresAt <= this.now()) {
+      this.map.delete(key);
+      return undefined;
+    }
+    // Refresh LRU position.
+    this.map.delete(key);
+    this.map.set(key, entry);
+    return entry.value;
+  }
+
+  set(key: K, value: V): void {
+    if (this.map.has(key)) this.map.delete(key);
+    this.map.set(key, { value, expiresAt: this.now() + this.ttlMs });
+    if (this.map.size > this.capacity) {
+      const oldest = this.map.keys().next();
+      if (!oldest.done) this.map.delete(oldest.value);
+    }
+  }
+
+  has(key: K): boolean {
+    return this.get(key) !== undefined;
+  }
+
+  get size(): number {
+    return this.map.size;
+  }
+}
+
+// -- Semantic cache --------------------------------------------------------
+
+// Toy deterministic embedding: bucket each lowercased word into 64 dims by hash.
+// This is enough to demonstrate cosine threshold behavior; replace with a real
+// embedding provider for production (text-embedding-3-small, voyage-3, etc.).
+const EMBED_DIM = 64;
+
+function embed(text: string): Float32Array {
+  const vec = new Float32Array(EMBED_DIM);
+  const tokens = text
+    .toLowerCase()
+    .replace(/[^a-z0-9 ]/g, " ")
+    .split(/\s+/)
+    .filter((s) => s.length > 0);
+  for (const tok of tokens) {
+    const h = createHash("sha256").update(tok).digest();
+    const idx = h.readUInt16BE(0) % EMBED_DIM;
+    // Sign bit from second pair so we get spread, not pure positive.
+    const sign = h[2] & 1 ? 1 : -1;
+    vec[idx] += sign;
+  }
+  // L2-normalize so cosine = dot product.
+  let norm = 0;
+  for (let i = 0; i < EMBED_DIM; i++) norm += vec[i] * vec[i];
+  norm = Math.sqrt(norm);
+  if (norm > 0) for (let i = 0; i < EMBED_DIM; i++) vec[i] /= norm;
+  return vec;
+}
+
+function cosine(a: Float32Array, b: Float32Array): number {
+  let dot = 0;
+  for (let i = 0; i < EMBED_DIM; i++) dot += a[i] * b[i];
+  return dot;
+}
+
+type SemanticEntry = { vec: Float32Array; response: string };
+
+class SemanticCache {
+  private readonly entries: SemanticEntry[] = [];
+  private readonly threshold: number;
+  private readonly capacity: number;
+
+  constructor(threshold = 0.95, capacity = 1000) {
+    if (threshold < 0 || threshold > 1) {
+      throw new Error("threshold must be in [0,1]");
+    }
+    this.threshold = threshold;
+    this.capacity = capacity;
+  }
+
+  // Returns best match above threshold, or undefined.
+  lookup(prompt: string): { response: string; similarity: number } | undefined {
+    const q = embed(prompt);
+    let bestSim = -1;
+    let bestIdx = -1;
+    for (let i = 0; i < this.entries.length; i++) {
+      const sim = cosine(q, this.entries[i].vec);
+      if (sim > bestSim) {
+        bestSim = sim;
+        bestIdx = i;
+      }
+    }
+    if (bestIdx >= 0 && bestSim >= this.threshold) {
+      return { response: this.entries[bestIdx].response, similarity: bestSim };
+    }
+    return undefined;
+  }
+
+  store(prompt: string, response: string): void {
+    if (this.entries.length >= this.capacity) this.entries.shift();
+    this.entries.push({ vec: embed(prompt), response });
+  }
+
+  get size(): number {
+    return this.entries.length;
+  }
+}
+
+// -- Workload + simulator --------------------------------------------------
+
+// Mulberry32 PRNG.
+function makeRng(seed: number): () => number {
+  let s = seed >>> 0;
+  return function () {
+    s = (s + 0x6d2b79f5) >>> 0;
+    let t = s;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function pickFrom<T>(rng: () => number, arr: readonly T[]): T {
+  return arr[Math.floor(rng() * arr.length)];
+}
+
+type Request = {
+  promptTokens: number;
+  prefixHash: string;
+  isParallelWave: boolean;
+  arrivedAt: number;
+  semanticKey: string;
+};
+
+function makeWorkload(n = 500, seed = 7): Request[] {
+  const rng = makeRng(seed);
+  const reqs: Request[] = [];
+  const prefixes = Array.from({ length: 12 }, (_, i) => `prefix_${i}`);
+  // A small set of FAQ-style canonical queries — drives L1 hit rate.
+  const faqs = [
+    "what is your refund policy",
+    "how do I reset my password",
+    "what are your office hours",
+    "how do I contact support",
+  ];
+  let now = 0.0;
+  while (reqs.length < n) {
+    if (rng() < 0.4) {
+      for (let k = 0; k < 5; k++) {
+        reqs.push({
+          promptTokens: pickFrom(rng, [2000, 4000, 8000]),
+          prefixHash: pickFrom(rng, prefixes),
+          isParallelWave: true,
+          arrivedAt: now,
+          semanticKey: pickFrom(rng, faqs),
+        });
+      }
+      now += 0.1 + rng() * 1.9;
+    } else {
+      reqs.push({
+        promptTokens: pickFrom(rng, [2000, 4000, 8000]),
+        prefixHash: pickFrom(rng, prefixes),
+        isParallelWave: false,
+        arrivedAt: now,
+        semanticKey: pickFrom(rng, faqs),
+      });
+      now += 0.1 + rng() * 1.9;
+    }
+  }
+  return reqs;
+}
+
+type Config = {
+  l1Enabled: boolean;
+  l2Enabled: boolean;
+  parallelPenalty: boolean;
+  l1Threshold: number;
+  l1HitProb: number;
+  ttl: "5min" | "1hr";
+};
+
+type SimResult = {
+  cost: number;
+  l1Hits: number;
+  l2Reads: number;
+  l2Writes: number;
+};
+
+function simulate(reqs: readonly Request[], cfg: Config): SimResult {
+  // L2 modeled as a set of prefix hashes seen "long enough ago" to be cached.
+  // L2 LRU here exists to demonstrate the API; the simulator uses a simpler
+  // set + parallel-wave flag (matches main.py's semantics).
+  const _l2Lru = new LRUCache<string, true>(
+    1024,
+    cfg.ttl === "5min" ? 5 * 60_000 : 60 * 60_000,
+  );
+  void _l2Lru; // referenced so the cache is exercised; behavior tied to set below
+  const l2Cache = new Set<string>();
+  const semantic = new SemanticCache(cfg.l1Threshold);
+
+  // Pre-warm semantic cache with canned answers for FAQ keys so we get hits.
+  semantic.store("what is your refund policy", "Refunds within 30 days.");
+  semantic.store("how do I reset my password", "Use the forgot-password link.");
+  semantic.store("what are your office hours", "Mon–Fri 9–5 PT.");
+  semantic.store("how do I contact support", "Email support@example.com.");
+
+  let l2Writes = 0;
+  let l2Reads = 0;
+  let l1Hits = 0;
+  let cost = 0.0;
+  const rng = makeRng(11);
+
+  for (const r of reqs) {
+    // L1 layer.
+    if (cfg.l1Enabled) {
+      // Inject randomized hit ratio per the simulator contract:
+      // l1HitProb fraction of requests is "semantically close enough" to a
+      // pre-warmed FAQ entry; we look it up to keep the path real.
+      if (rng() < cfg.l1HitProb) {
+        const hit = semantic.lookup(r.semanticKey);
+        if (hit) {
+          l1Hits++;
+          continue;
+        }
+      }
+    }
+
+    // L2 layer.
+    if (cfg.l2Enabled) {
+      if (l2Cache.has(r.prefixHash)) {
+        l2Reads++;
+        cost += (r.promptTokens / 1e6) * CACHED_INPUT;
+      } else {
+        const writeCost =
+          cfg.ttl === "5min" ? CACHE_WRITE_5MIN : CACHE_WRITE_1HR;
+        cost += (r.promptTokens / 1e6) * writeCost;
+        l2Writes++;
+        if (!(cfg.parallelPenalty && r.isParallelWave)) {
+          l2Cache.add(r.prefixHash);
+        }
+      }
+    } else {
+      cost += (r.promptTokens / 1e6) * BASE_INPUT;
+    }
+
+    // Output cost — held constant at 200 tokens.
+    cost += (200 / 1e6) * BASE_OUTPUT;
+  }
+
+  return { cost, l1Hits, l2Reads, l2Writes };
+}
+
+function report(label: string, cfg: Config, reqs: readonly Request[]): void {
+  const res = simulate(reqs, cfg);
+  const padLabel = label.padEnd(45);
+  const cost = `$${res.cost.toFixed(2)}`.padStart(8);
+  console.log(
+    `${padLabel}  cost=${cost}  L1=${String(res.l1Hits).padStart(4)}  ` +
+      `L2_reads=${String(res.l2Reads).padStart(4)}  ` +
+      `L2_writes=${String(res.l2Writes).padStart(4)}`,
+  );
+}
+
+function main(): void {
+  console.log("=".repeat(95));
+  console.log(
+    "PROMPT + SEMANTIC CACHING — 500 requests, Claude Sonnet-class pricing (2026-04)",
+  );
+  console.log("=".repeat(95));
+  const reqs = makeWorkload();
+
+  report(
+    "NO CACHING",
+    {
+      l1Enabled: false,
+      l2Enabled: false,
+      parallelPenalty: true,
+      l1Threshold: 0.95,
+      l1HitProb: 0.0,
+      ttl: "5min",
+    },
+    reqs,
+  );
+  report(
+    "L2 5-min, parallel penalty active",
+    {
+      l1Enabled: false,
+      l2Enabled: true,
+      parallelPenalty: true,
+      l1Threshold: 0.95,
+      l1HitProb: 0.0,
+      ttl: "5min",
+    },
+    reqs,
+  );
+  report(
+    "L2 5-min, parallel fixed (serialize first)",
+    {
+      l1Enabled: false,
+      l2Enabled: true,
+      parallelPenalty: false,
+      l1Threshold: 0.95,
+      l1HitProb: 0.0,
+      ttl: "5min",
+    },
+    reqs,
+  );
+  report(
+    "L2 1-hour + L1 semantic 30%",
+    {
+      l1Enabled: true,
+      l2Enabled: true,
+      parallelPenalty: false,
+      l1Threshold: 0.95,
+      l1HitProb: 0.3,
+      ttl: "1hr",
+    },
+    reqs,
+  );
+  report(
+    "L2 1-hour + L1 semantic 70% (structured FAQ)",
+    {
+      l1Enabled: true,
+      l2Enabled: true,
+      parallelPenalty: false,
+      l1Threshold: 0.95,
+      l1HitProb: 0.7,
+      ttl: "1hr",
+    },
+    reqs,
+  );
+
+  // Demonstrate the LRU + TTL primitive directly so the API is visible.
+  console.log("\n--- LRU+TTL primitive demo ---");
+  const lru = new LRUCache<string, number>(2, 1000);
+  lru.set("a", 1);
+  lru.set("b", 2);
+  lru.set("c", 3); // evicts "a"
+  console.log(`after inserting a,b,c with cap=2: has(a)=${lru.has("a")}, has(b)=${lru.has("b")}, has(c)=${lru.has("c")}`);
+
+  // Demonstrate semantic cache cosine behavior — same-meaning paraphrases.
+  console.log("\n--- Semantic cache cosine threshold demo ---");
+  const sc = new SemanticCache(0.5);
+  sc.store("how do I reset my password", "Use forgot-password link.");
+  const near = sc.lookup("how to reset password please");
+  const far = sc.lookup("what is the capital of France");
+  console.log(
+    `near sim=${(near?.similarity ?? 0).toFixed(3)} response=${near?.response ?? "<miss>"}`,
+  );
+  console.log(
+    `far  sim=${(far?.similarity ?? 0).toFixed(3)} response=${far?.response ?? "<miss>"}`,
+  );
+
+  console.log(
+    "\nRead: caching is a protocol. Structure your prompts and batching for it to pay off.",
+  );
+}
+
+main();

--- a/phases/17-infrastructure-and-production/15-batch-apis/code/main.ts
+++ b/phases/17-infrastructure-and-production/15-batch-apis/code/main.ts
@@ -1,0 +1,297 @@
+/**
+ * Batch APIs — TypeScript port + deferred-future dispatcher.
+ *
+ * Two halves:
+ *   1. BatchDispatcher: submits N jobs, returns a promise per job that resolves
+ *      when the batch completes. Simulates the OpenAI / Anthropic JSONL batch
+ *      lifecycle (in_progress → completed) without any network. The "deferred
+ *      future" pattern is what your code does at the call site — you fire and
+ *      forget, the promise hands you the answer hours later.
+ *   2. Cost simulator matching main.py: SYNC, SYNC+CACHE, BATCH, BATCH+CACHE
+ *      across three workloads. Pricing constants 2026-04 per docs/en.md.
+ *
+ * Citations:
+ *   - OpenAI Batch API: platform.openai.com/docs/guides/batch
+ *   - Anthropic Message Batches: docs.anthropic.com/en/docs/build-with-claude/batch-processing
+ *   - Vertex AI Batch Prediction: cloud.google.com/vertex-ai/generative-ai/docs/model-reference/batch-prediction
+ *
+ * Runs on Node 20+ stdlib. No npm deps.
+ */
+
+import { randomUUID } from "node:crypto";
+
+// -- Cost constants (2026-04) ---------------------------------------------
+
+const BASE_INPUT = 3.0;
+const BASE_OUTPUT = 15.0;
+const CACHED_INPUT = 0.3;
+const CACHE_WRITE_5MIN = 1.25 * BASE_INPUT;
+const BATCH_DISCOUNT = 0.5;
+
+// -- Batch dispatcher with deferred futures -------------------------------
+
+type BatchStatus = "queued" | "in_progress" | "completed" | "failed";
+
+type BatchJob<I, O> = {
+  id: string;
+  input: I;
+  promise: Promise<O>;
+  // Internal: resolver functions captured at dispatch.
+  resolve: (out: O) => void;
+  reject: (err: Error) => void;
+};
+
+type Batch<I, O> = {
+  id: string;
+  status: BatchStatus;
+  createdAt: number;
+  completedAt?: number;
+  jobs: BatchJob<I, O>[];
+};
+
+class BatchDispatcher<I, O> {
+  private readonly batches = new Map<string, Batch<I, O>>();
+  private readonly processor: (input: I) => Promise<O>;
+  // Simulated turnaround. Real providers say 24h SLA; typical P50 is 2-6h.
+  // In the demo we use small ms to keep the run snappy.
+  private readonly turnaroundMs: number;
+
+  constructor(
+    processor: (input: I) => Promise<O>,
+    turnaroundMs: number,
+  ) {
+    this.processor = processor;
+    this.turnaroundMs = turnaroundMs;
+  }
+
+  // Open a new batch. Returns the batch id you append jobs to.
+  openBatch(): string {
+    const id = `batch_${randomUUID().slice(0, 12)}`;
+    this.batches.set(id, {
+      id,
+      status: "queued",
+      createdAt: Date.now(),
+      jobs: [],
+    });
+    return id;
+  }
+
+  // Append a job to a queued batch. Returns the deferred Promise<O> the caller
+  // awaits once the batch closes and processes. Matches the user-facing shape
+  // of OpenAI's batch.create + retrieve flow.
+  addJob(batchId: string, input: I): Promise<O> {
+    const batch = this.requireBatch(batchId);
+    if (batch.status !== "queued") {
+      return Promise.reject(
+        new Error(`batch ${batchId} not queued (status=${batch.status})`),
+      );
+    }
+    // Hand-rolled deferred so we can resolve from the processor loop.
+    let resolve!: (out: O) => void;
+    let reject!: (err: Error) => void;
+    const promise = new Promise<O>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    batch.jobs.push({
+      id: `req_${randomUUID().slice(0, 8)}`,
+      input,
+      promise,
+      resolve,
+      reject,
+    });
+    return promise;
+  }
+
+  // Close + process. Returns when all jobs resolved/rejected.
+  // The async-iteration model is identical to a real batch: you don't await
+  // each job; you await the whole batch.
+  async closeBatch(batchId: string): Promise<Batch<I, O>> {
+    const batch = this.requireBatch(batchId);
+    batch.status = "in_progress";
+    // Simulate provider scheduling delay.
+    await new Promise<void>((res) => setTimeout(res, this.turnaroundMs));
+    const settlements: Promise<void>[] = batch.jobs.map(async (j) => {
+      try {
+        j.resolve(await this.processor(j.input));
+      } catch (err) {
+        j.reject(err instanceof Error ? err : new Error(String(err)));
+      }
+    });
+    await Promise.all(settlements);
+    batch.status = "completed";
+    batch.completedAt = Date.now();
+    return batch;
+  }
+
+  getStatus(batchId: string): BatchStatus {
+    return this.requireBatch(batchId).status;
+  }
+
+  private requireBatch(id: string): Batch<I, O> {
+    const b = this.batches.get(id);
+    if (!b) throw new Error(`no such batch: ${id}`);
+    return b;
+  }
+}
+
+// -- Mocked classification processor (no network) --------------------------
+
+type ClassifyIn = { docId: string; text: string };
+type ClassifyOut = { docId: string; label: string; confidence: number };
+
+async function fakeClassifier(input: ClassifyIn): Promise<ClassifyOut> {
+  // Deterministic toy classifier on input length parity.
+  const label = input.text.length % 2 === 0 ? "positive" : "neutral";
+  return {
+    docId: input.docId,
+    label,
+    confidence: 0.5 + (input.text.length % 5) / 10,
+  };
+}
+
+async function batchDemo(): Promise<void> {
+  console.log("--- Batch dispatcher with deferred futures ---");
+  // Turnaround set to 50ms in demo (production: 24h SLA).
+  const dispatcher = new BatchDispatcher<ClassifyIn, ClassifyOut>(
+    fakeClassifier,
+    50,
+  );
+  const batchId = dispatcher.openBatch();
+  const futures: Promise<ClassifyOut>[] = [];
+  for (let i = 0; i < 6; i++) {
+    futures.push(
+      dispatcher.addJob(batchId, {
+        docId: `doc-${i}`,
+        text: `document body number ${i}`,
+      }),
+    );
+  }
+  console.log(`status before close: ${dispatcher.getStatus(batchId)}`);
+  // Caller awaits jobs; dispatcher closes the batch concurrently.
+  const closePromise = dispatcher.closeBatch(batchId);
+  const results = await Promise.all(futures);
+  await closePromise;
+  console.log(`status after close: ${dispatcher.getStatus(batchId)}`);
+  for (const r of results) {
+    console.log(
+      `  ${r.docId} → label=${r.label} confidence=${r.confidence.toFixed(2)}`,
+    );
+  }
+}
+
+// -- Cost simulator -------------------------------------------------------
+
+function costSync(
+  docs: number,
+  prefixTokens: number,
+  perDocTokens: number,
+  outTokens: number,
+): number {
+  let cost = 0;
+  for (let i = 0; i < docs; i++) {
+    cost += (prefixTokens / 1e6) * BASE_INPUT;
+    cost += (perDocTokens / 1e6) * BASE_INPUT;
+    cost += (outTokens / 1e6) * BASE_OUTPUT;
+  }
+  return cost;
+}
+
+function costSyncCache(
+  docs: number,
+  prefixTokens: number,
+  perDocTokens: number,
+  outTokens: number,
+): number {
+  let cost = (prefixTokens / 1e6) * CACHE_WRITE_5MIN;
+  for (let i = 0; i < docs; i++) {
+    if (i > 0) cost += (prefixTokens / 1e6) * CACHED_INPUT;
+    cost += (perDocTokens / 1e6) * BASE_INPUT;
+    cost += (outTokens / 1e6) * BASE_OUTPUT;
+  }
+  return cost;
+}
+
+function costBatch(
+  docs: number,
+  prefixTokens: number,
+  perDocTokens: number,
+  outTokens: number,
+): number {
+  return costSync(docs, prefixTokens, perDocTokens, outTokens) * BATCH_DISCOUNT;
+}
+
+function costBatchCache(
+  docs: number,
+  prefixTokens: number,
+  perDocTokens: number,
+  outTokens: number,
+): number {
+  return (
+    costSyncCache(docs, prefixTokens, perDocTokens, outTokens) * BATCH_DISCOUNT
+  );
+}
+
+function fmtCost(n: number): string {
+  return `$${n.toFixed(2)}`.padStart(10);
+}
+
+function fmtPct(n: number, baseline: number): string {
+  return `${((n / baseline) * 100).toFixed(1)}%`.padStart(5);
+}
+
+function runScenario(
+  label: string,
+  docs: number,
+  prefix: number,
+  perDoc: number,
+  output: number,
+): void {
+  const sc = costSync(docs, prefix, perDoc, output);
+  const scc = costSyncCache(docs, prefix, perDoc, output);
+  const bc = costBatch(docs, prefix, perDoc, output);
+  const bcc = costBatchCache(docs, prefix, perDoc, output);
+  console.log(`\n${label}`);
+  console.log(
+    `  docs=${docs}, prefix=${prefix}, per_doc=${perDoc}, output=${output}`,
+  );
+  console.log(`  SYNC            : ${fmtCost(sc)}  (baseline)`);
+  console.log(`  SYNC + CACHE    : ${fmtCost(scc)}  (${fmtPct(scc, sc)} of baseline)`);
+  console.log(`  BATCH           : ${fmtCost(bc)}  (${fmtPct(bc, sc)} of baseline)`);
+  console.log(`  BATCH + CACHE   : ${fmtCost(bcc)}  (${fmtPct(bcc, sc)} of baseline)`);
+}
+
+async function main(): Promise<void> {
+  await batchDemo();
+  console.log("\n" + "=".repeat(80));
+  console.log(
+    "BATCH API ECONOMICS — stack batch with prompt caching for ~10% of sync bill",
+  );
+  console.log("=".repeat(80));
+  runScenario(
+    "Nightly doc summarization (50k docs)",
+    50_000,
+    4000,
+    2000,
+    200,
+  );
+  runScenario(
+    "Content classification (200k items, short per item)",
+    200_000,
+    1500,
+    300,
+    50,
+  );
+  runScenario(
+    "Large report draft (small N, heavy per item)",
+    1_000,
+    6000,
+    15_000,
+    2000,
+  );
+}
+
+main().catch((err: unknown) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/phases/17-infrastructure-and-production/16-model-routing/code/main.ts
+++ b/phases/17-infrastructure-and-production/16-model-routing/code/main.ts
@@ -1,0 +1,437 @@
+/**
+ * Model routing — TypeScript port + rule-based router.
+ *
+ * Two halves:
+ *   1. ModelRouter: rule-based picker over (model catalog, request signals).
+ *      Each rule scores candidates by capability fit, then weighs latency vs
+ *      cost vs capability per a caller-supplied policy. Matches the four
+ *      signals in docs/en.md (task class, prompt length, similarity to
+ *      hard set, self-confidence).
+ *   2. Cost/quality simulator matching main.py: NO_ROUTE / PRE_ROUTE /
+ *      CASCADE patterns on a mixed-difficulty workload.
+ *
+ * Citations:
+ *   - RouteLLM (LMSYS): https://github.com/lm-sys/RouteLLM
+ *   - OpenRouter recommendation/routing primitives: https://openrouter.ai/
+ *   - LiteLLM router config with fallback + cost-routing (referenced in docs)
+ *
+ * Runs on Node 20+ stdlib. No npm deps.
+ */
+
+// -- Pricing (2026-04 approximations) -------------------------------------
+
+const CHEAP_INPUT = 0.25;
+const CHEAP_OUTPUT = 1.0;
+const FRONTIER_INPUT = 3.0;
+const FRONTIER_OUTPUT = 15.0;
+
+// -- Model catalog + router primitive --------------------------------------
+
+type Capability =
+  | "chat"
+  | "code"
+  | "math"
+  | "vision"
+  | "long-context"
+  | "tool-use";
+
+type Model = {
+  id: string;
+  // Per-million-tokens.
+  inputPrice: number;
+  outputPrice: number;
+  // P50 first-token latency (ms).
+  latencyMs: number;
+  // Maximum context length (tokens).
+  contextWindow: number;
+  // Capability bag. Used by router fit-scoring.
+  capabilities: Set<Capability>;
+  // Subjective quality on a 0–1 scale per the docs' rough mapping.
+  qualityFloor: number;
+};
+
+const CATALOG: Model[] = [
+  {
+    id: "haiku-class",
+    inputPrice: CHEAP_INPUT,
+    outputPrice: CHEAP_OUTPUT,
+    latencyMs: 250,
+    contextWindow: 200_000,
+    capabilities: new Set<Capability>(["chat", "tool-use"]),
+    qualityFloor: 0.75,
+  },
+  {
+    id: "sonnet-class",
+    inputPrice: 1.0,
+    outputPrice: 5.0,
+    latencyMs: 450,
+    contextWindow: 200_000,
+    capabilities: new Set<Capability>([
+      "chat",
+      "code",
+      "tool-use",
+      "long-context",
+    ]),
+    qualityFloor: 0.9,
+  },
+  {
+    id: "frontier",
+    inputPrice: FRONTIER_INPUT,
+    outputPrice: FRONTIER_OUTPUT,
+    latencyMs: 800,
+    contextWindow: 1_000_000,
+    capabilities: new Set<Capability>([
+      "chat",
+      "code",
+      "math",
+      "vision",
+      "tool-use",
+      "long-context",
+    ]),
+    qualityFloor: 1.0,
+  },
+];
+
+type RouteSignals = {
+  // Task class derived from a small upstream classifier.
+  taskClass: "simple" | "medium" | "hard";
+  // Approximate prompt token count.
+  promptTokens: number;
+  // 0–1 cosine similarity to a curated known-hard set.
+  hardSetSimilarity: number;
+  // Required capabilities for this request.
+  required: Capability[];
+};
+
+type RoutePolicy = {
+  // Weights sum to 1; how much we care about each axis.
+  weightCost: number;
+  weightLatency: number;
+  weightCapability: number;
+  // Quality floor any chosen model must clear.
+  minQuality: number;
+};
+
+type RouteDecision = {
+  model: Model;
+  estCost: number;
+  reasoning: string;
+};
+
+class ModelRouter {
+  private readonly catalog: readonly Model[];
+  private readonly hardSetThreshold: number;
+
+  constructor(catalog: readonly Model[], hardSetThreshold = 0.88) {
+    this.catalog = catalog;
+    this.hardSetThreshold = hardSetThreshold;
+  }
+
+  // Estimate a request's blended cost on a model. Assumes 200 output tokens
+  // unless the caller threads through a real output estimate elsewhere.
+  estCost(model: Model, promptTokens: number, outputTokens = 200): number {
+    return (
+      (promptTokens / 1e6) * model.inputPrice +
+      (outputTokens / 1e6) * model.outputPrice
+    );
+  }
+
+  // Filter the catalog down to models that:
+  //  (a) cover every required capability,
+  //  (b) fit the prompt in their context window,
+  //  (c) clear the policy quality floor.
+  candidates(signals: RouteSignals, policy: RoutePolicy): Model[] {
+    return this.catalog.filter((m) => {
+      for (const c of signals.required) if (!m.capabilities.has(c)) return false;
+      if (signals.promptTokens > m.contextWindow) return false;
+      if (m.qualityFloor < policy.minQuality) return false;
+      return true;
+    });
+  }
+
+  // Weighted pick: lower cost / lower latency / higher capability fit is better.
+  // The 'hard set' similarity short-circuits to frontier (matches docs' rule).
+  pick(signals: RouteSignals, policy: RoutePolicy): RouteDecision {
+    if (signals.hardSetSimilarity >= this.hardSetThreshold) {
+      const frontier = this.catalog.find((m) => m.id === "frontier");
+      if (frontier) {
+        return {
+          model: frontier,
+          estCost: this.estCost(frontier, signals.promptTokens),
+          reasoning: `hard-set similarity ${signals.hardSetSimilarity.toFixed(2)} >= ${this.hardSetThreshold} — pinned to frontier`,
+        };
+      }
+    }
+
+    const cands = this.candidates(signals, policy);
+    if (cands.length === 0) {
+      throw new Error("no candidate model clears policy + required caps");
+    }
+    // Normalise for fair weighting.
+    const costs = cands.map((m) => this.estCost(m, signals.promptTokens));
+    const latencies = cands.map((m) => m.latencyMs);
+    const caps = cands.map((m) => m.capabilities.size);
+    const maxCost = Math.max(...costs);
+    const maxLat = Math.max(...latencies);
+    const maxCap = Math.max(...caps);
+
+    let bestIdx = 0;
+    let bestScore = -Infinity;
+    let bestReason = "";
+    for (let i = 0; i < cands.length; i++) {
+      const costScore = 1 - costs[i] / (maxCost || 1);
+      const latScore = 1 - latencies[i] / (maxLat || 1);
+      const capScore = caps[i] / (maxCap || 1);
+      const score =
+        policy.weightCost * costScore +
+        policy.weightLatency * latScore +
+        policy.weightCapability * capScore;
+      if (score > bestScore) {
+        bestScore = score;
+        bestIdx = i;
+        bestReason =
+          `cost=${costScore.toFixed(2)} latency=${latScore.toFixed(2)} cap=${capScore.toFixed(2)} ` +
+          `weighted=${score.toFixed(3)}`;
+      }
+    }
+
+    return {
+      model: cands[bestIdx],
+      estCost: costs[bestIdx],
+      reasoning: bestReason,
+    };
+  }
+}
+
+// -- Workload + simulator (matches main.py) --------------------------------
+
+type Difficulty = "simple" | "medium" | "hard";
+type Query = {
+  difficulty: Difficulty;
+  promptTokens: number;
+  outputTokens: number;
+};
+
+function makeRng(seed: number): () => number {
+  let s = seed >>> 0;
+  return function () {
+    s = (s + 0x6d2b79f5) >>> 0;
+    let t = s;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function randint(rng: () => number, lo: number, hi: number): number {
+  return lo + Math.floor(rng() * (hi - lo + 1));
+}
+
+function makeWorkload(n = 1000, seed = 7): Query[] {
+  const rng = makeRng(seed);
+  const reqs: Query[] = [];
+  for (let i = 0; i < n; i++) {
+    const p = rng();
+    if (p < 0.6) {
+      reqs.push({
+        difficulty: "simple",
+        promptTokens: randint(rng, 200, 1000),
+        outputTokens: randint(rng, 50, 200),
+      });
+    } else if (p < 0.9) {
+      reqs.push({
+        difficulty: "medium",
+        promptTokens: randint(rng, 800, 3000),
+        outputTokens: randint(rng, 100, 400),
+      });
+    } else {
+      reqs.push({
+        difficulty: "hard",
+        promptTokens: randint(rng, 2000, 8000),
+        outputTokens: randint(rng, 200, 1500),
+      });
+    }
+  }
+  return reqs;
+}
+
+function costOf(route: "cheap" | "frontier", q: Query): number {
+  if (route === "cheap") {
+    return (
+      (q.promptTokens / 1e6) * CHEAP_INPUT +
+      (q.outputTokens / 1e6) * CHEAP_OUTPUT
+    );
+  }
+  return (
+    (q.promptTokens / 1e6) * FRONTIER_INPUT +
+    (q.outputTokens / 1e6) * FRONTIER_OUTPUT
+  );
+}
+
+function quality(route: "cheap" | "frontier", q: Query): number {
+  if (route === "frontier") return 1.0;
+  return { simple: 0.99, medium: 0.92, hard: 0.75 }[q.difficulty];
+}
+
+type SimRow = {
+  pattern: string;
+  cost: number;
+  meanQuality: number;
+  escalated: number;
+};
+
+function simulate(pattern: string, reqs: readonly Query[]): SimRow {
+  let totalCost = 0;
+  let totalQ = 0;
+  let escalated = 0;
+  const rng = makeRng(11);
+
+  for (const q of reqs) {
+    if (pattern === "NO_ROUTE") {
+      totalCost += costOf("frontier", q);
+      totalQ += 1.0;
+    } else if (pattern === "PRE_ROUTE") {
+      if (q.difficulty === "simple") {
+        totalCost += costOf("cheap", q);
+        totalQ += quality("cheap", q);
+      } else {
+        totalCost += costOf("frontier", q);
+        totalQ += 1.0;
+      }
+    } else if (pattern === "CASCADE") {
+      totalCost += costOf("cheap", q);
+      const confident =
+        q.difficulty === "simple" ||
+        (q.difficulty === "medium" && rng() < 0.5);
+      if (confident) {
+        totalQ += quality("cheap", q);
+      } else {
+        escalated++;
+        totalCost += costOf("frontier", q);
+        totalQ += 1.0;
+      }
+    }
+  }
+
+  return {
+    pattern,
+    cost: totalCost,
+    meanQuality: totalQ / reqs.length,
+    escalated,
+  };
+}
+
+function reportRow(row: SimRow, baseline: number): void {
+  const save = ((baseline - row.cost) / baseline) * 100;
+  console.log(
+    `${row.pattern.padEnd(12)}  cost=$${row.cost.toFixed(2).padStart(7)}  ` +
+      `save=${save.toFixed(1).padStart(5)}%  ` +
+      `quality=${(row.meanQuality * 100).toFixed(1).padStart(5)}%  ` +
+      `escalated=${String(row.escalated).padStart(4)}`,
+  );
+}
+
+// -- Demos -----------------------------------------------------------------
+
+function routerDemo(): void {
+  console.log("--- Rule-based ModelRouter ---");
+  const router = new ModelRouter(CATALOG);
+
+  const balanced: RoutePolicy = {
+    weightCost: 0.5,
+    weightLatency: 0.2,
+    weightCapability: 0.3,
+    minQuality: 0.7,
+  };
+  const latencyFirst: RoutePolicy = {
+    weightCost: 0.1,
+    weightLatency: 0.7,
+    weightCapability: 0.2,
+    minQuality: 0.7,
+  };
+
+  const cases: { name: string; signals: RouteSignals; policy: RoutePolicy }[] = [
+    {
+      name: "FAQ-style short prompt (balanced policy)",
+      signals: {
+        taskClass: "simple",
+        promptTokens: 400,
+        hardSetSimilarity: 0.2,
+        required: ["chat"],
+      },
+      policy: balanced,
+    },
+    {
+      name: "code-gen with tool use (balanced)",
+      signals: {
+        taskClass: "medium",
+        promptTokens: 2500,
+        hardSetSimilarity: 0.4,
+        required: ["chat", "code", "tool-use"],
+      },
+      policy: balanced,
+    },
+    {
+      name: "math near known-hard set (auto-pin frontier)",
+      signals: {
+        taskClass: "hard",
+        promptTokens: 1500,
+        hardSetSimilarity: 0.92,
+        required: ["chat", "math"],
+      },
+      policy: balanced,
+    },
+    {
+      name: "long-context 800K tokens (frontier only fits)",
+      signals: {
+        taskClass: "hard",
+        promptTokens: 800_000,
+        hardSetSimilarity: 0.1,
+        required: ["chat", "long-context"],
+      },
+      policy: balanced,
+    },
+    {
+      name: "FAQ-style short prompt (latency-first)",
+      signals: {
+        taskClass: "simple",
+        promptTokens: 300,
+        hardSetSimilarity: 0.1,
+        required: ["chat"],
+      },
+      policy: latencyFirst,
+    },
+  ];
+
+  for (const c of cases) {
+    const d = router.pick(c.signals, c.policy);
+    console.log(`  ${c.name}`);
+    console.log(
+      `    → ${d.model.id}  est_cost=$${d.estCost.toFixed(5)}  reason=${d.reasoning}`,
+    );
+  }
+}
+
+function patternsDemo(): void {
+  console.log("\n" + "=".repeat(80));
+  console.log("MODEL ROUTING — three patterns, 1000 requests, mixed difficulty");
+  console.log("=".repeat(80));
+  const reqs = makeWorkload();
+  const baseline = simulate("NO_ROUTE", reqs).cost;
+  for (const p of ["NO_ROUTE", "PRE_ROUTE", "CASCADE"]) {
+    reportRow(simulate(p, reqs), baseline);
+  }
+  console.log(
+    "\nRead: PRE_ROUTE saves big when the classifier is accurate. CASCADE",
+  );
+  console.log(
+    "guarantees quality floor but adds latency on escalated requests.",
+  );
+}
+
+function main(): void {
+  routerDemo();
+  patternsDemo();
+}
+
+main();

--- a/phases/17-infrastructure-and-production/19-ai-gateways/code/main.ts
+++ b/phases/17-infrastructure-and-production/19-ai-gateways/code/main.ts
@@ -177,27 +177,41 @@ type RetryConfig = {
   sleep: (ms: number) => Promise<void>;
 };
 
+type RetryOutcome = {
+  response: ProviderResponse;
+  // Wall-clock spent across all retry attempts + backoff sleeps for this
+  // single provider. Equals response.latencyMs when the first attempt
+  // succeeds with no backoff.
+  totalLatencyMs: number;
+};
+
 async function callWithRetry(
   provider: Provider,
   prompt: string,
   cfg: RetryConfig,
-): Promise<ProviderResponse> {
+): Promise<RetryOutcome> {
   let lastErr: ProviderError | undefined;
+  let totalLatencyMs = 0;
   for (let attempt = 1; attempt <= cfg.maxAttempts; attempt++) {
     try {
       const r = await provider.call(prompt);
+      totalLatencyMs += r.latencyMs;
       return {
-        provider: provider.name,
-        text: r.text,
-        latencyMs: r.latencyMs,
-        attempt,
+        response: {
+          provider: provider.name,
+          text: r.text,
+          latencyMs: r.latencyMs,
+          attempt,
+        },
+        totalLatencyMs,
       };
     } catch (raw) {
       const err = raw as ProviderError;
       lastErr = err;
       if (!err.retryable || attempt === cfg.maxAttempts) break;
-      const sleep = cfg.baseBackoffMs * 2 ** (attempt - 1) * cfg.jitter();
-      await cfg.sleep(sleep);
+      const backoffMs = cfg.baseBackoffMs * 2 ** (attempt - 1) * cfg.jitter();
+      totalLatencyMs += backoffMs;
+      await cfg.sleep(backoffMs);
     }
   }
   // Surface the last error to the fallback layer.
@@ -208,14 +222,16 @@ async function callWithFallback(
   chain: readonly Provider[],
   prompt: string,
   cfg: RetryConfig,
-): Promise<{ response: ProviderResponse; fallbackHits: number }> {
+): Promise<{ response: ProviderResponse; fallbackHits: number; totalLatencyMs: number }> {
   let fallbackHits = 0;
+  let totalLatencyMs = 0;
   let lastErr: ProviderError | undefined;
   for (let i = 0; i < chain.length; i++) {
     if (i > 0) fallbackHits++;
     try {
-      const response = await callWithRetry(chain[i], prompt, cfg);
-      return { response, fallbackHits };
+      const outcome = await callWithRetry(chain[i], prompt, cfg);
+      totalLatencyMs += outcome.totalLatencyMs;
+      return { response: outcome.response, fallbackHits, totalLatencyMs };
     } catch (err) {
       lastErr = err as ProviderError;
     }
@@ -247,7 +263,7 @@ class AIGateway {
       return { ok: false, status: 429, reason: "rate limit exceeded" };
     }
     try {
-      const { response, fallbackHits } = await callWithFallback(
+      const { response, fallbackHits, totalLatencyMs } = await callWithFallback(
         this.chain,
         prompt,
         this.retry,
@@ -255,7 +271,10 @@ class AIGateway {
       return {
         ok: true,
         response,
-        totalLatencyMs: response.latencyMs + this.overheadMs,
+        // End-to-end wall clock: gateway overhead + every retry attempt +
+        // every backoff sleep + every failed-provider latency leading to the
+        // winning provider.
+        totalLatencyMs: totalLatencyMs + this.overheadMs,
         fallbackHits,
       };
     } catch (err) {
@@ -297,7 +316,9 @@ type SimRow = {
   gateway: string;
   successRate: number;
   meanLatency: number;
-  retries: number;
+  // Each inner iteration tries one provider exactly once before falling
+  // back, so this counts failed provider attempts, not in-provider retries.
+  providerFailures: number;
   fallbackHits: number;
 };
 
@@ -305,7 +326,7 @@ function simulateFallback(gateway: string, n = 1000, seed = 7): SimRow {
   const rng = makeRng(seed);
   let success = 0;
   let totalLatency = 0;
-  let retries = 0;
+  let providerFailures = 0;
   let fallbackHits = 0;
   const gwOverhead = GATEWAY_OVERHEAD[gateway];
 
@@ -322,7 +343,7 @@ function simulateFallback(gateway: string, n = 1000, seed = 7): SimRow {
         done = true;
         break;
       }
-      retries++;
+      providerFailures++;
     }
     void done;
     totalLatency += reqLatency;
@@ -332,7 +353,7 @@ function simulateFallback(gateway: string, n = 1000, seed = 7): SimRow {
     gateway,
     successRate: success / n,
     meanLatency: totalLatency / n,
-    retries,
+    providerFailures,
     fallbackHits,
   };
 }
@@ -342,7 +363,7 @@ function reportRow(r: SimRow): void {
     `${r.gateway.padEnd(12)}  ` +
       `success=${(r.successRate * 100).toFixed(1).padStart(5)}%  ` +
       `mean_latency=${r.meanLatency.toFixed(0).padStart(6)}ms  ` +
-      `retries=${String(r.retries).padStart(4)}  ` +
+      `prov_fails=${String(r.providerFailures).padStart(4)}  ` +
       `fallbacks=${String(r.fallbackHits).padStart(4)}`,
   );
 }
@@ -417,7 +438,7 @@ function simulatorDemo(): void {
   console.log("=".repeat(80));
   const header =
     `${"Gateway".padEnd(12)}  ` +
-    `${"Success".padStart(7)}         ${"mean latency".padStart(12)}  retries  fallbacks`;
+    `${"Success".padStart(7)}         ${"mean latency".padStart(12)}  prov_fails  fallbacks`;
   console.log(header);
   console.log("-".repeat(header.length));
   for (const gw of ["LiteLLM", "Portkey", "Kong", "Cloudflare"]) {

--- a/phases/17-infrastructure-and-production/19-ai-gateways/code/main.ts
+++ b/phases/17-infrastructure-and-production/19-ai-gateways/code/main.ts
@@ -1,0 +1,445 @@
+/**
+ * AI gateway skeleton — TypeScript port.
+ *
+ * Implements the four core gateway primitives from docs/en.md:
+ *   1. Auth: API-key check with constant-time comparison + per-tenant resolution.
+ *   2. Rate limit: token-bucket per tenant; LiteLLM-style.
+ *   3. Retry: exponential backoff with jitter on transient 429/5xx; bounded.
+ *   4. Fallback chain: try providers in order until one succeeds.
+ *
+ * Plus the same fallback simulator main.py runs (4 gateway profiles, 3-provider
+ * chain, error injection) so the numbers stay reproducible.
+ *
+ * Citations:
+ *   - Kong AI Gateway benchmark (228% vs Portkey, 859% vs LiteLLM):
+ *     https://konghq.com/blog/engineering/ai-gateway-benchmark-kong-ai-gateway-portkey-litellm
+ *   - LiteLLM (MIT OSS, 100+ providers): https://github.com/BerriAI/litellm
+ *   - Portkey (Apache 2.0 since March 2026): https://github.com/Portkey-AI/gateway
+ *   - Kong AI Gateway docs: https://docs.konghq.com/gateway/latest/ai-gateway/
+ *
+ * Runs on Node 20+ stdlib. No npm deps.
+ */
+
+import { timingSafeEqual, createHash } from "node:crypto";
+
+// -- Auth ------------------------------------------------------------------
+
+type Tenant = {
+  id: string;
+  // SHA-256 hex of the issued API key. Never store keys in plaintext.
+  keyHashHex: string;
+  // Per-tenant tier: shapes rate-limit budgets.
+  tier: "free" | "trial" | "paid";
+};
+
+class AuthService {
+  private readonly tenants = new Map<string, Tenant>();
+  private readonly hashByKey = new Map<string, Tenant>();
+
+  register(tenant: Tenant): void {
+    this.tenants.set(tenant.id, tenant);
+    this.hashByKey.set(tenant.keyHashHex, tenant);
+  }
+
+  // Constant-time check by digest comparison.
+  authenticate(presentedKey: string): Tenant | undefined {
+    const digest = createHash("sha256").update(presentedKey).digest("hex");
+    // Walk every known hash so an unknown key has the same wall-clock cost
+    // as a known one.
+    let match: Tenant | undefined;
+    const presented = Buffer.from(digest, "hex");
+    for (const t of this.tenants.values()) {
+      const stored = Buffer.from(t.keyHashHex, "hex");
+      if (
+        stored.length === presented.length &&
+        timingSafeEqual(stored, presented)
+      ) {
+        match = t;
+      }
+    }
+    return match;
+  }
+}
+
+// -- Rate limiter (token-bucket) ------------------------------------------
+
+type Bucket = {
+  tokens: number;
+  capacity: number;
+  refillPerSec: number;
+  lastNs: bigint;
+};
+
+class TokenBucketLimiter {
+  private readonly buckets = new Map<string, Bucket>();
+  private readonly tierConfig: Record<
+    Tenant["tier"],
+    { capacity: number; refillPerSec: number }
+  >;
+  private readonly now: () => bigint;
+
+  constructor(
+    tierConfig: Record<
+      Tenant["tier"],
+      { capacity: number; refillPerSec: number }
+    >,
+    now: () => bigint = process.hrtime.bigint,
+  ) {
+    this.tierConfig = tierConfig;
+    this.now = now;
+  }
+
+  private getOrCreate(tenant: Tenant): Bucket {
+    const existing = this.buckets.get(tenant.id);
+    if (existing) return existing;
+    const cfg = this.tierConfig[tenant.tier];
+    const bucket: Bucket = {
+      tokens: cfg.capacity,
+      capacity: cfg.capacity,
+      refillPerSec: cfg.refillPerSec,
+      lastNs: this.now(),
+    };
+    this.buckets.set(tenant.id, bucket);
+    return bucket;
+  }
+
+  // Returns true if the request fits within the bucket; false otherwise.
+  allow(tenant: Tenant, cost = 1): boolean {
+    const bucket = this.getOrCreate(tenant);
+    const nowNs = this.now();
+    const elapsedSec = Number(nowNs - bucket.lastNs) / 1e9;
+    bucket.tokens = Math.min(
+      bucket.capacity,
+      bucket.tokens + elapsedSec * bucket.refillPerSec,
+    );
+    bucket.lastNs = nowNs;
+    if (bucket.tokens >= cost) {
+      bucket.tokens -= cost;
+      return true;
+    }
+    return false;
+  }
+}
+
+// -- Provider abstraction + retry/fallback --------------------------------
+
+type ProviderResponse = {
+  provider: string;
+  text: string;
+  latencyMs: number;
+  attempt: number;
+};
+
+type ProviderError = {
+  retryable: boolean;
+  status: 429 | 500 | 502 | 503 | 504 | 400;
+  message: string;
+};
+
+type Provider = {
+  name: string;
+  // Call is async because the real one is HTTP. Returns either text + latency
+  // or throws a ProviderError-shaped value.
+  call(prompt: string): Promise<{ text: string; latencyMs: number }>;
+};
+
+// Mocked provider with deterministic error injection by request counter.
+function makeMockProvider(
+  name: string,
+  baseLatencyMs: number,
+  // Function that decides whether call #n errors and how.
+  errorPolicy: (n: number) => ProviderError | null,
+): Provider {
+  let n = 0;
+  return {
+    name,
+    async call(prompt: string): Promise<{ text: string; latencyMs: number }> {
+      const callN = ++n;
+      const err = errorPolicy(callN);
+      // Yield a microtask so we look properly async.
+      await Promise.resolve();
+      if (err) {
+        throw err;
+      }
+      return {
+        text: `[${name}] ${prompt.slice(0, 60)}`,
+        latencyMs: baseLatencyMs,
+      };
+    },
+  };
+}
+
+type RetryConfig = {
+  maxAttempts: number;
+  baseBackoffMs: number;
+  // For determinism in tests/demos.
+  jitter: () => number;
+  sleep: (ms: number) => Promise<void>;
+};
+
+async function callWithRetry(
+  provider: Provider,
+  prompt: string,
+  cfg: RetryConfig,
+): Promise<ProviderResponse> {
+  let lastErr: ProviderError | undefined;
+  for (let attempt = 1; attempt <= cfg.maxAttempts; attempt++) {
+    try {
+      const r = await provider.call(prompt);
+      return {
+        provider: provider.name,
+        text: r.text,
+        latencyMs: r.latencyMs,
+        attempt,
+      };
+    } catch (raw) {
+      const err = raw as ProviderError;
+      lastErr = err;
+      if (!err.retryable || attempt === cfg.maxAttempts) break;
+      const sleep = cfg.baseBackoffMs * 2 ** (attempt - 1) * cfg.jitter();
+      await cfg.sleep(sleep);
+    }
+  }
+  // Surface the last error to the fallback layer.
+  throw lastErr ?? ({ retryable: false, status: 500, message: "unknown" } as ProviderError);
+}
+
+async function callWithFallback(
+  chain: readonly Provider[],
+  prompt: string,
+  cfg: RetryConfig,
+): Promise<{ response: ProviderResponse; fallbackHits: number }> {
+  let fallbackHits = 0;
+  let lastErr: ProviderError | undefined;
+  for (let i = 0; i < chain.length; i++) {
+    if (i > 0) fallbackHits++;
+    try {
+      const response = await callWithRetry(chain[i], prompt, cfg);
+      return { response, fallbackHits };
+    } catch (err) {
+      lastErr = err as ProviderError;
+    }
+  }
+  throw lastErr ?? { retryable: false, status: 500, message: "no providers" };
+}
+
+// -- The gateway -----------------------------------------------------------
+
+class AIGateway {
+  constructor(
+    private readonly auth: AuthService,
+    private readonly limiter: TokenBucketLimiter,
+    private readonly chain: readonly Provider[],
+    private readonly retry: RetryConfig,
+    private readonly overheadMs: number,
+  ) {}
+
+  async handle(
+    presentedKey: string,
+    prompt: string,
+  ): Promise<
+    | { ok: true; response: ProviderResponse; totalLatencyMs: number; fallbackHits: number }
+    | { ok: false; status: number; reason: string }
+  > {
+    const tenant = this.auth.authenticate(presentedKey);
+    if (!tenant) return { ok: false, status: 401, reason: "invalid api key" };
+    if (!this.limiter.allow(tenant)) {
+      return { ok: false, status: 429, reason: "rate limit exceeded" };
+    }
+    try {
+      const { response, fallbackHits } = await callWithFallback(
+        this.chain,
+        prompt,
+        this.retry,
+      );
+      return {
+        ok: true,
+        response,
+        totalLatencyMs: response.latencyMs + this.overheadMs,
+        fallbackHits,
+      };
+    } catch (err) {
+      const e = err as ProviderError;
+      return { ok: false, status: e.status ?? 500, reason: e.message };
+    }
+  }
+}
+
+// -- Simulator (matches main.py shape) ------------------------------------
+
+type ProviderProfile = { name: string; baseLatencyMs: number; errorRate: number };
+
+const PROVIDERS: ProviderProfile[] = [
+  { name: "OpenAI", baseLatencyMs: 180, errorRate: 0.03 },
+  { name: "Anthropic", baseLatencyMs: 220, errorRate: 0.02 },
+  { name: "Self-hosted", baseLatencyMs: 100, errorRate: 0.05 },
+];
+
+const GATEWAY_OVERHEAD: Record<string, number> = {
+  LiteLLM: 10,
+  Portkey: 30,
+  Kong: 5,
+  Cloudflare: 2,
+};
+
+function makeRng(seed: number): () => number {
+  let s = seed >>> 0;
+  return function () {
+    s = (s + 0x6d2b79f5) >>> 0;
+    let t = s;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+type SimRow = {
+  gateway: string;
+  successRate: number;
+  meanLatency: number;
+  retries: number;
+  fallbackHits: number;
+};
+
+function simulateFallback(gateway: string, n = 1000, seed = 7): SimRow {
+  const rng = makeRng(seed);
+  let success = 0;
+  let totalLatency = 0;
+  let retries = 0;
+  let fallbackHits = 0;
+  const gwOverhead = GATEWAY_OVERHEAD[gateway];
+
+  for (let i = 0; i < n; i++) {
+    let reqLatency = gwOverhead;
+    let done = false;
+    for (let attempt = 0; attempt < PROVIDERS.length; attempt++) {
+      const p = PROVIDERS[attempt];
+      const errored = rng() < p.errorRate;
+      reqLatency += errored ? p.baseLatencyMs * 0.3 : p.baseLatencyMs;
+      if (attempt > 0) fallbackHits++;
+      if (!errored) {
+        success++;
+        done = true;
+        break;
+      }
+      retries++;
+    }
+    void done;
+    totalLatency += reqLatency;
+  }
+
+  return {
+    gateway,
+    successRate: success / n,
+    meanLatency: totalLatency / n,
+    retries,
+    fallbackHits,
+  };
+}
+
+function reportRow(r: SimRow): void {
+  console.log(
+    `${r.gateway.padEnd(12)}  ` +
+      `success=${(r.successRate * 100).toFixed(1).padStart(5)}%  ` +
+      `mean_latency=${r.meanLatency.toFixed(0).padStart(6)}ms  ` +
+      `retries=${String(r.retries).padStart(4)}  ` +
+      `fallbacks=${String(r.fallbackHits).padStart(4)}`,
+  );
+}
+
+// -- Demo ------------------------------------------------------------------
+
+async function liveDemo(): Promise<void> {
+  console.log("--- AI gateway primitives (auth + rate limit + retry + fallback) ---");
+
+  const auth = new AuthService();
+  // Pre-issue two keys; "secret-paid-key" → paid tier, "secret-free-key" → free.
+  const paidHash = createHash("sha256").update("secret-paid-key").digest("hex");
+  const freeHash = createHash("sha256").update("secret-free-key").digest("hex");
+  auth.register({ id: "tenant-paid", keyHashHex: paidHash, tier: "paid" });
+  auth.register({ id: "tenant-free", keyHashHex: freeHash, tier: "free" });
+
+  const limiter = new TokenBucketLimiter({
+    free: { capacity: 2, refillPerSec: 0.5 },
+    trial: { capacity: 5, refillPerSec: 1 },
+    paid: { capacity: 100, refillPerSec: 10 },
+  });
+
+  // Provider 1: 429 on the first call, succeeds afterwards.
+  const flaky = makeMockProvider("openai", 180, (n) =>
+    n === 1
+      ? { retryable: true, status: 429, message: "rate_limit_exceeded" }
+      : null,
+  );
+  // Provider 2: 5xx half the time.
+  const wobble = makeMockProvider("anthropic", 220, (n) =>
+    n % 2 === 1
+      ? { retryable: true, status: 503, message: "upstream_unavailable" }
+      : null,
+  );
+  // Provider 3: always healthy.
+  const healthy = makeMockProvider("self-hosted", 100, () => null);
+
+  const retry: RetryConfig = {
+    maxAttempts: 2,
+    baseBackoffMs: 1,
+    jitter: () => 1.0,
+    sleep: (ms: number) => new Promise((res) => setTimeout(res, ms)),
+  };
+
+  const gateway = new AIGateway(
+    auth,
+    limiter,
+    [flaky, wobble, healthy],
+    retry,
+    /* overheadMs */ 5,
+  );
+
+  console.log("paid tenant — should succeed via retry / fallback:");
+  for (let i = 0; i < 3; i++) {
+    const r = await gateway.handle("secret-paid-key", `hello world ${i}`);
+    console.log("  →", JSON.stringify(r));
+  }
+
+  console.log("\nfree tenant — capacity=2, third call hits rate limit:");
+  for (let i = 0; i < 4; i++) {
+    const r = await gateway.handle("secret-free-key", `q ${i}`);
+    console.log("  →", JSON.stringify(r));
+  }
+
+  console.log("\nbad key — 401:");
+  console.log("  →", JSON.stringify(await gateway.handle("nope", "x")));
+}
+
+function simulatorDemo(): void {
+  console.log("\n" + "=".repeat(80));
+  console.log("AI GATEWAY FALLBACK — 3-provider chain under error injection");
+  console.log("=".repeat(80));
+  const header =
+    `${"Gateway".padEnd(12)}  ` +
+    `${"Success".padStart(7)}         ${"mean latency".padStart(12)}  retries  fallbacks`;
+  console.log(header);
+  console.log("-".repeat(header.length));
+  for (const gw of ["LiteLLM", "Portkey", "Kong", "Cloudflare"]) {
+    reportRow(simulateFallback(gw));
+  }
+  console.log(
+    "\nNotes: a single-provider target at 3% error rate → 97% success.",
+  );
+  console.log(
+    "Two-provider fallback → 99.94% success (complement of 0.03 × 0.02).",
+  );
+  console.log(
+    "Three-provider fallback → 99.997% success. Latency rises on fallback.",
+  );
+}
+
+async function main(): Promise<void> {
+  await liveDemo();
+  simulatorDemo();
+}
+
+main().catch((err: unknown) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/phases/17-infrastructure-and-production/20-shadow-canary-progressive/code/main.ts
+++ b/phases/17-infrastructure-and-production/20-shadow-canary-progressive/code/main.ts
@@ -1,0 +1,340 @@
+/**
+ * Shadow + canary + progressive rollout — TypeScript port + policy engine.
+ *
+ * Three policies:
+ *   1. Shadow mode: duplicates each request to candidate; logs the deltas;
+ *      never returns candidate output to the user. Catches cost/length
+ *      regressions before any user exposure.
+ *   2. Canary rollout: progressive traffic shift through stages with five
+ *      LLM-specific gates. Halts the moment any gate breaches.
+ *   3. Progressive policy: combines shadow → canary → 100%, with a policy
+ *      flag that supports seconds-not-hours rollback.
+ *
+ * Plus the same canary simulator main.py runs (six stages, five gates, six
+ * regression scenarios) so the numbers reproduce.
+ *
+ * Citations:
+ *   - Argo Rollouts (Kubernetes progressive delivery)
+ *     https://argo-rollouts.readthedocs.io/
+ *   - Flagger (progressive delivery operator)
+ *     https://docs.flagger.app/
+ *   - Non-determinism ~15% run-to-run cited in docs/en.md (GPU FP
+ *     non-associativity + batch-size variance + sampling).
+ *
+ * Runs on Node 20+ stdlib. No npm deps.
+ */
+
+// -- Baseline + gates ------------------------------------------------------
+
+type Metrics = {
+  latencyP99Ms: number;
+  costPerReq: number;
+  errorRate: number;
+  outputLenP99: number;
+  thumbsDownRate: number;
+};
+
+const BASELINE: Metrics = {
+  latencyP99Ms: 900,
+  costPerReq: 0.02,
+  errorRate: 0.02,
+  outputLenP99: 450,
+  thumbsDownRate: 0.03,
+};
+
+// Multipliers above baseline that constitute a breach. Set high enough to
+// stay above the LLM non-determinism noise floor (~15% per docs/en.md).
+const GATES: Record<keyof Metrics, number> = {
+  latencyP99Ms: 1.5,
+  costPerReq: 1.2,
+  errorRate: 2.0,
+  outputLenP99: 1.4,
+  thumbsDownRate: 1.5,
+};
+
+const STAGES = [0.01, 0.1, 0.25, 0.5, 0.75, 1.0];
+
+// -- Mulberry32 PRNG ------------------------------------------------------
+
+function makeRng(seed: number): () => number {
+  let s = seed >>> 0;
+  return function () {
+    s = (s + 0x6d2b79f5) >>> 0;
+    let t = s;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function stageSeed(i: number): number {
+  return 11 + i * 3;
+}
+
+// -- Regression injector --------------------------------------------------
+
+type Regression = {
+  latencyMult: number;
+  costMult: number;
+  errorMult: number;
+  outputLenMult: number;
+  thumbsDownMult: number;
+};
+
+const NO_REGRESSION: Regression = {
+  latencyMult: 1,
+  costMult: 1,
+  errorMult: 1,
+  outputLenMult: 1,
+  thumbsDownMult: 1,
+};
+
+function measureStage(_stage: number, reg: Regression, seed: number): Metrics {
+  const rng = makeRng(seed);
+  // Noise floor is the non-determinism docs/en.md describes: ~±8% per measurement.
+  const noise = (v: number): number => v * (0.92 + rng() * 0.16);
+  return {
+    latencyP99Ms: noise(BASELINE.latencyP99Ms * reg.latencyMult),
+    costPerReq: noise(BASELINE.costPerReq * reg.costMult),
+    errorRate: noise(BASELINE.errorRate * reg.errorMult),
+    outputLenP99: noise(BASELINE.outputLenP99 * reg.outputLenMult),
+    thumbsDownRate: noise(BASELINE.thumbsDownRate * reg.thumbsDownMult),
+  };
+}
+
+function checkGates(metrics: Metrics): (keyof Metrics)[] {
+  const breaches: (keyof Metrics)[] = [];
+  for (const k of Object.keys(GATES) as (keyof Metrics)[]) {
+    if (metrics[k] > BASELINE[k] * GATES[k]) breaches.push(k);
+  }
+  return breaches;
+}
+
+// -- Policy engine --------------------------------------------------------
+
+type ShadowSample = {
+  baselineCost: number;
+  candidateCost: number;
+  baselineLatencyMs: number;
+  candidateLatencyMs: number;
+};
+
+type ShadowReport = {
+  n: number;
+  meanCostDeltaPct: number;
+  meanLatencyDeltaPct: number;
+  // True if shadow alone justifies halting before canary.
+  alert: boolean;
+  reasons: string[];
+};
+
+function shadowEvaluate(samples: ShadowSample[]): ShadowReport {
+  if (samples.length === 0) {
+    return {
+      n: 0,
+      meanCostDeltaPct: 0,
+      meanLatencyDeltaPct: 0,
+      alert: false,
+      reasons: [],
+    };
+  }
+  let costDelta = 0;
+  let latDelta = 0;
+  for (const s of samples) {
+    costDelta += (s.candidateCost - s.baselineCost) / s.baselineCost;
+    latDelta += (s.candidateLatencyMs - s.baselineLatencyMs) / s.baselineLatencyMs;
+  }
+  const meanCost = (costDelta / samples.length) * 100;
+  const meanLat = (latDelta / samples.length) * 100;
+  const reasons: string[] = [];
+  if (meanCost > 30) reasons.push(`cost +${meanCost.toFixed(1)}% (>30%)`);
+  if (meanLat > 50) reasons.push(`latency +${meanLat.toFixed(1)}% (>50%)`);
+  return {
+    n: samples.length,
+    meanCostDeltaPct: meanCost,
+    meanLatencyDeltaPct: meanLat,
+    alert: reasons.length > 0,
+    reasons,
+  };
+}
+
+type CanaryDecision = {
+  promoted: boolean;
+  stagesAdvanced: number;
+  breaches: (keyof Metrics)[];
+};
+
+function canaryRollout(reg: Regression): CanaryDecision {
+  for (let i = 0; i < STAGES.length; i++) {
+    const metrics = measureStage(STAGES[i], reg, stageSeed(i));
+    const breaches = checkGates(metrics);
+    if (breaches.length > 0) {
+      return { promoted: false, stagesAdvanced: i, breaches };
+    }
+  }
+  return { promoted: true, stagesAdvanced: STAGES.length, breaches: [] };
+}
+
+// PolicyEngine wraps a feature flag — flip pinnedModel from candidate back to
+// baseline in O(1). Mirrors LaunchDarkly/Flagsmith/Unleash flag-flip rollback.
+class PolicyEngine {
+  private pinnedDigest: string;
+  private rolloutPct = 0;
+
+  constructor(initialDigest: string) {
+    this.pinnedDigest = initialDigest;
+  }
+
+  promote(candidateDigest: string, pct: number): void {
+    this.pinnedDigest = candidateDigest;
+    this.rolloutPct = pct;
+  }
+
+  // Constant-time rollback — what your runbook flips.
+  rollback(baselineDigest: string): void {
+    this.pinnedDigest = baselineDigest;
+    this.rolloutPct = 0;
+  }
+
+  pick(rng: () => number): { digest: string; chose: "baseline" | "candidate" } {
+    return rng() < this.rolloutPct
+      ? { digest: this.pinnedDigest, chose: "candidate" }
+      : { digest: "baseline-digest", chose: "baseline" };
+  }
+}
+
+// -- Reporting ------------------------------------------------------------
+
+function rolloutReport(name: string, reg: Regression): void {
+  console.log(`\n${name}`);
+  console.log(
+    `Regression: latency=${reg.latencyMult}, cost=${reg.costMult}, error=${reg.errorMult}, len=${reg.outputLenMult}, thumbs=${reg.thumbsDownMult}`,
+  );
+  for (let i = 0; i < STAGES.length; i++) {
+    const stage = STAGES[i];
+    const metrics = measureStage(stage, reg, stageSeed(i));
+    const breaches = checkGates(metrics);
+    const status =
+      breaches.length === 0 ? "PASS" : `HALT (${breaches.join(",")})`;
+    const pct = Math.round(stage * 100);
+    console.log(
+      `  stage ${String(pct).padStart(3)}%  ` +
+        `lat_p99=${metrics.latencyP99Ms.toFixed(0).padStart(5)}  ` +
+        `cost=$${metrics.costPerReq.toFixed(4)}  ` +
+        `err=${(metrics.errorRate * 100).toFixed(1).padStart(4)}%  ` +
+        `thumbs_dn=${(metrics.thumbsDownRate * 100).toFixed(1).padStart(4)}%  ` +
+        `${status}`,
+    );
+    if (breaches.length > 0) {
+      console.log("  → ROLLBACK (policy flip, pinned model reverted)");
+      return;
+    }
+  }
+  console.log("  → PROMOTED to 100%");
+}
+
+// -- Demo ------------------------------------------------------------------
+
+function shadowDemo(): void {
+  console.log("--- Shadow-mode evaluation (zero user impact) ---");
+  // Three scenarios: candidate roughly comparable, candidate cheaper, candidate
+  // 40% more expensive (the docs' canonical bad scenario).
+  const rng = makeRng(99);
+  const mkSamples = (costMult: number, latMult: number): ShadowSample[] =>
+    Array.from({ length: 200 }, () => ({
+      baselineCost: 0.02 * (0.95 + rng() * 0.1),
+      candidateCost: 0.02 * costMult * (0.95 + rng() * 0.1),
+      baselineLatencyMs: 800 * (0.95 + rng() * 0.1),
+      candidateLatencyMs: 800 * latMult * (0.95 + rng() * 0.1),
+    }));
+
+  const scenarios: { name: string; samples: ShadowSample[] }[] = [
+    { name: "comparable candidate", samples: mkSamples(1.05, 1.02) },
+    { name: "candidate 20% cheaper", samples: mkSamples(0.8, 0.95) },
+    { name: "candidate 40% more expensive (rollback case)", samples: mkSamples(1.4, 1.0) },
+  ];
+
+  for (const s of scenarios) {
+    const r = shadowEvaluate(s.samples);
+    console.log(
+      `  ${s.name}: n=${r.n} cost_delta=${r.meanCostDeltaPct.toFixed(1)}%  ` +
+        `lat_delta=${r.meanLatencyDeltaPct.toFixed(1)}%  ` +
+        `alert=${r.alert}${r.reasons.length ? "  reasons=" + r.reasons.join("; ") : ""}`,
+    );
+  }
+}
+
+function policyEngineDemo(): void {
+  console.log("\n--- PolicyEngine — promote then rollback in O(1) ---");
+  const engine = new PolicyEngine("baseline-digest");
+  engine.promote("candidate-digest-v2", 0.1);
+  const rng = makeRng(42);
+  let candidateCount = 0;
+  for (let i = 0; i < 1000; i++) {
+    if (engine.pick(rng).chose === "candidate") candidateCount++;
+  }
+  console.log(
+    `  after promote to 10%: ${candidateCount}/1000 picks chose candidate (target ~100)`,
+  );
+  engine.rollback("baseline-digest");
+  let postCount = 0;
+  for (let i = 0; i < 1000; i++) {
+    if (engine.pick(rng).chose === "candidate") postCount++;
+  }
+  console.log(`  after rollback: ${postCount}/1000 (target 0)`);
+}
+
+function canaryDemo(): void {
+  console.log("\n" + "=".repeat(95));
+  console.log("CANARY ROLLOUT — six stages, five gates, injected regressions");
+  console.log("=".repeat(95));
+
+  rolloutReport("Clean promotion", NO_REGRESSION);
+  rolloutReport("Small cost regression (10%) — within gate", {
+    ...NO_REGRESSION,
+    costMult: 1.1,
+  });
+  rolloutReport("Cost regression 25%", { ...NO_REGRESSION, costMult: 1.25 });
+  rolloutReport("Latency regression 80%", {
+    ...NO_REGRESSION,
+    latencyMult: 1.8,
+  });
+  rolloutReport("Thumbs-down regression 60%", {
+    ...NO_REGRESSION,
+    thumbsDownMult: 1.6,
+  });
+  rolloutReport("Quality silent + cost creep", {
+    ...NO_REGRESSION,
+    costMult: 1.15,
+    thumbsDownMult: 1.45,
+  });
+
+  // Programmatic outcome of canaryRollout() for the same six scenarios.
+  console.log("\n--- canaryRollout() programmatic verdict ---");
+  const scenarios: { name: string; reg: Regression }[] = [
+    { name: "clean", reg: NO_REGRESSION },
+    { name: "cost 10%", reg: { ...NO_REGRESSION, costMult: 1.1 } },
+    { name: "cost 25%", reg: { ...NO_REGRESSION, costMult: 1.25 } },
+    { name: "latency 80%", reg: { ...NO_REGRESSION, latencyMult: 1.8 } },
+    { name: "thumbs 60%", reg: { ...NO_REGRESSION, thumbsDownMult: 1.6 } },
+    {
+      name: "cost 15% + thumbs 45%",
+      reg: { ...NO_REGRESSION, costMult: 1.15, thumbsDownMult: 1.45 },
+    },
+  ];
+  for (const s of scenarios) {
+    const d = canaryRollout(s.reg);
+    const verdict = d.promoted
+      ? "PROMOTED"
+      : `HALT @ stage ${d.stagesAdvanced} on ${d.breaches.join(",")}`;
+    console.log(`  ${s.name.padEnd(28)} → ${verdict}`);
+  }
+}
+
+function main(): void {
+  shadowDemo();
+  policyEngineDemo();
+  canaryDemo();
+}
+
+main();

--- a/phases/17-infrastructure-and-production/20-shadow-canary-progressive/code/main.ts
+++ b/phases/17-infrastructure-and-production/20-shadow-canary-progressive/code/main.ts
@@ -140,12 +140,22 @@ function shadowEvaluate(samples: ShadowSample[]): ShadowReport {
   }
   let costDelta = 0;
   let latDelta = 0;
+  let costN = 0;
+  let latN = 0;
   for (const s of samples) {
-    costDelta += (s.candidateCost - s.baselineCost) / s.baselineCost;
-    latDelta += (s.candidateLatencyMs - s.baselineLatencyMs) / s.baselineLatencyMs;
+    // Skip rows with non-positive baselines so a single zero row cannot turn
+    // the average into Infinity/NaN and corrupt the gate decision.
+    if (s.baselineCost > 0) {
+      costDelta += (s.candidateCost - s.baselineCost) / s.baselineCost;
+      costN++;
+    }
+    if (s.baselineLatencyMs > 0) {
+      latDelta += (s.candidateLatencyMs - s.baselineLatencyMs) / s.baselineLatencyMs;
+      latN++;
+    }
   }
-  const meanCost = (costDelta / samples.length) * 100;
-  const meanLat = (latDelta / samples.length) * 100;
+  const meanCost = costN > 0 ? (costDelta / costN) * 100 : 0;
+  const meanLat = latN > 0 ? (latDelta / latN) * 100 : 0;
   const reasons: string[] = [];
   if (meanCost > 30) reasons.push(`cost +${meanCost.toFixed(1)}% (>30%)`);
   if (meanLat > 50) reasons.push(`latency +${meanLat.toFixed(1)}% (>50%)`);
@@ -178,10 +188,12 @@ function canaryRollout(reg: Regression): CanaryDecision {
 // PolicyEngine wraps a feature flag — flip pinnedModel from candidate back to
 // baseline in O(1). Mirrors LaunchDarkly/Flagsmith/Unleash flag-flip rollback.
 class PolicyEngine {
+  private baselineDigest: string;
   private pinnedDigest: string;
   private rolloutPct = 0;
 
   constructor(initialDigest: string) {
+    this.baselineDigest = initialDigest;
     this.pinnedDigest = initialDigest;
   }
 
@@ -190,16 +202,19 @@ class PolicyEngine {
     this.rolloutPct = pct;
   }
 
-  // Constant-time rollback — what your runbook flips.
-  rollback(baselineDigest: string): void {
-    this.pinnedDigest = baselineDigest;
+  // Constant-time rollback — what your runbook flips. Repins to the
+  // baseline captured at construction time (or the most recent rollback
+  // override).
+  rollback(baselineDigest?: string): void {
+    if (baselineDigest !== undefined) this.baselineDigest = baselineDigest;
+    this.pinnedDigest = this.baselineDigest;
     this.rolloutPct = 0;
   }
 
   pick(rng: () => number): { digest: string; chose: "baseline" | "candidate" } {
     return rng() < this.rolloutPct
       ? { digest: this.pinnedDigest, chose: "candidate" }
-      : { digest: "baseline-digest", chose: "baseline" };
+      : { digest: this.baselineDigest, chose: "baseline" };
   }
 }
 
@@ -276,7 +291,7 @@ function policyEngineDemo(): void {
   console.log(
     `  after promote to 10%: ${candidateCount}/1000 picks chose candidate (target ~100)`,
   );
-  engine.rollback("baseline-digest");
+  engine.rollback();
   let postCount = 0;
   for (let i = 0; i < 1000; i++) {
     if (engine.pick(rng).chose === "candidate") postCount++;


### PR DESCRIPTION
Adds idiomatic TypeScript ports of six Phase 17 lessons where TS is the lingua franca for the topic (observability, rate-limited services, gateways, rollout policy). Each TS file lives alongside the existing `main.py` so neither language is replaced — the audit and catalog now reflect both.

## The 6 lessons

| Lesson | Surface | What main.ts adds beyond main.py |
|---|---|---|
| `17-infrastructure-and-production/13-llm-observability` | OpenTelemetry GenAI tracer | In-memory tracer using the OTel GenAI Semantic Convention attribute names (`gen_ai.system`, `gen_ai.request.model`, `gen_ai.usage.*`). Sampling exporter (keep all errors + high-cost, sample rest). Same 1M-trace retention simulator. |
| `17-infrastructure-and-production/14-prompt-semantic-caching` | LRU+TTL + semantic cache | `LRUCache<K,V>` (insertion-order Map, get-refreshes-LRU). `SemanticCache` with cosine threshold over a deterministic 64-dim word-hash embedding. Same two-layer cost simulator with 2026-04 pricing. |
| `17-infrastructure-and-production/15-batch-apis` | Batch dispatcher with deferred futures | `BatchDispatcher<I,O>` with `openBatch / addJob / closeBatch` — addJob returns a `Promise<O>` the caller awaits later, the OpenAI/Anthropic-shaped lifecycle. Same SYNC/CACHE/BATCH cost simulator. |
| `17-infrastructure-and-production/16-model-routing` | Rule-based router | `ModelRouter` over a catalog with capability bags, context-window fit, quality floors. Weighted picker on cost/latency/capability with hard-set similarity short-circuit. Same NO_ROUTE/PRE_ROUTE/CASCADE simulator. |
| `17-infrastructure-and-production/19-ai-gateways` | Gateway skeleton | `AuthService` (SHA-256 hashes, timingSafeEqual), `TokenBucketLimiter` (per-tenant tier), `callWithRetry` (exp backoff + jitter), `callWithFallback` (provider chain). Same 4-gateway simulator. |
| `17-infrastructure-and-production/20-shadow-canary-progressive` | Shadow/canary/policy engine | `shadowEvaluate()` (zero-impact cost+latency delta with alert rule), `canaryRollout()` (six stages, five gates), `PolicyEngine` (promote/rollback in O(1) — the feature-flag rollback shape). Same six-regression simulator. |

## Commits

7 commits — 6 atomic per-lesson + 1 catalog regen.

```
e178f3c chore(catalog): regenerate after Phase 17 TypeScript ports
dba3b21 feat(phase17-20): TypeScript port — shadow + canary + progressive rollout policy
9502f65 feat(phase17-19): TypeScript port — AI gateway skeleton (auth + rate limit + retry + fallback)
f5d7cc9 feat(phase17-16): TypeScript port — rule-based model router + cascade simulator
8bfddf5 feat(phase17-15): TypeScript port — batch dispatcher with deferred futures + cost simulator
107bac1 feat(phase17·14): TypeScript port — LRU+TTL + semantic cache + two-layer simulator
44b7428 feat(phase17·13): TypeScript port — OpenTelemetry GenAI tracer + retention simulator
```

## Validation

- **Typecheck**: tsc 5.7.3 (`--strict --target ES2022 --module NodeNext --moduleResolution NodeNext --noEmit --types node`) clean on all 6 files.
- **Runtime**: tsx 4.19.0 runs all six end-to-end with deterministic output. Mocked LLM / provider calls, no network.
- **Audit**: `python3 scripts/audit_lessons.py` clean — 435 lessons checked, 0 issues.
- **Catalog**: `python3 scripts/build_catalog.py` regenerated; `code_files` 435 → 441.
- **No npm deps**. Each file is single-file Node 20+ stdlib only. The catalog already accepted `.ts` (added in scripts/build_catalog.py `CODE_SUFFIXES`).
- README, site, docs/en.md untouched.

## References embedded in the source

Every TS file cites the same primary URLs the existing `docs/en.md` uses:

- OpenTelemetry GenAI Semantic Conventions — https://opentelemetry.io/docs/specs/semconv/gen-ai/
- Anthropic Prompt Caching — https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching
- OpenAI Prompt Caching — https://platform.openai.com/docs/guides/prompt-caching
- OpenAI Batch API — https://platform.openai.com/docs/guides/batch
- Anthropic Message Batches — https://docs.anthropic.com/en/docs/build-with-claude/batch-processing
- Vertex AI Batch Prediction — https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/batch-prediction
- Kong AI Gateway benchmark — https://konghq.com/blog/engineering/ai-gateway-benchmark-kong-ai-gateway-portkey-litellm
- LiteLLM — https://github.com/BerriAI/litellm
- Portkey — https://github.com/Portkey-AI/gateway
- Kong AI Gateway docs — https://docs.konghq.com/gateway/latest/ai-gateway/
- RouteLLM — https://github.com/lm-sys/RouteLLM
- OpenRouter — https://openrouter.ai/
- Argo Rollouts — https://argo-rollouts.readthedocs.io/
- Flagger — https://docs.flagger.app/
- ProjectDiscovery 7% → 74% — https://projectdiscovery.io/blog/how-we-cut-llm-cost-with-prompt-caching

## Test plan

- [ ] `python3 scripts/audit_lessons.py --phase 17` → 0 issues
- [ ] `python3 scripts/audit_lessons.py` → 0 issues
- [ ] `npx -y -p tsx@4.19.0 tsx phases/17-infrastructure-and-production/13-llm-observability/code/main.ts`
- [ ] `npx -y -p tsx@4.19.0 tsx phases/17-infrastructure-and-production/14-prompt-semantic-caching/code/main.ts`
- [ ] `npx -y -p tsx@4.19.0 tsx phases/17-infrastructure-and-production/15-batch-apis/code/main.ts`
- [ ] `npx -y -p tsx@4.19.0 tsx phases/17-infrastructure-and-production/16-model-routing/code/main.ts`
- [ ] `npx -y -p tsx@4.19.0 tsx phases/17-infrastructure-and-production/19-ai-gateways/code/main.ts`
- [ ] `npx -y -p tsx@4.19.0 tsx phases/17-infrastructure-and-production/20-shadow-canary-progressive/code/main.ts`