### PR TITLE
fix(site): wire up theme toggle on about.html (stuck in light mode)

### DIFF
--- a/site/about.html
+++ b/site/about.html
@@ -163,6 +163,41 @@
   <script src="progress.js?v=20260525a"></script>
   <script src="header.js?v=20260525a" defer></script>
   <script src="cmdpalette.js?v=20260525a" defer></script>
+  <script>
+    (function () {
+      var root = document.documentElement;
+      var stored = localStorage.getItem('theme');
+      if (stored) {
+        root.setAttribute('data-theme', stored);
+      } else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+        root.setAttribute('data-theme', 'dark');
+      } else {
+        root.setAttribute('data-theme', 'light');
+      }
+
+      function updateIcon() {
+        var icon = document.getElementById('themeIcon');
+        if (!icon) return;
+        icon.textContent = root.getAttribute('data-theme') === 'light' ? 'N' : 'D';
+      }
+
+      updateIcon();
+
+      document.addEventListener('DOMContentLoaded', function () {
+        updateIcon();
+
+        var btn = document.getElementById('themeToggle');
+        if (btn) {
+          btn.addEventListener('click', function () {
+            var next = root.getAttribute('data-theme') === 'light' ? 'dark' : 'light';
+            root.setAttribute('data-theme', next);
+            localStorage.setItem('theme', next);
+            updateIcon();
+          });
+        }
+      });
+    })();
+  </script>
   <script defer src="https://va.vercel-scripts.com/v1/script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Fixes #272

## Problem
`about.html` ships a theme-toggle button but includes **neither** `app.js` (whose `initThemeToggle()` is the only JS that wires `#themeToggle`) **nor** the inline theme `<script>` that `catalog.html` / `glossary.html` / `prereqs.html` / `lesson.html` each carry. So the toggle does nothing and the page is stuck in light mode, ignoring `localStorage.theme` and the OS `prefers-color-scheme`.

The dark CSS already works — forcing `document.documentElement.setAttribute("data-theme","dark")` renders `about.html` correctly in dark. It is purely a missing-script wiring bug.

## Fix
Add the same self-contained inline theme-init script the other standalone pages use (read stored/OS preference → set `data-theme`, wire `#themeToggle` click, update the `N`/`D` icon, persist to `localStorage`). No behavior change to other pages; single-file, additive.

## Verification
Served the built site locally and exercised the toggle on `about.html`:

| step | data-theme | icon | localStorage.theme |
|------|-----------|------|--------------------|
| initial | `light` | N | – |
| click | `dark` | D | `dark` |
| click | `light` | N | `light` |

Before the fix, clicking left `data-theme` at `light` (no handler). After, it toggles and persists, matching every other page.