### PR TITLE
fix: update Wikipedia dataset config from 20220301.en to 20231101.en

### DIFF
--- a/phases/00-setup-and-tooling/09-data-management/docs/en.md
+++ b/phases/00-setup-and-tooling/09-data-management/docs/en.md
@@ -140,7 +140,7 @@ Model weights and large datasets should not go into git. Three options:
 
 **Option A: .gitignore (simplest)**
 
-```
+```text
 *.bin
 *.safetensors
 *.pt

--- a/phases/00-setup-and-tooling/09-data-management/docs/en.md
+++ b/phases/00-setup-and-tooling/09-data-management/docs/en.md
@@ -57,7 +57,7 @@ This downloads the IMDB movie review dataset. After the first download, it loads
 Some datasets are too large to fit on disk. Streaming loads them row by row without downloading the full thing.
 
 ```python
-dataset = load_dataset("wikimedia/wikipedia", "20220301.en", split="train", streaming=True)
+dataset = load_dataset("wikimedia/wikipedia", "20231101.en", split="train", streaming=True)
 
 for i, example in enumerate(dataset):
     print(example["title"])


### PR DESCRIPTION
## Problem

The Wikipedia dataset config `20220301.en` referenced in Lesson 09 (Data Management) Step 3 no longer exists. Running the code as written produces:

ValueError: BuilderConfig '20220301.en' not found. Available: ['20231101.ab', '20231101.ace', ..., '20231101.en', ...]

The dataset has been re-exported with the `20231101` snapshot, making the `20220301` config unavailable.

## Fix

Updated the config from `20220301.en` to `20231101.en` in:
- `phases/00-setup-and-tooling/09-data-management/docs/en.md` (line 60)

## Verification

Tested with `datasets==4.8.5` and the updated config loads successfully:

```python
from datasets import load_dataset
dataset = load_dataset("wikimedia/wikipedia", "20231101.en", split="train", streaming=True)
for i, example in enumerate(dataset):
    print(example["title"])
    if i >= 4:
        break