### PR TITLE
chore(phase-00): sync docs/en.md Languages fields to Shell/Docker

### DIFF
--- a/phases/00-setup-and-tooling/06-python-environments/docs/en.md
+++ b/phases/00-setup-and-tooling/06-python-environments/docs/en.md
@@ -3,7 +3,7 @@
 > Dependency hell is real. Virtual environments are the cure.
 
 **Type:** Build
-**Languages:** Python
+**Languages:** Shell
 **Prerequisites:** Phase 0, Lesson 01
 **Time:** ~30 minutes
 

--- a/phases/00-setup-and-tooling/07-docker-for-ai/docs/en.md
+++ b/phases/00-setup-and-tooling/07-docker-for-ai/docs/en.md
@@ -3,7 +3,7 @@
 > Containers make "works on my machine" a thing of the past.
 
 **Type:** Build
-**Languages:** Python
+**Languages:** Docker
 **Prerequisites:** Phase 0, Lessons 01 and 03
 **Time:** ~60 minutes
 


### PR DESCRIPTION
Phase 0 lessons 06 (python-environments) and 07 (docker-for-ai) ship env_setup.sh / Dockerfile only. README PR #182 already corrected the catalog to Shell/Docker; this aligns docs/en.md to match. Closes the .py-coverage gap report.