### PR TITLE
fix(readme): add missing lesson links for Phase 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -752,34 +752,34 @@ Each Phase 14 workbench lesson (31-42) ships a `mission.md` briefing the agent b
 
 | # | Lesson | Type | Lang |
 |:---:|--------|:----:|------|
-| 01 | Managed LLM Platforms — Bedrock, Azure OpenAI, Vertex AI | Learn | Python |
-| 02 | Inference Platform Economics — Fireworks, Together, Baseten, Modal | Learn | Python |
-| 03 | GPU Autoscaling on Kubernetes — Karpenter, KAI Scheduler | Learn | Python |
-| 04 | vLLM Serving Internals — PagedAttention, Continuous Batching, Chunked Prefill | Learn | Python |
-| 05 | EAGLE-3 Speculative Decoding in Production | Learn | Python |
-| 06 | SGLang and RadixAttention for Prefix-Heavy Workloads | Learn | Python |
-| 07 | TensorRT-LLM on Blackwell with FP8 and NVFP4 | Learn | Python |
-| 08 | Inference Metrics — TTFT, TPOT, ITL, Goodput, P99 | Learn | Python |
-| 09 | Production Quantization — AWQ, GPTQ, GGUF, FP8, NVFP4 | Learn | Python |
-| 10 | Cold Start Mitigation for Serverless LLMs | Learn | Python |
-| 11 | Multi-Region LLM Serving and KV Cache Locality | Learn | Python |
-| 12 | Edge Inference — ANE, Hexagon, WebGPU, Jetson | Learn | Python |
-| 13 | LLM Observability Stack Selection | Learn | Python |
-| 14 | Prompt Caching and Semantic Caching Economics | Learn | Python |
-| 15 | Batch APIs — the 50% Discount as Industry Standard | Learn | Python |
-| 16 | Model Routing as a Cost-Reduction Primitive | Learn | Python |
-| 17 | Disaggregated Prefill/Decode — NVIDIA Dynamo and llm-d | Learn | Python |
-| 18 | vLLM Production Stack with LMCache KV Offloading | Learn | Python |
-| 19 | AI Gateways — LiteLLM, Portkey, Kong, Bifrost | Learn | Python |
-| 20 | Shadow, Canary, and Progressive Deployment | Learn | Python |
-| 21 | A/B Testing LLM Features — GrowthBook and Statsig | Learn | Python |
-| 22 | Load Testing LLM APIs — k6, LLMPerf, GenAI-Perf | Build | Python |
-| 23 | SRE for AI — Multi-Agent Incident Response | Learn | Python |
-| 24 | Chaos Engineering for LLM Production | Learn | Python |
-| 25 | Security — Secrets, PII Scrubbing, Audit Logs | Learn | Python |
-| 26 | Compliance — SOC 2, HIPAA, GDPR, EU AI Act, ISO 42001 | Learn | Python |
-| 27 | FinOps for LLMs — Unit Economics and Multi-Tenant Attribution | Learn | Python |
-| 28 | Self-Hosted Serving Selection — llama.cpp, Ollama, TGI, vLLM, SGLang | Learn | Python |
+| 01 | [Managed LLM Platforms — Bedrock, Azure OpenAI, Vertex AI](phases/17-infrastructure-and-production/01-managed-llm-platforms/) | Learn | Python |
+| 02 | [Inference Platform Economics — Fireworks, Together, Baseten, Modal](phases/17-infrastructure-and-production/02-inference-platform-economics/) | Learn | Python |
+| 03 | [GPU Autoscaling on Kubernetes — Karpenter, KAI Scheduler](phases/17-infrastructure-and-production/03-gpu-autoscaling-kubernetes/) | Learn | Python |
+| 04 | [vLLM Serving Internals — PagedAttention, Continuous Batching, Chunked Prefill](phases/17-infrastructure-and-production/04-vllm-serving-internals/) | Learn | Python |
+| 05 | [EAGLE-3 Speculative Decoding in Production](phases/17-infrastructure-and-production/05-eagle3-speculative-decoding/) | Learn | Python |
+| 06 | [SGLang and RadixAttention for Prefix-Heavy Workloads](phases/17-infrastructure-and-production/06-sglang-radixattention/) | Learn | Python |
+| 07 | [TensorRT-LLM on Blackwell with FP8 and NVFP4](phases/17-infrastructure-and-production/07-tensorrt-llm-blackwell/) | Learn | Python |
+| 08 | [Inference Metrics — TTFT, TPOT, ITL, Goodput, P99](phases/17-infrastructure-and-production/08-inference-metrics-goodput/) | Learn | Python |
+| 09 | [Production Quantization — AWQ, GPTQ, GGUF, FP8, NVFP4](phases/17-infrastructure-and-production/09-production-quantization/) | Learn | Python |
+| 10 | [Cold Start Mitigation for Serverless LLMs](phases/17-infrastructure-and-production/10-cold-start-mitigation/) | Learn | Python |
+| 11 | [Multi-Region LLM Serving and KV Cache Locality](phases/17-infrastructure-and-production/11-multi-region-kv-locality/) | Learn | Python |
+| 12 | [Edge Inference — ANE, Hexagon, WebGPU, Jetson](phases/17-infrastructure-and-production/12-edge-inference/) | Learn | Python |
+| 13 | [LLM Observability Stack Selection](phases/17-infrastructure-and-production/13-llm-observability/) | Learn | Python |
+| 14 | [Prompt Caching and Semantic Caching Economics](phases/17-infrastructure-and-production/14-prompt-semantic-caching/) | Learn | Python |
+| 15 | [Batch APIs — the 50% Discount as Industry Standard](phases/17-infrastructure-and-production/15-batch-apis/) | Learn | Python |
+| 16 | [Model Routing as a Cost-Reduction Primitive](phases/17-infrastructure-and-production/16-model-routing/) | Learn | Python |
+| 17 | [Disaggregated Prefill/Decode — NVIDIA Dynamo and llm-d](phases/17-infrastructure-and-production/17-disaggregated-prefill-decode/) | Learn | Python |
+| 18 | [vLLM Production Stack with LMCache KV Offloading](phases/17-infrastructure-and-production/18-vllm-production-stack-lmcache/) | Learn | Python |
+| 19 | [AI Gateways — LiteLLM, Portkey, Kong, Bifrost](phases/17-infrastructure-and-production/19-ai-gateways/) | Learn | Python |
+| 20 | [Shadow, Canary, and Progressive Deployment](phases/17-infrastructure-and-production/20-shadow-canary-progressive/) | Learn | Python |
+| 21 | [A/B Testing LLM Features — GrowthBook and Statsig](phases/17-infrastructure-and-production/21-ab-testing-llm-features/) | Learn | Python |
+| 22 | [Load Testing LLM APIs — k6, LLMPerf, GenAI-Perf](phases/17-infrastructure-and-production/22-load-testing-llm-apis/) | Build | Python |
+| 23 | [SRE for AI — Multi-Agent Incident Response](phases/17-infrastructure-and-production/23-sre-for-ai/) | Learn | Python |
+| 24 | [Chaos Engineering for LLM Production](phases/17-infrastructure-and-production/24-chaos-engineering-llm/) | Learn | Python |
+| 25 | [Security — Secrets, PII Scrubbing, Audit Logs](phases/17-infrastructure-and-production/25-security-secrets-audit/) | Learn | Python |
+| 26 | [Compliance — SOC 2, HIPAA, GDPR, EU AI Act, ISO 42001](phases/17-infrastructure-and-production/26-compliance-frameworks/) | Learn | Python |
+| 27 | [FinOps for LLMs — Unit Economics and Multi-Tenant Attribution](phases/17-infrastructure-and-production/27-finops-llms/) | Learn | Python |
+| 28 | [Self-Hosted Serving Selection — llama.cpp, Ollama, TGI, vLLM, SGLang](phases/17-infrastructure-and-production/28-self-hosted-serving-selection/) | Learn | Python |
 
 </details>
 


### PR DESCRIPTION
## Problem

Phase 17 (Infrastructure & Production) lessons in the README are plain text with **no links**, while all other 19 phases use `[Lesson Name](phases/.../)`. The 28 lesson docs exist on disk — only the README table is missing the links.

## Impact

`site/build.js` derives each lesson's `url` from its README link. With no links, Phase 17's 28 lessons get no `url` in `data.js`, so on the site the catalog can't open any Phase 17 lesson.

## Reproduce (current main)

```
node site/build.js
grep -c 'tree/main/phases/17-' site/data.js   # 0   <- bug
grep -c 'tree/main/phases/16-' site/data.js   # 25  <- normal
```

## Fix

Added `[Lesson Name](phases/17-infrastructure-and-production/<slug>/)` links to all 28 Phase 17 lessons, matching every other phase. README-only change (data.js is a build artifact). After the fix:

```
grep -c 'tree/main/phases/17-' site/data.js   # 28
```

Lesson count unchanged (430). No other files touched.

## Before
<img width="2368" height="1912" alt="image" src="https://github.com/user-attachments/assets/c40945ca-c710-46ac-ac31-adc769eb15a7" />

## After
<img width="2352" height="2018" alt="image" src="https://github.com/user-attachments/assets/84f19c72-7c42-4154-a9f9-80933433b675" />

