### PR TITLE
chore(phase-00/01): clean up imports and format lambda in verify.py

### DIFF
--- a/phases/00-setup-and-tooling/01-dev-environment/code/verify.py
+++ b/phases/00-setup-and-tooling/01-dev-environment/code/verify.py
@@ -1,5 +1,5 @@
-import shutil
 import sys
+import shutil
 
 CHECKS = [
     ("Python 3.10+", lambda: sys.version_info >= (3, 10), f"Python {sys.version}"),

--- a/phases/00-setup-and-tooling/01-dev-environment/code/verify.py
+++ b/phases/00-setup-and-tooling/01-dev-environment/code/verify.py
@@ -1,6 +1,5 @@
-import sys
 import shutil
-import subprocess
+import sys
 
 CHECKS = [
     ("Python 3.10+", lambda: sys.version_info >= (3, 10), f"Python {sys.version}"),
@@ -17,7 +16,11 @@ GPU_CHECKS = [
     (
         "CUDA",
         lambda: __import__("torch").cuda.is_available(),
-        lambda: __import__("torch").cuda.get_device_name(0) if __import__("torch").cuda.is_available() else "Not available",
+        lambda: (
+            __import__("torch").cuda.get_device_name(0)
+            if __import__("torch").cuda.is_available()
+            else "Not available"
+        ),
     ),
 ]
 


### PR DESCRIPTION
Remove unused `subprocess` import, reorder imports, and reformat long lambda for readability.