### PR TITLE
docs: quote pip extras install examples

### DIFF
--- a/phases/03-deep-learning-core/12-intro-to-jax/docs/en.md
+++ b/phases/03-deep-learning-core/12-intro-to-jax/docs/en.md
@@ -438,13 +438,13 @@ pip install jax jaxlib optax flax
 For GPU support:
 
 ```bash
-pip install jax[cuda12]
+pip install 'jax[cuda12]'
 ```
 
 For TPU (Google Cloud):
 
 ```bash
-pip install jax[tpu] -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
+pip install 'jax[tpu]' -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
 ```
 
 **Performance gotchas:**


### PR DESCRIPTION
## Summary
- Quote `pip install` examples that include extras.

## Why
- Shells such as zsh can expand unquoted bracket expressions before `pip` receives them.

## Scope
- Files changed:
- `phases/03-deep-learning-core/12-intro-to-jax/docs/en.md`
- This does not change dependencies or runtime behavior.

## Testing
- `git diff --check`

## Maintainer Fit
- Small install-command correctness fix.
- Duplicate PR search terms checked: `quote pip extras`, `quote optional dependency`, `zsh pip install extras`, `pip extras install examples`