### PR TITLE
fix(docs): escape pipes inside inline code so markdown tables render across 19 lessons

### DIFF
--- a/phases/00-setup-and-tooling/08-editor-setup/docs/en.md
+++ b/phases/00-setup-and-tooling/08-editor-setup/docs/en.md
@@ -122,7 +122,7 @@ Useful shortcuts:
 
 | Action | macOS | Linux/Windows |
 |--------|-------|---------------|
-| Toggle terminal | `` Ctrl+` `` | `` Ctrl+` `` |
+| Toggle terminal | `` Ctrl+` `` \| `` Ctrl+` `` |
 | New terminal | `Ctrl+Shift+`` ` | `Ctrl+Shift+`` ` |
 | Split terminal | `Cmd+\` | `Ctrl+\` |
 

--- a/phases/00-setup-and-tooling/08-editor-setup/docs/en.md
+++ b/phases/00-setup-and-tooling/08-editor-setup/docs/en.md
@@ -122,7 +122,7 @@ Useful shortcuts:
 
 | Action | macOS | Linux/Windows |
 |--------|-------|---------------|
-| Toggle terminal | `` Ctrl+` `` \| `` Ctrl+` `` |
+| Toggle terminal | `` Ctrl+` `` | `` Ctrl+` `` |
 | New terminal | `Ctrl+Shift+`` ` | `Ctrl+Shift+`` ` |
 | Split terminal | `Cmd+\` | `Ctrl+\` |
 

--- a/phases/06-speech-and-audio/05-whisper-architecture-finetuning/docs/en.md
+++ b/phases/06-speech-and-audio/05-whisper-architecture-finetuning/docs/en.md
@@ -171,7 +171,7 @@ Save as `outputs/skill-whisper-tuner.md`. Design a Whisper fine-tune or inferenc
 | Term | What people say | What it actually means |
 |------|-----------------|-----------------------|
 | 30-sec window | Whisper's limit | Hard input cap; chunk longer audio. |
-| SOT | Start-of-transcript | `<|startoftranscript|>` kicks off the decoder prompt. |
+| SOT | Start-of-transcript | `<\|startoftranscript\|>` kicks off the decoder prompt. |
 | Timestamps token | Temporal alignment | Every 0.02 s offset is a special token in the 51k vocab. |
 | Turbo | The fast variant | 4-decoder layers, 8× faster, <1% WER regression. |
 | WhisperX | The long-form wrapper | VAD + Whisper + wav2vec alignment + diarization. |

--- a/phases/07-transformers-deep-dive/04-positional-encoding/docs/en.md
+++ b/phases/07-transformers-deep-dive/04-positional-encoding/docs/en.md
@@ -164,7 +164,7 @@ See `outputs/skill-positional-encoding-picker.md`. The skill picks an encoding s
 | Positional encoding | "Tells attention about order" | Any signal added to embeddings or attention that encodes position. |
 | Sinusoidal | "The original one" | `sin/cos` at geometric frequencies added to embeddings; doesn't extrapolate. |
 | RoPE | "Rotary embeddings" | Rotate Q, K by position-dependent angle; dot product encodes relative distance. |
-| ALiBi | "Linear bias trick" | Add `-m·|i-j|` to attention scores; no embedding needed, great extrapolation. |
+| ALiBi | "Linear bias trick" | Add `-m·\|i-j\|` to attention scores; no embedding needed, great extrapolation. |
 | base | "RoPE's knob" | The frequency scaler in RoPE; increase to extend context at inference. |
 | NTK-aware | "A RoPE scaling trick" | Rescale `base` so high-frequency dims aren't squeezed when context expands. |
 | YaRN | "The fancy one" | Per-dimension interpolation+extrapolation that preserves attention entropy. |

--- a/phases/07-transformers-deep-dive/10-audio-transformers-whisper/docs/en.md
+++ b/phases/07-transformers-deep-dive/10-audio-transformers-whisper/docs/en.md
@@ -176,7 +176,7 @@ See `outputs/skill-asr-configurator.md`. The skill picks an ASR model, decoding 
 | Mel spectrogram | "Audio image" | 2D representation: frequency bins on one axis, time frames on the other; log-scaled energy per cell. |
 | Log-mel | "What Whisper sees" | Mel spectrogram passed through log; approximates human perception of loudness. |
 | Frame | "One time slice" | A 25 ms window of samples; overlapping at 10 ms stride. |
-| Task token | "Prompt prefix for speech" | Special tokens like `<|transcribe|>` / `<|translate|>` in the decoder prompt. |
+| Task token | "Prompt prefix for speech" | Special tokens like `<\|transcribe\|>` / `<\|translate\|>` in the decoder prompt. |
 | Voice activity detection (VAD) | "Find the speech" | Gate that removes silence before ASR; cuts cost massively. |
 | CTC | "Connectionist Temporal Classification" | Classic ASR loss for alignment-free training; Whisper does NOT use it. |
 | Whisper-turbo | "Small decoder, full encoder" | large-v3 encoder + 4-layer decoder; 8× faster decoding. |

--- a/phases/08-generative-ai/02-autoencoders-vae/docs/en.md
+++ b/phases/08-generative-ai/02-autoencoders-vae/docs/en.md
@@ -128,7 +128,7 @@ Skill takes: dataset profile + latent-dim target + downstream use (reconstructio
 |------|-----------------|-----------------------|
 | Autoencoder | Encode-decode network | `x → z → x̂`, learn MSE. Not generative. |
 | VAE | AE with a sampler | Encoder outputs a distribution, KL penalty shapes code space. |
-| ELBO | Evidence lower bound | `log p(x) ≥ recon - KL[q(z|x) \|\| p(z)]`; tight when `q = p(z|x)`. |
+| ELBO | Evidence lower bound | `log p(x) ≥ recon - KL[q(z\|x) \|\| p(z)]`; tight when `q = p(z\|x)`. |
 | Reparameterization | `z = μ + σ·ε` | Rewrites stochastic node as deterministic + pure noise. Enables backprop through sampling. |
 | Prior | `p(z)` | Target distribution for the latent, typically `N(0, I)`. |
 | Posterior collapse | "KL term wins" | Encoder ignores `x`, outputs the prior; decoder must hallucinate. |

--- a/phases/08-generative-ai/06-diffusion-ddpm-from-scratch/docs/en.md
+++ b/phases/08-generative-ai/06-diffusion-ddpm-from-scratch/docs/en.md
@@ -149,11 +149,11 @@ Save `outputs/skill-diffusion-trainer.md`. Skill takes a dataset + compute budge
 
 | Term | What people say | What it actually means |
 |------|-----------------|-----------------------|
-| Forward process | "Adding noise" | Fixed Markov chain `q(x_t | x_{t-1})` that destroys the data. |
-| Reverse process | "Denoising" | Learned chain `p_θ(x_{t-1} | x_t)` that reconstructs the data. |
+| Forward process | "Adding noise" | Fixed Markov chain `q(x_t \| x_{t-1})` that destroys the data. |
+| Reverse process | "Denoising" | Learned chain `p_θ(x_{t-1} \| x_t)` that reconstructs the data. |
 | β schedule | "The noise ladder" | Per-step variance; linear, cosine, or sigmoid. |
 | α̅ | "Alpha bar" | Cumulative product `∏(1 - β)`; gives closed-form `x_t` from `x_0`. |
-| Simple loss | "MSE on noise" | `||ε - ε_θ(x_t, t)||²`; all variational derivations collapse to this. |
+| Simple loss | "MSE on noise" | `\|\|ε - ε_θ(x_t, t)\|\|²`; all variational derivations collapse to this. |
 | ε-prediction | "Predict noise" | Output is the noise added; standard DDPM. |
 | V-prediction | "Predict velocity" | Output is `α·ε - σ·x`; better conditioning across t. |
 | DDPM | "The paper" | Ho et al. 2020; linear β, 1000 steps, U-Net. |

--- a/phases/08-generative-ai/09-inpainting-outpainting-editing/docs/en.md
+++ b/phases/08-generative-ai/09-inpainting-outpainting-editing/docs/en.md
@@ -129,7 +129,7 @@ Save `outputs/skill-editing-pipeline.md`. Skill takes an original image + edit d
 |------|-----------------|-----------------------|
 | Inpainting | "Fill the hole" | Regenerate inside a mask; keep outside pixels. |
 | Outpainting | "Extend the canvas" | Regenerate outside the canvas; keep inside. |
-| 9-channel U-Net | "Proper inpainting model" | U-Net with `noisy | encoded-source | mask` as input. |
+| 9-channel U-Net | "Proper inpainting model" | U-Net with `noisy \| encoded-source \| mask` as input. |
 | SDEdit | "Img2img with noise level" | Noise to time `t`, denoise with new prompt. |
 | InstructPix2Pix | "Text-only edits" | Fine-tuned diffusion on (image, instruction, output) triples. |
 | RePaint | "No retraining" | Re-noise periodically during reverse to reduce seams. |

--- a/phases/09-reinforcement-learning/01-mdps-states-actions-rewards/docs/en.md
+++ b/phases/09-reinforcement-learning/01-mdps-states-actions-rewards/docs/en.md
@@ -172,7 +172,7 @@ Refuse to ship any MDP where the state is non-Markovian without explicit mention
 |------|-----------------|-----------------------|
 | MDP | "Reinforcement learning setup" | Tuple `(S, A, P, R, γ)` satisfying the Markov property. |
 | State | "What the agent sees" | Sufficient statistic for future dynamics under the chosen policy class. |
-| Policy | "Agent's behavior" | Conditional distribution `π(a | s)` or deterministic map `s → a`. |
+| Policy | "Agent's behavior" | Conditional distribution `π(a \| s)` or deterministic map `s → a`. |
 | Return | "Total reward" | Discounted sum `Σ γ^t r_t` from the current step. |
 | Value | "How good a state is" | Expected return under `π` starting from `s`. |
 | Q-value | "How good an action is" | Expected return under `π` starting from `s` with first action `a`. |

--- a/phases/09-reinforcement-learning/02-dynamic-programming/docs/en.md
+++ b/phases/09-reinforcement-learning/02-dynamic-programming/docs/en.md
@@ -190,7 +190,7 @@ Refuse to run DP on state spaces > 10⁷. Refuse to claim convergence without a 
 | Policy iteration | "DP algorithm" | Alternating evaluation (`V^π`) and improvement (greedy `π` w.r.t. `V^π`) until the policy stops changing. |
 | Value iteration | "Faster DP" | Bellman optimality backup applied in one sweep; converges to `V*` geometrically. |
 | Bellman operator | "The recursion" | `(T V)(s) = max_a Σ P (r + γ V(s'))`; a `γ`-contraction in sup-norm. |
-| Contraction | "Why DP converges" | Any operator `T` with `||T x - T y|| ≤ γ ||x - y||` has a unique fixed point. |
+| Contraction | "Why DP converges" | Any operator `T` with `\|\|T x - T y\|\| ≤ γ \|\|x - y\|\|` has a unique fixed point. |
 | GPI | "Everything is DP" | Generalized Policy Iteration: any method driving `V` and `π` to mutual consistency. |
 | Synchronous update | "Jacobi-style" | Use old `V` throughout a sweep; cleanly analyzable but slower. |
 | In-place update | "Gauss-Seidel-style" | Use `V` as it's being updated; converges faster in practice. |

--- a/phases/09-reinforcement-learning/03-monte-carlo-methods/docs/en.md
+++ b/phases/09-reinforcement-learning/03-monte-carlo-methods/docs/en.md
@@ -191,7 +191,7 @@ Refuse to run MC on non-episodic tasks without a finite horizon cap. Refuse to r
 | First-visit MC | "Count each state once" | Only the first visit in an episode contributes to the value estimate. |
 | Every-visit MC | "Use all visits" | Every visit contributes; slightly biased but more sample-efficient. |
 | ε-greedy | "Exploration noise" | Pick greedy action with prob `1-ε`; random action with prob `ε`. |
-| Importance sampling | "Correcting for sampling from the wrong distribution" | Reweight returns by `π(a|s)/μ(a|s)` products to estimate `V^π` from `μ` data. |
+| Importance sampling | "Correcting for sampling from the wrong distribution" | Reweight returns by `π(a\|s)/μ(a\|s)` products to estimate `V^π` from `μ` data. |
 | On-policy | "Learn from my own data" | Target policy = behavior policy. Vanilla MC, PPO, SARSA. |
 | Off-policy | "Learn from someone else's data" | Target policy ≠ behavior policy. Importance-sampled MC, Q-learning, DQN. |
 

--- a/phases/09-reinforcement-learning/06-policy-gradients-reinforce/docs/en.md
+++ b/phases/09-reinforcement-learning/06-policy-gradients-reinforce/docs/en.md
@@ -180,12 +180,12 @@ Refuse REINFORCE-no-baseline on horizons > 500 steps. Refuse continuous-action c
 
 | Term | What people say | What it actually means |
 |------|-----------------|-----------------------|
-| Policy gradient | "Train the policy directly" | `∇J(θ) = E[G · ∇ log π_θ(a|s)]`; derived from the log-derivative trick. |
+| Policy gradient | "Train the policy directly" | `∇J(θ) = E[G · ∇ log π_θ(a\|s)]`; derived from the log-derivative trick. |
 | REINFORCE | "The original PG algorithm" | Williams (1992); Monte Carlo returns multiplied by log-policy gradient. |
 | Log-derivative trick | "Score function estimator" | `∇P(τ;θ) = P(τ;θ) · ∇ log P(τ;θ)`; makes gradients of expectations tractable. |
 | Baseline | "Variance reduction" | Any `b(s)` subtracted from `G`; unbiased because `E[b · ∇ log π] = 0`. |
 | Reward-to-go | "Only future returns count" | `G_t^{from t}` instead of the full `G_0`; correct and lower-variance. |
-| Entropy bonus | "Encourage exploration" | `+β · H(π(·|s))` term keeps the policy from collapsing. |
+| Entropy bonus | "Encourage exploration" | `+β · H(π(·\|s))` term keeps the policy from collapsing. |
 | On-policy | "Train on what you just saw" | Gradient expectation is w.r.t. the current policy — cannot reuse old data directly. |
 | Advantage | "How much better than average" | `A(s, a) = G(s, a) - V(s)`; the signed quantity REINFORCE-with-baseline multiplies. |
 

--- a/phases/09-reinforcement-learning/07-actor-critic-a2c-a3c/docs/en.md
+++ b/phases/09-reinforcement-learning/07-actor-critic-a2c-a3c/docs/en.md
@@ -174,7 +174,7 @@ Refuse single-worker A2C on environments with horizon > 1000 (too on-policy, too
 
 | Term | What people say | What it actually means |
 |------|-----------------|-----------------------|
-| Actor | "The policy net" | `π_θ(a|s)`, updated by policy gradient. |
+| Actor | "The policy net" | `π_θ(a\|s)`, updated by policy gradient. |
 | Critic | "The value net" | `V_φ(s)`, updated by MSE regression to returns / TD targets. |
 | Advantage | "How much better than average" | `A(s, a) = Q(s, a) - V(s)` or its estimators. Multiplier for `∇ log π`. |
 | TD residual | "δ" | `δ_t = r + γ V(s') - V(s)`; one-step advantage estimate. |

--- a/phases/09-reinforcement-learning/08-ppo/docs/en.md
+++ b/phases/09-reinforcement-learning/08-ppo/docs/en.md
@@ -184,10 +184,10 @@ Refuse `K > 30` or `ε > 0.3` (unsafe trust region). Refuse any PPO run without 
 
 | Term | What people say | What it actually means |
 |------|-----------------|-----------------------|
-| Importance ratio | "r_t(θ)" | `π_θ(a|s) / π_old(a|s)`; deviation from the policy that collected the data. |
+| Importance ratio | "r_t(θ)" | `π_θ(a\|s) / π_old(a\|s)`; deviation from the policy that collected the data. |
 | Clipped surrogate | "PPO's main trick" | `min(r·A, clip(r, 1-ε, 1+ε)·A)`; flat gradient past the clip on beneficial side. |
 | Trust region | "TRPO / PPO intent" | Limit each update's KL to guarantee monotone improvement. |
-| KL penalty | "Soft trust region" | Alternative PPO: `L - β · KL(π_θ || π_old)`. Adaptive `β`. |
+| KL penalty | "Soft trust region" | Alternative PPO: `L - β · KL(π_θ \|\| π_old)`. Adaptive `β`. |
 | Clip fraction | "How often clipping triggers" | Diagnostic — should be 0.1-0.3; outside means mistuned. |
 | Multi-epoch training | "Data reuse" | K epochs on each rollout; variance cost traded for sample efficiency. |
 | On-policy-ish | "Mostly on-policy" | PPO is nominally on-policy but K>1 epochs uses slightly-off-policy data safely. |

--- a/phases/09-reinforcement-learning/09-reward-modeling-rlhf/docs/en.md
+++ b/phases/09-reinforcement-learning/09-reward-modeling-rlhf/docs/en.md
@@ -219,7 +219,7 @@ Refuse to ship RLHF-PPO without a KL monitor. Refuse to use an RM smaller than t
 | RLHF | "Alignment RL" | Three-stage SFT + RM + PPO pipeline (Christiano 2017, Ouyang 2022). |
 | Reward Model (RM) | "The scoring net" | Learned scalar function fit to pairwise preferences via Bradley-Terry. |
 | Bradley-Terry | "Pairwise logistic loss" | `P(y_+ ≻ y_-) = σ(R(y_+) - R(y_-))`; the standard RM objective. |
-| KL penalty | "Stay near the reference" | `β · KL(π_θ || π_ref)` in the reward; the anti-reward-hacking regularizer. |
+| KL penalty | "Stay near the reference" | `β · KL(π_θ \|\| π_ref)` in the reward; the anti-reward-hacking regularizer. |
 | Reward hacking | "Goodhart's law" | Policy exploits RM flaws; symptoms: reward up, human eval flat. |
 | RLAIF | "AI-labeled preferences" | RLHF where labels come from another LM instead of humans. |
 | PRM | "Process Reward Model" | Scores partial reasoning steps; used in reasoning pipelines. |

--- a/phases/13-tools-and-protocols/06-mcp-fundamentals/docs/en.md
+++ b/phases/13-tools-and-protocols/06-mcp-fundamentals/docs/en.md
@@ -150,7 +150,7 @@ This lesson produces `outputs/skill-mcp-handshake-tracer.md`. Given a pcap-style
 | `tools/list` | "Discovery" | Client asks server for its current tool set |
 | `tools/call` | "Invocation" | Client asks server to execute a tool with arguments |
 | `notifications/*_changed` | "Mutation events" | Server tells client that its primitive list has changed |
-| Content block | "Typed result" | `{type: "text" | "image" | "resource" | "ui_resource"}` in tool result |
+| Content block | "Typed result" | `{type: "text" \| "image" \| "resource" \| "ui_resource"}` in tool result |
 | SEP | "Spec Evolution Proposal" | Named draft proposal (e.g. SEP-1686 for async Tasks) |
 
 ## Further Reading

--- a/phases/13-tools-and-protocols/10-mcp-resources-and-prompts/docs/en.md
+++ b/phases/13-tools-and-protocols/10-mcp-resources-and-prompts/docs/en.md
@@ -136,7 +136,7 @@ This lesson produces `outputs/skill-primitive-splitter.md`. Given a proposed MCP
 | Prompt | "Slash-command template" | Named multi-message template with argument slots |
 | Prompt arguments | "Template inputs" | Typed parameters the host collects before rendering |
 | `prompts/get` | "Render template" | Server returns the filled-in message list |
-| Content block | "Typed chunk" | `{type: text | image | resource | ui_resource}` |
+| Content block | "Typed chunk" | `{type: text \| image \| resource \| ui_resource}` |
 | Slash-command UX | "User shortcut" | Host surfaces prompts as commands starting with `/` |
 
 ## Further Reading

--- a/phases/18-ethics-safety-alignment/01-instruction-following-alignment-signal/docs/en.md
+++ b/phases/18-ethics-safety-alignment/01-instruction-following-alignment-signal/docs/en.md
@@ -106,7 +106,7 @@ This lesson produces `outputs/skill-instructgpt-explainer.md`. Given an RLHF pip
 | SFT | "instruction tuning" | Stage 1: cross-entropy fine-tune on prompt-response pairs |
 | Reward model | "the RM" | Scalar regressor over (prompt, response) trained with Bradley-Terry on pairwise labels |
 | Bradley-Terry | "pairwise preference loss" | -log sigmoid(r_w - r_l); reduces pairwise ranking to binary classification |
-| KL penalty | "the regularizer" | `beta * KL(pi || pi_SFT)` — keeps the RL policy near the SFT anchor |
+| KL penalty | "the regularizer" | `beta * KL(pi \|\| pi_SFT)` — keeps the RL policy near the SFT anchor |
 | PPO-ptx | "PPO with pretraining mix" | Adds a fraction of pre-training log-likelihood to the PPO objective to offset the alignment tax |
 | Alignment tax | "the RLHF regression" | Post-RLHF drop on standard benchmarks that RLHF did not target |
 | Labeler preference | "the ground truth" | Sample of human rankings; the RM is a statistical proxy for this, not for "human values" |

--- a/phases/18-ethics-safety-alignment/02-reward-hacking-goodhart/docs/en.md
+++ b/phases/18-ethics-safety-alignment/02-reward-hacking-goodhart/docs/en.md
@@ -97,7 +97,7 @@ This lesson produces `outputs/skill-reward-hack-auditor.md`. Given a trained RLH
 | Gold reward | "what we actually want" | The target the proxy is a noisy measurement of; in practice, a larger-sample RM or human eval |
 | Proxy reward | "the RM" | The scalar used during training; by construction, it is what the optimizer sees |
 | Over-optimization curve | "the reward-hacking U-curve" | Proxy climbs, gold peaks then falls as KL from initial policy grows |
-| KL budget | "how far we can drift" | `sqrt(KL(pi || pi_init))`; Gao et al. plot reward against this |
+| KL budget | "how far we can drift" | `sqrt(KL(pi \|\| pi_init))`; Gao et al. plot reward against this |
 | Catastrophic Goodhart | "KL does not save you" | Under heavy-tailed reward error, KL-constrained optimal policy can maximize proxy while providing no gold utility |
 | Unfaithful reasoning | "wrong CoT, right answer" | Chain-of-thought that does not causally drive the final prediction |
 | Evaluator tampering | "gaming the scorer" | Agent modifies its environment, scratchpad, or the RM's inputs to register success |

--- a/phases/18-ethics-safety-alignment/03-direct-preference-optimization-family/docs/en.md
+++ b/phases/18-ethics-safety-alignment/03-direct-preference-optimization-family/docs/en.md
@@ -145,7 +145,7 @@ This lesson produces `outputs/skill-preference-loss-selector.md`. Given dataset 
 | Term | What people say | What it actually means |
 |------|-----------------|------------------------|
 | DPO | "RLHF without a reward model" | Loss derived from the closed-form RLHF optimum; policy parameters only |
-| Implicit reward | "the log-ratio" | `beta * log(pi(y|x) / pi_ref(y|x))` — the DPO-implied reward |
+| Implicit reward | "the log-ratio" | `beta * log(pi(y\|x) / pi_ref(y\|x))` — the DPO-implied reward |
 | IPO | "bounded DPO" | Replaces log-sigmoid with identity; implicit reward gap capped by `1/(2 beta)` |
 | KTO | "unpaired DPO" | Prospect-theory utility over single labels with loss aversion |
 | SimPO | "reference-free DPO" | Length-normalized log-likelihood + margin; no reference policy |


### PR DESCRIPTION
Inline code inside markdown table cells with unescaped pipes (`|`) breaks the table renderer, splitting cells (e.g. `q(z|x)` and `p(z|x)` in Phase 8 lesson 02 VAE Key Terms). Site rendering split the ELBO row into 7 columns instead of 3.

Fix: escape every unescaped `|` inside inline code spans inside table rows with `\|`.

19 lessons fixed (atomic per-lesson commits):
- Phase 0/08, Phase 6/05, Phase 7/04+10, Phase 8/02+06+09
- Phase 9/01+02+03+06+07+08+09
- Phase 13/06+10
- Phase 18/01+02+03

Mechanical sweep via /tmp/fix_table_pipes.py; verified 0 remaining hits.