### PR TITLE
fix(site): About page dark mode + header overlap

### DIFF
--- a/site/about.html
+++ b/site/about.html
@@ -24,7 +24,7 @@
     .about {
       max-width: 760px;
       margin: 0 auto;
-      padding: 64px 0 80px;
+      padding: 100px 0 80px;
     }
     .about-eyebrow {
       font-family: var(--font-mono);
@@ -69,7 +69,7 @@
       border: 1px solid var(--rule-soft);
     }
     .about .lede { font-size: 1.15rem; color: var(--ink); }
-    @media (max-width: 768px) { .about { padding: 40px 0 56px; } }
+    @media (max-width: 768px) { .about { padding: 80px 0 48px; } }
   </style>
 </head>
 <body>
@@ -158,6 +158,41 @@
       "founder": { "@type": "Person", "name": "Rohit Ghumare", "url": "https://github.com/rohitg00" }
     }
   }
+  </script>
+  <script>
+    (function () {
+      var root = document.documentElement;
+      var stored = localStorage.getItem('theme');
+      if (stored) {
+        root.setAttribute('data-theme', stored);
+      } else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+        root.setAttribute('data-theme', 'dark');
+      } else {
+        root.setAttribute('data-theme', 'light');
+      }
+
+      function updateIcon() {
+        var icon = document.getElementById('themeIcon');
+        if (!icon) return;
+        icon.textContent = root.getAttribute('data-theme') === 'light' ? 'N' : 'D';
+      }
+
+      updateIcon();
+
+      document.addEventListener('DOMContentLoaded', function () {
+        updateIcon();
+
+        var btn = document.getElementById('themeToggle');
+        if (btn) {
+          btn.addEventListener('click', function () {
+            var next = root.getAttribute('data-theme') === 'light' ? 'dark' : 'light';
+            root.setAttribute('data-theme', next);
+            localStorage.setItem('theme', next);
+            updateIcon();
+          });
+        }
+      });
+    })();
   </script>
   <script src="data.js?v=20260525a"></script>
   <script src="progress.js?v=20260525a"></script>


### PR DESCRIPTION
The About page (merged in #270) was built as a near-standalone page and missed two things every other page has.

## 1. Dark mode dead
About shipped without the inline theme bootstrap script that index/catalog/glossary/prereqs/lesson all carry. The `themeToggle` button had no listener and `data-theme` stayed hardcoded `light`, so the page ignored the site theme and the toggle did nothing. Added the same localStorage + `prefers-color-scheme` bootstrap and toggle wiring, verbatim from the other pages.

## 2. Headline overlapping the header
`.site-header` is `position: fixed` at 64px tall. The glossary page clears it with `padding: 100px 0 80px`; About used `64px 0 80px`, exactly the header height with zero breathing room, so the ABOUT eyebrow tucked under the fixed header. Bumped to 100px desktop / 80px mobile to match glossary.

## Scope
One file, CSS padding + one inline script. No new behavior, just parity with the existing pages.