### PR TITLE
docs: add translated README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@
   <a href="https://aiengineeringfromscratch.com"><img src="https://img.shields.io/badge/web-aiengineeringfromscratch.com-3553ff?style=flat-square&labelColor=fafaf5" alt="Website"></a>
 </p>
 
+<!-- Keep these links, translations synced daily. -->
+<p align="center">
+<a href="https://zdoc.app/de/rohitg00/ai-engineering-from-scratch">Deutsch</a> |
+<a href="https://zdoc.app/es/rohitg00/ai-engineering-from-scratch">Español</a> |
+<a href="https://zdoc.app/fr/rohitg00/ai-engineering-from-scratch">français</a> |
+<a href="https://zdoc.app/ja/rohitg00/ai-engineering-from-scratch">日本語</a> |
+<a href="https://zdoc.app/ko/rohitg00/ai-engineering-from-scratch">한국어</a> |
+<a href="https://zdoc.app/pt/rohitg00/ai-engineering-from-scratch">Português</a> |
+<a href="https://zdoc.app/ru/rohitg00/ai-engineering-from-scratch">Русский</a> |
+<a href="https://zdoc.app/zh/rohitg00/ai-engineering-from-scratch">中文</a>
+</p>
+
 ## From the creator of [Agent Memory - #1 Persistent memory ⭐](https://github.com/rohitg00/agentmemory) <a href="https://github.com/rohitg00/agentmemory/stargazers"><img src="https://img.shields.io/github/stars/rohitg00/agentmemory?style=flat-square&labelColor=fafaf5&color=3553ff" alt="GitHub stars"></a> which naturally works with any agents or chat assistants.
 
 ```


### PR DESCRIPTION
This PR adds links to translated versions of the README to help non-English-speaking users access translated documentation.

Supported languages:

- German
- Spanish
- French
- Japanese
- Korean
- Portuguese
- Russian
- Chinese

Translations are automatically synchronized and require no maintenance effort from project maintainers.

This change only affects README documentation and does not modify project code, dependencies, CI workflows, or repository settings.