### PR TITLE
docs(phase-00/01): note Python 3.14 lacks PyTorch CUDA wheels (#192)

### DIFF
--- a/phases/00-setup-and-tooling/01-dev-environment/docs/en.md
+++ b/phases/00-setup-and-tooling/01-dev-environment/docs/en.md
@@ -123,6 +123,8 @@ nvidia-smi
 uv pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu124
 ```
 
+> **On Python 3.14?** PyTorch doesn't ship CUDA wheels for the newest Python release right away, so the command above can't find a matching GPU build and you fall back to CPU-only torch. Use Python 3.11–3.13 for GPU support until the CUDA wheels catch up to 3.14.
+
 ```python
 import torch
 print(f"CUDA available: {torch.cuda.is_available()}")

--- a/phases/00-setup-and-tooling/01-dev-environment/docs/en.md
+++ b/phases/00-setup-and-tooling/01-dev-environment/docs/en.md
@@ -123,7 +123,7 @@ nvidia-smi
 uv pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu124
 ```
 
-> **On Python 3.14?** PyTorch doesn't ship CUDA wheels for the newest Python release right away, so the command above can't find a matching GPU build and you fall back to CPU-only torch. Use Python 3.11–3.13 for GPU support until the CUDA wheels catch up to 3.14.
+> **On Python 3.14?** The `cu124` index above doesn't have 3.14 wheels, so the install falls back to CPU-only torch. The newer CUDA builds do ship 3.14 wheels — use `--index-url https://download.pytorch.org/whl/cu128` (or `cu126`) instead. If you'd rather stay on `cu124`, use Python 3.11–3.13.
 
 ```python
 import torch


### PR DESCRIPTION
Adds a short note in the GPU setup step pointing out that PyTorch doesn't publish CUDA wheels for the newest Python right away, so on Python 3.14 the install falls back to CPU-only torch. Suggests using Python 3.11–3.13 for GPU until 3.14 wheels are available.

This matches the setup doc, which already recommends Python 3.11+.

Fixes #192.
