### PR TITLE
chore(catalog): sync code_files count after recent merges

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -6,7 +6,7 @@
     "skills": 378,
     "prompts": 99,
     "agents": 0,
-    "code_files": 443
+    "code_files": 447
   },
   "phases": [
     {


### PR DESCRIPTION
Drift check on main failed: catalog reports 443 files, filesystem has 447. Rebuilds catalog.json via `python3 scripts/build_catalog.py`. Single-byte change to summary.code_files.