### PR TITLE
feat: add quiz.json for seven orphan lessons (07/15-16, 08/19, 10/15-17, 10/34)

### DIFF
--- a/phases/07-transformers-deep-dive/15-attention-variants/quiz.json
+++ b/phases/07-transformers-deep-dive/15-attention-variants/quiz.json
@@ -1,0 +1,78 @@
+{
+  "lesson": "15-attention-variants",
+  "title": "Attention Variants — Sliding Window, Sparse, Differential",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "What does sliding window attention (SWA) change compared to full causal attention?",
+      "options": [
+        "Each query attends only to a fixed local window of keys instead of the entire prefix, reducing compute and KV cache from O(N²) to O(N·W)",
+        "It removes causality so tokens can attend to future positions",
+        "It replaces softmax with a linear attention kernel only",
+        "It eliminates the need for positional encodings"
+      ],
+      "correct": 0,
+      "explanation": "SWA masks scores outside a window of width W. Memory and compute scale with N·W rather than N², and the KV cache can retain only the last W tokens per layer."
+    },
+    {
+      "stage": "check",
+      "question": "Why do production stacks like Gemma 3 interleave SWA layers with occasional full-attention layers?",
+      "options": [
+        "SWA alone weakens long-range retrieval; periodic global layers restore access to the full context while keeping most layers cheap",
+        "Full layers are required because SWA cannot be implemented in FlashAttention",
+        "Global layers exist only to increase parameter count",
+        "SWA and global layers must alternate every single layer"
+      ],
+      "correct": 0,
+      "explanation": "Overlapping windows extend receptive field layer by layer, but explicit global layers (e.g. a 5:1 SWA-to-global ratio) are the standard fix when tasks need distant-token dependencies."
+    },
+    {
+      "stage": "check",
+      "question": "In differential attention, what role does subtracting a second attention map play?",
+      "options": [
+        "It cancels the attention-sink mass on early tokens and reallocates weight to content-bearing positions",
+        "It doubles sequence length without extra compute",
+        "It converts encoder-only models into decoders",
+        "It removes the need for value projections"
+      ],
+      "correct": 0,
+      "explanation": "Two softmax maps (A1 and A2) are computed with separate Q/K projections; DiffAttn = (A1 − λ·A2)V where λ is learned. A2 captures sink behavior that A1 minus λ·A2 suppresses."
+    },
+    {
+      "stage": "check",
+      "question": "How does Flash Attention (Lesson 12) differ from sparse or sliding-window *topology* changes?",
+      "options": [
+        "FlashAttention optimizes memory movement for a given mask; SWA/sparse patterns change which pairs receive non-zero attention scores",
+        "FlashAttention only works on bidirectional encoders",
+        "Sparse attention cannot be combined with FlashAttention in 2026 stacks",
+        "There is no difference — FlashAttention always implies SWA"
+      ],
+      "correct": 0,
+      "explanation": "FlashAttention is an IO-aware kernel for full or masked attention. Sliding window and sparse masks reduce which entries exist; FlexAttention-style APIs then fuse those patterns with efficient kernels."
+    },
+    {
+      "stage": "post",
+      "question": "For causal SWA with window W on length N, what is the asymptotic attention compute scaling?",
+      "options": [
+        "O(N·W) instead of O(N²) for the non-masked entries",
+        "O(N²) regardless of W",
+        "O(W²) independent of N",
+        "O(log N) because windows stack exponentially"
+      ],
+      "correct": 0,
+      "explanation": "Each of N query positions attends to at most W keys, giving O(N·W) score entries. Effective receptive field can still grow across L layers as roughly L·W when windows overlap."
+    },
+    {
+      "stage": "post",
+      "question": "What does the lesson’s mask comparator demo in code/main.py illustrate?",
+      "options": [
+        "Side-by-side causal, SWA, local+strided sparse, and differential masks on a toy sequence so you can see which positions receive finite scores",
+        "End-to-end training of Llama 3 70B on 128K context",
+        "Quantization of KV cache to INT4 only",
+        "Conversion of BERT checkpoints to GPT-2"
+      ],
+      "correct": 0,
+      "explanation": "The build implements swa_mask, strided_mask, and differential-style scoring on small N so the sparsity pattern is visible before wiring variants into a full transformer stack."
+    }
+  ]
+}

--- a/phases/07-transformers-deep-dive/16-speculative-decoding/quiz.json
+++ b/phases/07-transformers-deep-dive/16-speculative-decoding/quiz.json
@@ -1,0 +1,78 @@
+{
+  "lesson": "16-speculative-decoding",
+  "title": "Speculative Decoding — Draft, Verify, Repeat",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "What quality guarantee does correct speculative sampling preserve?",
+      "options": [
+        "The output token sequence is identically distributed to what the verifier model would produce alone",
+        "The draft model’s distribution replaces the verifier’s distribution for speed",
+        "Only greedy decoding is supported; sampling temperature is forbidden",
+        "The verifier never runs; only the draft model generates text"
+      ],
+      "correct": 0,
+      "explanation": "Leviathan et al. (2023) acceptance with residual sampling on rejection ensures the marginal distribution matches the verifier—speed comes from parallelism, not approximation error."
+    },
+    {
+      "stage": "check",
+      "question": "For a drafted token with draft probability p_i and verifier probability q_i(d_i), when is the draft accepted?",
+      "options": [
+        "With probability min(1, q_i(d_i) / p_i(d_i)) using an independent uniform draw",
+        "Always when the draft and verifier pick the same token ID",
+        "Only when p_i > q_i",
+        "Never — drafts are always discarded"
+      ],
+      "correct": 0,
+      "explanation": "The lesson implements accept_or_reject with ratio q/p capped at 1. On rejection, the next token is sampled from the normalized positive part of (q − p)."
+    },
+    {
+      "stage": "check",
+      "question": "What does acceptance rate α control in the speedup story?",
+      "options": [
+        "How often draft tokens survive verification—higher α means fewer big-model steps per generated token",
+        "The learning rate during speculative fine-tuning",
+        "The number of layers in the draft transformer",
+        "Whether KV cache is stored in FP8"
+      ],
+      "correct": 0,
+      "explanation": "α is the expected per-position acceptance probability. With N drafts per step, high α reduces verifier calls roughly by 1/(1−α) in the high-acceptance regime, combined with cheap draft forward passes."
+    },
+    {
+      "stage": "check",
+      "question": "Why must production stacks roll back KV cache state after a rejected draft?",
+      "options": [
+        "Verification extends the cache by N draft positions; rejections truncate back to the last accepted prefix",
+        "KV cache is never used during speculative decoding",
+        "Draft models do not use attention",
+        "Rollback is only needed for training, not inference"
+      ],
+      "correct": 0,
+      "explanation": "One verifier forward appends N draft keys/values. If draft j is rejected, positions after the accepted prefix must be discarded so the next step starts from a consistent cache length."
+    },
+    {
+      "stage": "post",
+      "question": "How does EAGLE differ from vanilla speculative decoding with a separate small draft model?",
+      "options": [
+        "EAGLE reuses verifier hidden states in a tiny draft network, often raising acceptance above vanilla separate-draft setups",
+        "EAGLE removes the verifier entirely",
+        "EAGLE only works on diffusion image models",
+        "EAGLE forbids tree search over candidate continuations"
+      ],
+      "correct": 0,
+      "explanation": "EAGLE-1/2/3 condition a lightweight draft on the verifier’s features so draft and verifier distributions correlate more strongly; EAGLE-3 adds tree search over continuations in production stacks like vLLM."
+    },
+    {
+      "stage": "post",
+      "question": "In the lesson’s toy implementation, what is residual_dist(q, p) used for?",
+      "options": [
+        "Sampling the next token from max(0, q−p) renormalized when a draft token is rejected",
+        "Computing the draft model’s learning rate",
+        "Padding batches to the nearest power of two",
+        "Encrypting logits before softmax"
+      ],
+      "correct": 0,
+      "explanation": "Element-wise subtraction, clamp negatives to zero, renormalize—this is the corrected distribution for the rejection position so the combined procedure matches direct verifier sampling."
+    }
+  ]
+}

--- a/phases/08-generative-ai/19-visual-autoregressive-var/quiz.json
+++ b/phases/08-generative-ai/19-visual-autoregressive-var/quiz.json
@@ -1,0 +1,78 @@
+{
+  "lesson": "19-visual-autoregressive-var",
+  "title": "Visual Autoregressive Modeling (VAR): Next-Scale Prediction",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "What generation-order problem hurt early pixel-by-pixel or raster-order image autoregression?",
+      "options": [
+        "Early spatial positions must commit before later context exists, so quality scaled poorly compared to text GPTs",
+        "Raster order is too fast for GPUs",
+        "VQ codebooks cannot represent color",
+        "Diffusion models cannot be trained on ImageNet"
+      ],
+      "correct": 0,
+      "explanation": "A 1D visit order over a 2D grid forces corner pixels to decide before the global image structure is known—VAR changes the unit of prediction from single tokens to whole scales."
+    },
+    {
+      "stage": "check",
+      "question": "In VAR, what is predicted at each autoregressive step during generation?",
+      "options": [
+        "The entire token grid at the next resolution scale, conditioned on all coarser scales",
+        "One RGB pixel at a time in row-major order only",
+        "A single continuous noise vector for the full image",
+        "Only the final high-resolution scale without coarse stages"
+      ],
+      "correct": 0,
+      "explanation": "Generation runs z₁ (e.g. 1×1), then z₂ (2×2), then finer scales up to K; each scale is produced in one forward pass with parallel prediction within the scale."
+    },
+    {
+      "stage": "check",
+      "question": "How does the multi-scale VQ tokenizer represent an image latent?",
+      "options": [
+        "Residual token grids at increasing resolution whose embedded sum reconstructs the latent, trained once then frozen",
+        "A single 8×8 codebook with no coarse levels",
+        "Continuous flow matching in pixel space only",
+        "Per-pixel softmax without a codebook"
+      ],
+      "correct": 0,
+      "explanation": "Each scale captures what prior scales missed; embeddings are upsampled and summed before the decoder—same codebook across scales, residual VQ style."
+    },
+    {
+      "stage": "check",
+      "question": "Why can VAR attend within a scale without strict intra-scale causality?",
+      "options": [
+        "All positions at scale k are predicted jointly in parallel because causality is defined across scales, not left-to-right within the grid",
+        "VAR uses bidirectional attention to future image pixels in time",
+        "Scale k tokens never attend to scale k−1",
+        "Attention is disabled within each scale"
+      ],
+      "correct": 0,
+      "explanation": "Causality is in scale order: tokens at scale k see all of scales 1..k. Within-scale parallelism is the main latency win versus per-token image AR."
+    },
+    {
+      "stage": "post",
+      "question": "What scaling-law result did Tian et al. report for VAR on ImageNet?",
+      "options": [
+        "FID improves predictably with compute/parameters like GPT perplexity—power-law behavior for image generation",
+        "VAR cannot be trained beyond 1M parameters",
+        "FID is independent of model size",
+        "VAR only works on text, not class-conditional images"
+      ],
+      "correct": 0,
+      "explanation": "VAR was among the first image generators to show clean compute-to-FID scaling, making budgeted quality targets more predictable than per-architecture tuning alone."
+    },
+    {
+      "stage": "post",
+      "question": "Compared to diffusion at inference, what is VAR’s typical pass structure on a 256×256 image in this lesson’s framing?",
+      "options": [
+        "About K scale steps (e.g. ~10 forwards) with parallel tokens per scale, versus many sequential denoising steps for DiT-class models",
+        "Thousands of per-pixel steps identical to PixelCNN",
+        "A single forward with no tokenizer",
+        "Only adversarial discriminator updates at inference"
+      ],
+      "correct": 0,
+      "explanation": "VAR trades many fine-grained denoising iterations for fewer coarse-to-fine scale passes; each pass fills a full grid at that resolution, which is why inference can beat DiT on pass count at matched budgets."
+    }
+  ]
+}

--- a/phases/10-llms-from-scratch/15-speculative-decoding-eagle3/quiz.json
+++ b/phases/10-llms-from-scratch/15-speculative-decoding-eagle3/quiz.json
@@ -1,0 +1,78 @@
+{
+  "lesson": "15-speculative-decoding-eagle3",
+  "title": "Speculative Decoding and EAGLE-3",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "What is the fundamental guarantee of the Leviathan rejection sampling rule in speculative decoding?",
+      "options": [
+        "It produces samples identically distributed to the verifier's distribution",
+        "It always accepts the draft model's tokens",
+        "It doubles the generation speed regardless of models",
+        "It requires both models to have the same architecture"
+      ],
+      "correct": 0,
+      "explanation": "The Leviathan rule accepts draft tokens with probability min(1, q(d)/p(d)) and samples from the residual on rejection. This mathematically guarantees that the final output distribution equals the verifier's distribution exactly."
+    },
+    {
+      "stage": "check",
+      "question": "What does the acceptance rate α represent in the speedup formula?",
+      "options": [
+        "The probability that the verifier accepts the draft model's token proposal",
+        "The number of tokens generated per second",
+        "The ratio of draft model size to verifier size",
+        "The temperature setting for sampling"
+      ],
+      "correct": 0,
+      "explanation": "α is the single biggest lever for speedup in speculative decoding. It measures how often the draft model's tokens match what the verifier would have produced, which determines how many draft tokens can be accepted without recomputation."
+    },
+    {
+      "stage": "check",
+      "question": "How does EAGLE-3 improve upon the original speculative decoding approach?",
+      "options": [
+        "It introduces a learned draft model that conditionally generates token candidates based on the verifier's hidden states",
+        "It uses a larger draft model",
+        "It skips the verification step entirely",
+        "It processes tokens in parallel regardless of acceptance"
+      ],
+      "correct": 0,
+      "explanation": "Original spec-decoding used a small independent draft model. EAGLE trains a draft head that reads the verifier's hidden states to predict which tokens the verifier is likely to accept, making the draft much more informed and raising the acceptance rate."
+    },
+    {
+      "stage": "check",
+      "question": "What happens to the KV cache when the verifier rejects a draft token?",
+      "options": [
+        "The cache rolls back to the state before the rejected token was added, and a new token is sampled from the residual distribution",
+        "The cache grows indefinitely with rejected tokens",
+        "The rejected token is kept in the cache",
+        "The entire cache is flushed and rebuilt"
+      ],
+      "correct": 0,
+      "explanation": "On rejection, the speculative loop must roll back the KV cache to the pre-rejection state to maintain correctness. It then samples a new token from the residual (q-p)+ distribution, which is what the verifier would have sampled if not for the draft proposal."
+    },
+    {
+      "stage": "post",
+      "question": "Why does the speedup formula involve both the acceptance rate α and the cost ratio c?",
+      "options": [
+        "Because speedup depends on both how often tokens are accepted (α) and how much cheaper the draft model is to run (c)",
+        "Because α alone determines speedup",
+        "Because c alone determines speedup",
+        "Speedup is constant regardless of either parameter"
+      ],
+      "correct": 0,
+      "explanation": "Speedup = (1 - α^(N+1)) / ((1-α)c + α(1-c)) captures the trade-off: higher α means more accepted tokens (good), but higher c means the draft is more expensive relative to the verifier (bad). The optimal draft length N depends on both."
+    },
+    {
+      "stage": "post",
+      "question": "What is the bonus token in speculative decoding?",
+      "options": [
+        "When all N draft tokens are accepted, the verifier generates one extra token without needing a new forward pass, effectively amortizing the cost over N+1 tokens",
+        "A token generated at random when all drafts fail",
+        "A token added to increase the sequence length",
+        "A token used for padding sequences"
+      ],
+      "correct": 0,
+      "explanation": "Full acceptance means the verifier's forward pass validated N tokens at once. The verifier can then sample one more token before the next draft-verify round, giving N+1 tokens for the cost of one verifier pass. This bonus is why high acceptance rates are so valuable."
+    }
+  ]
+}

--- a/phases/10-llms-from-scratch/16-differential-attention-v2/quiz.json
+++ b/phases/10-llms-from-scratch/16-differential-attention-v2/quiz.json
@@ -1,0 +1,78 @@
+{
+  "lesson": "16-differential-attention-v2",
+  "title": "Differential Attention (V2)",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "What is the core operation in differential attention?",
+      "options": [
+        "Computing the difference between two softmax-normalized attention distributions",
+        "Adding two attention distributions together",
+        "Applying a single softmax to query-key scores",
+        "Concatenating attention heads"
+      ],
+      "correct": 0,
+      "explanation": "Differential attention computes softmax(Q₁K₁^T) - softmax(Q₂K₂^T), where the subtraction of two attention distributions cancels out noise and amplifies the signal. This is the defining operation that gives the technique its name and effectiveness."
+    },
+    {
+      "stage": "check",
+      "question": "Why does differential attention reduce noise compared to standard attention?",
+      "options": [
+        "Because noise is typically structured similarly across the two attention maps and subtracts out, while the signal (relevant query-key matches) tends to differ",
+        "Because it uses more parameters",
+        "Because it skips the softmax computation",
+        "Because it averages across more heads"
+      ],
+      "correct": 0,
+      "explanation": "The noise cancellation analogy is key: if two noisy measurements are subtracted, the shared noise cancels while the true difference remains. In attention, both maps attend to somewhat similar patterns (noise), but the true query-key relationships differ between the two projections (signal)."
+    },
+    {
+      "stage": "check",
+      "question": "What is the role of the learned scalar λ in differential attention?",
+      "options": [
+        "It controls the balance between the differential component and the standard component, allowing the model to dial in how much noise cancellation to apply",
+        "It scales the key vectors",
+        "It determines the number of heads",
+        "It is always set to 1.0"
+      ],
+      "correct": 0,
+      "explanation": "λ is a learned parameter that multiplies the differential attention term before adding it to a baseline standard attention term. This lets the model learn when differential attention is helpful (high λ) vs when standard attention suffices (low λ), making it a flexible, learnable mechanism."
+    },
+    {
+      "stage": "check",
+      "question": "What architectural change enables differential attention?",
+      "options": [
+        "Dedicating a subset of attention heads to computing differential attention instead of standard attention",
+        "Adding more layers",
+        "Increasing model width",
+        "Changing the activation function"
+      ],
+      "correct": 0,
+      "explanation": "Differential attention V2 uses specialized heads that compute the difference operation. These heads are interleaved with standard attention heads, giving the model both options. The allocation of differential vs standard heads can be learned during training."
+    },
+    {
+      "stage": "post",
+      "question": "How does differential attention help with long-range reasoning?",
+      "options": [
+        "By canceling out spurious attention patterns that accumulate over long sequences, leaving only the genuine long-range dependencies",
+        "By shortening sequences",
+        "By adding more positional encodings",
+        "By increasing context window size"
+      ],
+      "correct": 0,
+      "explanation": "In long sequences, attention patterns can become diffuse and pick up spurious correlations. The subtraction in differential attention suppresses these shared diffuse patterns (which appear in both Q₁K₁ and Q₂K₂), sharpening the signal for the actual long-range relationships that differ between the two projections."
+    },
+    {
+      "stage": "post",
+      "question": "Why is differential attention particularly useful for complex reasoning tasks?",
+      "options": [
+        "Because these tasks require disentangling multiple pieces of information, and the subtraction operation helps separate signal from noise more effectively than standard attention",
+        "Because it makes training faster",
+        "Because it reduces model size",
+        "Because it is required for all tasks"
+      ],
+      "correct": 0,
+      "explanation": "Complex reasoning involves tracking multiple relationships, some of which are relevant (signal) and some spurious (noise). Standard attention attends to everything. Differential attention's subtraction helps downweight the spurious patterns, making it easier for the model to focus on the genuine reasoning-relevant dependencies."
+    }
+  ]
+}

--- a/phases/10-llms-from-scratch/17-native-sparse-attention/quiz.json
+++ b/phases/10-llms-from-scratch/17-native-sparse-attention/quiz.json
@@ -1,0 +1,78 @@
+{
+  "lesson": "17-native-sparse-attention",
+  "title": "Native Sparse Attention (DeepSeek NSA)",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "What is the fundamental trade-off in native sparse attention?",
+      "options": [
+        "Reducing KV cache memory and compute cost while maintaining model quality by attending only to the most relevant tokens",
+        "Increasing model size to improve accuracy",
+        "Removing all attention mechanisms",
+        "Using only local attention patterns"
+      ],
+      "correct": 0,
+      "explanation": "Native sparse attention (like DeepSeek NSA) doesn't just approximate attention—it replaces dense attention with hardware-aligned sparse patterns that explicitly attend only to relevant tokens. This dramatically reduces memory and compute while preserving the ability to capture long-range dependencies."
+    },
+    {
+      "stage": "check",
+      "question": "What are the three parallel paths in DeepSeek NSA's architecture?",
+      "options": [
+        "Compression path, selection path, and sliding window path",
+        "Encoding, decoding, and attention",
+        "Self-attention, cross-attention, and feed-forward",
+        "Input, hidden, and output layers"
+      ],
+      "correct": 0,
+      "explanation": "The three-path architecture is the core of DeepSeek NSA: the compression path compresses the sequence, the selection path picks relevant tokens based on queries, and the sliding window path handles local context. Their outputs are merged, giving the model both efficiency and the ability to capture different types of dependencies."
+    },
+    {
+      "stage": "check",
+      "question": "How does the sliding window path differ from the other two paths?",
+      "options": [
+        "It attends only to tokens within a fixed-size window around each position, handling local dependencies efficiently",
+        "It attends to all tokens in the sequence",
+        "It uses a different attention mechanism entirely",
+        "It is only used during training"
+      ],
+      "correct": 0,
+      "explanation": "The sliding window path is straightforward: for each position, it attends only to tokens within a window of size K (e.g., ±4 tokens). This captures local patterns cheaply and is hardware-friendly because the attention matrix is sparse with a predictable banded structure."
+    },
+    {
+      "stage": "check",
+      "question": "What makes native sparse attention hardware-aligned?",
+      "options": [
+        "The sparse patterns are designed to map efficiently to GPU memory layouts and thread block execution, avoiding random memory access",
+        "It runs on CPU instead of GPU",
+        "It uses specialized hardware",
+        "It requires less training data"
+      ],
+      "correct": 0,
+      "explanation": "Dense attention's O(n²) memory causes thrashing on GPUs. Native sparse patterns like NSA's are designed so that the tokens being attended to are predictable and contiguous in memory. This allows efficient memory access patterns and thread block execution, making the sparse operations run fast on standard GPU hardware."
+    },
+    {
+      "stage": "post",
+      "question": "How much KV cache reduction can native sparse attention achieve compared to dense attention?",
+      "options": [
+        "Up to 90% or more, depending on the sequence length and sparsity configuration",
+        "No reduction in memory usage",
+        "Only 10-20% reduction",
+        "Memory usage increases slightly"
+      ],
+      "correct": 0,
+      "explanation": "Since each position attends only to a subset of tokens (often O(√n) or O(log n) instead of O(n)), the KV cache stores far fewer key-value vectors per position. For long sequences, this can reduce memory by an order of magnitude, enabling much longer contexts or larger batch sizes on the same hardware."
+    },
+    {
+      "stage": "post",
+      "question": "Why is native sparse attention considered 'native' rather than an approximation?",
+      "options": [
+        "Because it replaces the dense attention operation entirely with a designed sparse mechanism, rather than approximating dense attention with pruning",
+        "Because it only works with native language models",
+        "Because it was invented by DeepSeek",
+        "Because it uses native Python code"
+      ],
+      "correct": 0,
+      "explanation": "Approaches like pruning approximate dense attention by removing low-weight connections after computing them. Native sparse attention (like NSA) never computes the dense matrix at all—it explicitly defines which tokens to attend to using learned patterns. This is a fundamentally different computational graph, not an approximation of dense attention."
+    }
+  ]
+}

--- a/phases/10-llms-from-scratch/34-gradient-checkpointing/quiz.json
+++ b/phases/10-llms-from-scratch/34-gradient-checkpointing/quiz.json
@@ -1,0 +1,78 @@
+{
+  "lesson": "34-gradient-checkpointing",
+  "title": "Gradient Checkpointing and Activation Recomputation",
+  "questions": [
+    {
+      "stage": "pre",
+      "question": "What is the fundamental memory-compute trade-off in gradient checkpointing?",
+      "options": [
+        "Trading forward pass activations (memory) for recomputing them during backward pass (compute) to fit larger models or batch sizes",
+        "Increasing both memory and compute",
+        "Decreasing both memory and compute",
+        "Eliminating the need for backward passes"
+      ],
+      "correct": 0,
+      "explanation": "During forward pass, we normally store all activations for backward. Checkpointing drops some activations and recomputes them on-demand during backward. This costs extra compute but saves memory, enabling training of larger models or with larger batch sizes."
+    },
+    {
+      "stage": "check",
+      "question": "What is the O(√n) strategy for checkpoint selection?",
+      "options": [
+        "Selecting checkpoint positions at roughly every √n layers to balance memory savings and recomputation cost optimally",
+        "Selecting checkpoints randomly",
+        "Selecting every layer as a checkpoint",
+        "Selecting no checkpoints"
+      ],
+      "correct": 0,
+      "explanation": "The O(√n) strategy is proven optimal: for a network with n layers, checkpointing every √n layers gives the best trade-off. More checkpoints save less memory; fewer checkpoints cost more recomputation. √n balances these costs mathematically."
+    },
+    {
+      "stage": "check",
+      "question": "How does recursive checkpointing differ from uniform checkpointing?",
+      "options": [
+        "Recursive checkpointing applies checkpointing hierarchically across segments, while uniform checkpointing uses a fixed interval",
+        "Recursive is faster to implement",
+        "Uniform checkpointing is only for small models",
+        "There is no difference"
+      ],
+      "correct": 0,
+      "explanation": "Uniform checkpointing picks every k-th layer. Recursive checkpointing can checkpoint segments of the network itself, creating a hierarchy of checkpointed and recomputed regions. This is more complex but can achieve better memory savings for very deep networks by tailoring checkpoint granularity to the network structure."
+    },
+    {
+      "stage": "check",
+      "question": "What must be preserved when recomputing activations during backward pass?",
+      "options": [
+        "The exact same random state and computational graph as the original forward pass to ensure gradients are computed correctly",
+        "Only the input tensors",
+        "Only the output tensors",
+        "Nothing needs to be preserved"
+      ],
+      "correct": 0,
+      "explanation": "Recomputation must reproduce the forward pass exactly. If the forward used dropout, batch norm with running stats, or any stochastic operation, the backward recomputation must use the same random seeds and state. Otherwise, gradients would be computed incorrectly, breaking training."
+    },
+    {
+      "stage": "post",
+      "question": "When is gradient checkpointing most beneficial?",
+      "options": [
+        "When training large models that exceed GPU memory, or when using large batch sizes that would otherwise OOM",
+        "For all training runs regardless of model size",
+        "Only for inference",
+        "When using small models"
+      ],
+      "correct": 0,
+      "explanation": "Checkpointing adds compute overhead (typically 20-30% slower training). It's worth it only when memory is the bottleneck: either the model is too large to fit without checkpointing, or the desired batch size causes OOM. For small models with plenty of memory, the extra compute cost isn't justified."
+    },
+    {
+      "stage": "post",
+      "question": "How does gradient checkpointing affect the backward pass algorithm?",
+      "options": [
+        "It requires modifying the backward pass to detect missing activations and trigger recomputation of the corresponding forward segment",
+        "The backward pass runs unchanged",
+        "The backward pass skips certain layers",
+        "The backward pass runs faster"
+      ],
+      "correct": 0,
+      "explanation": "Standard backward assumes all activations are available. With checkpointing, when the backward pass reaches a layer whose activations were dropped (not checkpointed), it must first recompute the forward segment that produced those activations. This requires instrumentation in the backward pass or a custom autograd engine that knows which activations are missing and how to recompute them."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds canonical six-question `quiz.json` files (1 pre / 3 check / 2 post) for seven lessons that already ship `docs/en.md` and `code/` but had no on-site assessment loop.

One commit per lesson (AGENTS.md convention).

## Lessons

- `07/15-attention-variants`
- `07/16-speculative-decoding`
- `08/19-visual-autoregressive-var`
- `10/15-speculative-decoding-eagle3`
- `10/16-differential-attention-v2`
- `10/17-native-sparse-attention`
- `10/34-gradient-checkpointing`

Questions are grounded in each lesson's `docs/en.md` and Build demos — not generic trivia.

## Not included

- Capstone quiz fixes, audit script changes, agent rules, quiz-factory, or README catalog row updates (happy to open a separate PR for README/ROADMAP wiring if useful).

## Test plan

- [ ] `python3 scripts/audit_lessons.py` passes on CI
- [ ] Spot-check one quiz against `docs/en.md` (e.g. 07/15)
