### PR TITLE
fix(phase00): use fully-qualified dataset id for rotten_tomatoes

### DIFF
--- a/phases/00-setup-and-tooling/09-data-management/code/data_utils.py
+++ b/phases/00-setup-and-tooling/09-data-management/code/data_utils.py
@@ -159,10 +159,10 @@ if __name__ == "__main__":
     print("=" * 60)
 
     print("\n--- 1. Load and inspect a dataset ---")
-    ds = load_and_inspect("rotten_tomatoes", split="train")
+    ds = load_and_inspect("cornell-movie-review-data/rotten_tomatoes", split="train")
 
     print("\n--- 2. Stream a dataset ---")
-    rows = stream_dataset("rotten_tomatoes", max_rows=3)
+    rows = stream_dataset("cornell-movie-review-data/rotten_tomatoes", max_rows=3)
     for row in rows:
         print(f"  {row['text'][:80]}...")
 


### PR DESCRIPTION
Newer huggingface_hub requires the namespace/name format for all dataset ids. Replace bare 'rotten_tomatoes' with
'cornell-movie-review-data/rotten_tomatoes' so the script runs without a HfUriError.

## What this PR does

Replace bare 'rotten_tomatoes' dataset id with 'cornell-movie-review-data/rotten_tomatoes' to fix a HfUriError raised by newer versions of huggingface_hub.

## Kind of change

- [ ] New lesson
- [x] Fix to an existing lesson
- [ ] Translation
- [ ] New output (prompt, skill, agent, MCP server)
- [ ] Docs / website / tooling

## Checklist

- [x] Code runs without errors with the listed dependencies
- [ ] No comments in code files (docs explain, code is self-explanatory)
- [ ] Built from scratch first, then shown with a framework (for new lessons)
- [ ] Lesson folder matches `LESSON_TEMPLATE.md` structure
- [ ] ROADMAP.md row for the lesson is a markdown link (`[Name](phases/...)`), not bare text
- [ ] One lesson per commit (atomic per-lesson rule)
- [x] Tested locally / code output matches what `docs/en.md` claims

## Phase / lesson
Phase 00 . 09-data-management

## Notes for reviewer

Newer huggingface_hub enforces the namespace/name format for all dataset ids. The bare name 'rotten_tomatoes' now raises HfUriError at runtime. No logic changes — identifier only.
