### PR TITLE
fix: sandbox path jail bypassed by a slashless symlink (escape)

### DIFF
--- a/phases/19-capstone-projects/26-sandbox-runner-denylist/code/main.py
+++ b/phases/19-capstone-projects/26-sandbox-runner-denylist/code/main.py
@@ -215,9 +215,13 @@ def _looks_like_path(arg: str) -> bool:
 def _check_path_jail(argv: Sequence[str], cfg: SandboxConfig) -> str | None:
     root = cfg.project_root
     for arg in argv[1:]:
-        if not _looks_like_path(arg):
+        if not arg or arg.startswith("-"):
             continue
-        if arg.startswith("-"):
+        # Also jail-check slashless names that exist under root: a symlink like
+        # `link.txt` -> /etc/passwd has no path separator, so _looks_like_path
+        # misses it, yet realpath still escapes the jail. lexists() catches the
+        # symlink even when its target is missing.
+        if not _looks_like_path(arg) and not os.path.lexists(os.path.join(root, arg)):
             continue
         # Resolve against root if arg is relative; let absolute paths stay absolute.
         candidate = arg

--- a/phases/19-capstone-projects/26-sandbox-runner-denylist/code/tests/test_main.py
+++ b/phases/19-capstone-projects/26-sandbox-runner-denylist/code/tests/test_main.py
@@ -125,7 +125,10 @@ class PathJailChecks(unittest.TestCase):
         secret = os.path.join(outside_dir, "secret.txt")
         with open(secret, "w", encoding="utf-8") as fh:
             fh.write("TOP-SECRET\n")
-        os.symlink(secret, os.path.join(root, "link.txt"))
+        try:
+            os.symlink(secret, os.path.join(root, "link.txt"))
+        except OSError:
+            self.skipTest("symlinks not supported on this platform")
         reason = _check_path_jail(["cat", "link.txt"], cfg)
         self.assertIsNotNone(reason)
         self.assertIn("outside project root", reason)

--- a/phases/19-capstone-projects/26-sandbox-runner-denylist/code/tests/test_main.py
+++ b/phases/19-capstone-projects/26-sandbox-runner-denylist/code/tests/test_main.py
@@ -116,6 +116,20 @@ class PathJailChecks(unittest.TestCase):
         reason = _check_path_jail(["echo", "-n"], cfg)
         self.assertIsNone(reason)
 
+    def test_slashless_symlink_to_outside_is_denied(self) -> None:
+        # A symlink whose name has no slash points outside the root. The module
+        # advertises a "symlink-safe path jail via realpath prefix check", so the
+        # jail must resolve and refuse it even though _looks_like_path misses it.
+        root, cfg = _make_root()
+        outside_dir = tempfile.mkdtemp(prefix="sandbox-outside-")
+        secret = os.path.join(outside_dir, "secret.txt")
+        with open(secret, "w", encoding="utf-8") as fh:
+            fh.write("TOP-SECRET\n")
+        os.symlink(secret, os.path.join(root, "link.txt"))
+        reason = _check_path_jail(["cat", "link.txt"], cfg)
+        self.assertIsNotNone(reason)
+        self.assertIn("outside project root", reason)
+
 
 class TruncateTests(unittest.TestCase):
     def test_under_cap_not_truncated(self) -> None:


### PR DESCRIPTION
## What

The sandbox in `19-capstone-projects/26-sandbox-runner-denylist` can be escaped with a **slashless symlink**, reading files outside the project root — the exact thing its "symlink-safe path jail" is documented to prevent.

## Why

`_check_path_jail` only resolves/prefix-checks an argument when `_looks_like_path(arg)` is true, and that returns true only when the arg contains `/`/`\` or is exactly `.`/`..`:

```python
for arg in argv[1:]:
    if not _looks_like_path(arg):
        continue          # <-- slashless names are never jail-checked
    ...
    resolved = os.path.realpath(candidate)
    if resolved != root and not resolved.startswith(root + os.sep):
        return "...outside project root..."
```

A symlink whose name has no separator — e.g. `link.txt` in the project root pointing at `/etc/passwd` — is skipped, so `cat link.txt` runs and exfiltrates host files. The tell: `sub/link.txt` (same symlink one dir deep, has a slash) **is** correctly denied. The command runs as a real subprocess with `cwd=root`, so the jail is the only thing standing between a sandboxed tool and arbitrary host reads.

## Fix

Also jail-check arguments that exist on disk under the root, so a slashless symlink is resolved and refused (`os.path.lexists` catches the symlink even if its target is missing). Non-path tokens that don't exist under root are still skipped, and real files under root still resolve inside root (no false denials).

## Test

```
$ python3 -m pytest tests/ -q
26 passed
```
New `test_slashless_symlink_to_outside_is_denied` fails on the previous code (jail returned `None`/allowed) and passes after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
