### PR TITLE
ci(curriculum): regen catalog.json only on main push, not on PRs

### DIFF
--- a/.github/workflows/curriculum.yml
+++ b/.github/workflows/curriculum.yml
@@ -40,15 +40,15 @@ jobs:
         run: python3 scripts/audit_lessons.py
 
   catalog-sync:
-    name: catalog.json auto-regen
+    name: catalog.json auto-regen (main only)
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name == 'push'
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          ref: ${{ github.ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
@@ -75,9 +75,9 @@ jobs:
           git push
 
   catalog-drift-advisory:
-    name: catalog.json drift advisory (forks)
+    name: catalog.json drift advisory
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+    if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
@@ -90,7 +90,7 @@ jobs:
       - name: diff against committed catalog.json
         run: |
           if ! diff -u catalog.json /tmp/catalog.fresh.json; then
-            echo "::warning::catalog.json drift detected. A maintainer will regenerate on merge."
+            echo "::warning::catalog.json drift detected. Main will self-heal on merge via the catalog-sync job."
           else
             echo "catalog.json matches filesystem"
           fi
@@ -98,8 +98,6 @@ jobs:
   readme-counts-drift:
     name: README.md counts drift check
     runs-on: ubuntu-latest
-    needs: catalog-sync
-    if: always() && (needs.catalog-sync.result == 'success' || needs.catalog-sync.result == 'skipped')
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:


### PR DESCRIPTION
## Why

Current auto-regen commits catalog.json back to every PR branch. Each PR ends up with its own catalog delta, conflicting with main the moment another PR merges. Triggers chains of conflict-resolution churn (PR #197 hit this).

## What

- **catalog-sync** now runs only on \`push\` to main. Self-heals one commit after merge.
- **catalog-drift-advisory** runs on every PR (warning only, no commit). Fork + same-repo PRs treated identically.
- **readme-counts-drift** rebuilds catalog locally first, so the check works on PRs without needing catalog-sync to commit.

## Net effect

- PRs never modify catalog.json
- No more PR-side catalog conflicts
- Main always self-corrects within ~30s of merge