### PR TITLE
docs(phase-14): close three harness-engineering gaps in Agent Workbench

### DIFF
--- a/phases/14-agent-engineering/33-instructions-as-executable-constraints/docs/en.md
+++ b/phases/14-agent-engineering/33-instructions-as-executable-constraints/docs/en.md
@@ -56,6 +56,30 @@ Rules live one per heading in a single markdown file. Renames are visible in dif
 
 Framework guardrails (OpenAI Agents SDK guardrails, LangGraph interrupts) enforce rules at the runtime level. The rule set in this lesson is the human-readable, reviewable contract that those guardrails implement. You need both: the runtime catches violations during a turn, the rule set proves the runtime is doing the right thing.
 
+### Progressive disclosure: a map, not an encyclopedia
+
+The reason `AGENTS.md` keeps growing is that every incident adds a rule and no incident removes one. A year in, the file is two thousand lines, and the agent reads the first screen, runs out of attention budget, and acts on a fraction of what it was told. A giant instruction file fails for the same reason a forty-page onboarding doc fails: the reader skims it once and never returns to the part that mattered.
+
+The fix is not a shorter file. It is a layered one. The root router stays small enough to read every session and holds nothing but pointers. The depth lives in topic files the agent loads only when the task touches them. Give the agent a map, not the whole encyclopedia, and let it walk to the page it needs.
+
+```
+AGENTS.md                  # router, < 50 lines: what this repo is, where to look, the 5 hard rules
+docs/
+  agent-rules.md           # the full rule set (this lesson)
+  architecture.md          # loaded when the task touches module boundaries
+  testing.md               # loaded when the task writes or runs tests
+  deploy.md                # loaded only for release work, gated behind an approval rule
+feature_list.json          # the backlog (Phase 14 · 36)
+```
+
+| Tier | Lives in | Read when | Size budget |
+|------|----------|-----------|-------------|
+| Router | `AGENTS.md` | Every session, always | Under ~50 lines |
+| Rules | `docs/agent-rules.md` | Every session, on startup | One screen per category |
+| Topic docs | `docs/<topic>.md` | Only when the task touches that topic | As deep as needed |
+
+Two tests keep the layering honest. The reachability test: an agent should reach any rule in at most two hops from the router, so the router must link every topic doc by path, not describe it in prose. The freshness test: the router is short enough that a reviewer rereads it on every PR, which is the only thing that stops it from silently growing back into the encyclopedia it replaced. A pointer that no longer resolves is a worse failure than a missing rule, so a broken link in the router is itself a startup-check violation.
+
 ## Build It
 
 `code/main.py` ships:

--- a/phases/14-agent-engineering/36-scope-contracts/docs/en.md
+++ b/phases/14-agent-engineering/36-scope-contracts/docs/en.md
@@ -60,6 +60,36 @@ Listing how to roll back forces the contract author to think about what could go
 
 The agent writes a diff. The checker reads the diff, the allowed globs, the forbidden globs, and a list of any acceptance commands that ran. Each violation is a tagged finding the verification gate can refuse.
 
+### Two altitudes of scope: the feature list and the task contract
+
+The scope contract bounds one task. It does not bound the project. An agent can stay perfectly inside a contract for the login fix and still, on the next turn, decide the project also needs a settings page, a dark mode toggle, and a rewrite of the router. The contract was never asked which work was in scope for the project, only which files were in scope for the task.
+
+That second altitude needs its own primitive: a `feature_list.json` the agent reads at session start. It is the project backlog as a machine-readable, ordered file. The agent picks exactly one feature whose `status` is `todo`, writes its `id` into the active scope contract, and is forbidden from starting a second feature in the same session. "One feature at a time" stops being a line in the prompt the agent can rationalize past and becomes a value it reads off disk and a check the gate enforces.
+
+```json
+{
+  "project": "knowledge-base",
+  "active": "import-pdf",
+  "features": [
+    { "id": "import-pdf",   "status": "in_progress", "goal": "import a PDF into the library",        "done_when": "pytest tests/test_import.py && a sample PDF appears in the library view" },
+    { "id": "full-text-search", "status": "todo",     "goal": "search document text and rank hits",   "done_when": "query returns ranked results with snippets" },
+    { "id": "cite-answers", "status": "todo",         "goal": "answers carry source citations",        "done_when": "every answer renders at least one clickable citation" }
+  ]
+}
+```
+
+| Field | Purpose |
+|-------|---------|
+| `active` | The single feature the current session may touch; empty means pick one and set it |
+| `features[].id` | Stable slug the scope contract's `task_id` points at |
+| `features[].status` | `todo`, `in_progress`, `done`, `blocked`; only one `in_progress` at a time |
+| `features[].goal` | One sentence the reviewer can verify |
+| `features[].done_when` | The acceptance line that flips `in_progress` to `done` |
+
+Two rules make the list load-bearing instead of decorative. First, the invariant "at most one `in_progress`" is itself a startup check (Phase 14 · 33): if the list shows two, the session refuses to start until a human resolves it. Second, the feature list is a file, not a chat message, because the chat scrolls out of context and the file persists across sessions and across agents. The handoff (Phase 14 · 40) writes the finished feature's status back to `done` so the next session opens to an accurate board instead of re-deriving what is left.
+
+The contract and the list compose by least privilege, the same merge described below: the task contract's `allowed_files` must sit inside whatever the active feature touches, never outside it.
+
 ## Build It
 
 `code/main.py` implements:

--- a/phases/14-agent-engineering/40-multi-session-handoff/docs/en.md
+++ b/phases/14-agent-engineering/40-multi-session-handoff/docs/en.md
@@ -58,6 +58,22 @@ A hand-written handoff is a handoff that gets skipped on a hard day. The generat
 
 The full `feedback_record.jsonl` may be hundreds of entries. The handoff carries only the last K plus every entry with a non-zero exit. The next session loads the full log if it needs to, but the packet stays small.
 
+### Leave a clean state
+
+A handoff describes the work. A clean state makes the work resumable. They are not the same thing. A perfect `handoff.md` is worthless if the next session opens to a half-applied diff, a temp file the agent forgot, a stray branch, and tests that error before they even run. The next agent then spends its first ten minutes cleaning up after the last one instead of building, and the cost compounds every session for the life of the task.
+
+So the session does not end when the feature works. It ends when the workbench is in a state the generator can summarize and the next session can trust. Cleanup is its own phase, run before the handoff, and it is a check, not a habit, because a habit is the thing that gets skipped on a hard day.
+
+| Check | Clean means | Dirty blocks because |
+|-------|-------------|----------------------|
+| Working tree | Every change committed or explicitly stashed with a note | A half-applied diff looks like intentional work to the next agent |
+| Temp artifacts | No `*.tmp`, scratch dirs, debug prints, or commented-out blocks left behind | Stray files pollute the diff and the next agent's mental model |
+| Tests | Green, or red with the failure named in `open_risks` | A silent red test is a trap the next session steps in |
+| Feature board | `feature_list.json` status reflects reality (Phase 14 · 36) | A stale board sends the next session to work that is already done |
+| Branch | On the expected branch, no detached HEAD, no orphan branches | Wrong branch means the next session's first commit lands in the wrong place |
+
+The cleanup phase emits a `clean_state.json` of blocking issues; an empty list is the precondition the handoff generator asserts before it writes a packet. A handoff built on a dirty tree is not a handoff, it is a forwarded mess. The two artifacts pair: cleanup proves the workbench is safe to leave, the handoff proves the next session knows where to start.
+
 ## Build It
 
 `code/main.py` implements:


### PR DESCRIPTION
Adds three missing mechanisms to the Phase 14 Agent Workbench mini-track

## Sections added

- **Lesson 33 (Instructions)** — Progressive disclosure: a thin `AGENTS.md` router plus tiered `docs/*.md` loaded on demand. Two enforcement tests (reachability, freshness). Closes the gap where one giant instruction file fails.
- **Lesson 36 (Scope Contracts)** — `feature_list.json` as the project-level scope primitive (distinct from the per-task contract). One `in_progress` invariant as a startup check; the handoff writes status back to `done`.
- **Lesson 40 (Handoff)** — Leave a clean state: a cleanup phase before the handoff packet, with a clean/dirty/why-blocks table and a `clean_state.json` precondition.

## Scope

Docs only, +70 lines across three `en.md` files. No code, quiz, or template changes in this PR. Follow-up: reference implementations for the `feature_list.json` validator (36) and the `clean_state` check (40), plus quiz questions.