### PR TITLE
docs(site): add figure visual style guide and contributor docs

### DIFF
--- a/site/CONTRIBUTING-FIGURES.md
+++ b/site/CONTRIBUTING-FIGURES.md
@@ -1,0 +1,273 @@
+# Contributing Figures
+
+This guide covers how to create, register, embed, and maintain figures in the curriculum. Two figure systems exist:
+
+- **Interactive widgets** — slider-driven, theme-aware, vanilla JS (134+ across 13 modules)
+- **Animated SVG explainers** — auto-looping, hover-pause, SVG-based (10 core figures)
+- **Static SVGs** — hand-crafted, standalone diagrams in `assets/figures/`
+
+---
+
+## Quick Start: Embed an Existing Figure
+
+Open any lesson's `docs/en.md` and add a fenced block:
+
+````markdown
+```figure
+attention-matrix
+```
+````
+
+The lesson renderer (`lesson.html:2268`) converts this into a `<div class="lesson-figure" data-figure="attention-matrix">`, and the mount system hydrates it on page load.
+
+To pass configuration:
+
+````markdown
+```figure
+kv-cache
+{"layers": 32, "kvHeads": 8, "headDim": 128}
+```
+````
+
+---
+
+## Interactive Widgets (140+ existing)
+
+These are slider/select-driven tools embedded inside a styled card (`.lf` container). Users drag parameters and see the output update in real time.
+
+### File Organization
+
+Pick the right module file based on the target lesson's phase:
+
+| Module file | Phases |
+|-------------|--------|
+| `figures-math.js` | P1 (math foundations) |
+| `figures-ml.js` | P2 (ML fundamentals) |
+| `figures-dl.js` | P3 (deep learning core) |
+| `figures-vision-speech.js` | P4 (vision), P6 (speech) |
+| `figures-transformers.js` | P5 (NLP), P7 (transformers) |
+| `figures-genai-rl.js` | P8 (generative AI), P9 (RL) |
+| `figures-llms-systems.js` | P10 (LLMs), P12 (multimodal), P13 (tools) |
+| `figures-agents-alignment.js` | P11 (LLM eng), P14 (agents), P16 (swarms), P18 (alignment) |
+| `figures-math2.js` | P1 (advanced math) |
+| `figures-nlp2.js` | P5 (advanced NLP) |
+| `figures-llms2.js` | P10 (LLM internals) |
+| `figures-infra.js` | P17 (infrastructure) |
+| `figures-frontier.js` | P15 (autonomy), P19 (capstones) |
+
+If your concept spans phases not covered by an existing module, create a new file named `figures-<topic>.js`.
+
+### Anatomy of a Widget
+
+```javascript
+(function () {
+  'use strict';
+  var LF = window.LF;
+  if (!LF) { return; }
+  var el = LF.el, svgEl = LF.svgEl, slider = LF.slider, clamp = LF.clamp;
+
+  // ── widget-name: one-line description ──────────────────────────────
+  function widgetName(host) {
+    // 1. State object — all mutable parameters live here
+    var state = { param: 1.0, count: 5 };
+
+    // 2. SVG surface
+    var W = 520, H = 240, PAD = 28;
+    var svg = svgEl('svg', { viewBox: '0 0 ' + W + ' ' + H });
+    var num = el('span', { class: 'lf-num' });
+    var meta = el('div', { class: 'lf-meta' });
+    var formula = el('div', { class: 'lf-formula' });
+
+    // 3. Coordinate helpers
+    function px(x) { return PAD + x / maxX * (W - 2 * PAD); }
+    function py(y) { return H - PAD - y / maxY * (H - 2 * PAD); }
+
+    // 4. Render function — called on every slider change
+    state._render = function () {
+      while (svg.firstChild) svg.removeChild(svg.firstChild);
+      // Rebuild SVG content deterministically from state
+      // Update text nodes: num.innerHTML, meta.textContent, formula.textContent
+    };
+
+    // 5. Controls
+    var grid = el('div', { class: 'lf-grid' }, [
+      slider(state, 'param', 'label', 0, 10, 0.1),
+    ]);
+
+    // 6. Assemble the card
+    host.appendChild(el('div', { class: 'lf' }, [
+      el('div', { class: 'lf-head' }, [
+        el('span', { class: 'lf-label' }, ['UPPERCASE NAME']),
+        el('span', {}, ['interaction hint'])
+      ]),
+      el('div', { class: 'lf-body' }, [
+        grid,
+        el('div', { class: 'lf-out' }, [svg, num, meta, formula])
+      ]),
+      el('div', { class: 'lf-cap' }, ['Educational caption explaining the concept.'])
+    ]));
+
+    // 7. Initial render
+    state._render();
+  }
+
+  // 8. Register the widget
+  LF.register({ 'widget-name-slug': widgetName });
+})();
+```
+
+### State Contract
+
+- All mutable parameters in a `state` object.
+- `state._render` clears and fully rebuilds the SVG on each call (deterministic).
+- Controls (`slider`/`select`) call `state._render()` automatically.
+- No randomness in `_render` — use pre-computed or seeded data.
+
+### Available Controls
+
+```javascript
+// Slider: range input with live value display
+slider(state, key, label, min, max, step, formatFn?)
+// Example:
+slider(state, 'layers', 'layers', 1, 128, 1, fmtInt)
+slider(state, 'lr', 'learning rate', 0.01, 1.2, 0.01)
+
+// Select: dropdown
+select(state, key, label, [['Display Name', value], ...])
+// Example:
+select(state, 'kernel', 'kernel', [['Edge', 'edge'], ['Blur', 'blur']])
+
+// Text: raw text node
+el('text', { x: 100, y: 50, 'font-family': 'monospace' }, [txt('label')])
+```
+
+### Output Elements
+
+```html
+<span class="lf-num">3.14 <small>GiB</small></span>   <!-- Large highlighted number -->
+<div class="lf-bar"><i></i></div>                        <!-- Progress/usage bar -->
+<div class="lf-meta">context line of text</div>         <!-- Secondary description -->
+<div class="lf-formula">f(x) = x + 1</div>             <!-- Math formula -->
+```
+
+---
+
+## Animated SVG Explainers (10 existing)
+
+These are auto-looping, hover-pause SVG animations that live in `figures.js`. They work well for processes with a natural temporal flow (tokenization, attention, embedding arithmetic).
+
+### Adding a New Animated Explainer
+
+1. Define a function in `figures.js` that takes a `host` DOM element.
+2. Inside, create an SVG element and append it to `host`.
+3. Use the `loop(host, fn, period, opts)` utility:
+
+```javascript
+function myNewFigure(host) {
+  var W = 760, H = 540;
+  var svg = el('svg', { viewBox: '0 0 ' + W + ' ' + H, width: '100%',
+    role: 'img', 'aria-label': 'Description' });
+  host.appendChild(svg);
+
+  // ... build static SVG elements ...
+
+  loop(host, function (t) {
+    // t floats 0→1 over the period
+    // Update element attributes based on t
+  }, 10000); // period in ms
+}
+```
+
+4. Register in the `FIGURES` map at the bottom of `figures.js`.
+
+### loop() API
+
+```javascript
+loop(host, fn, period = 6000, opts = {})
+// fn(localT) — called every frame. localT is 0→1 over the period.
+// opts.staticT — frame to show when motion is reduced (default: 0.62)
+// Hover-pause: built in (mouseenter pauses, mouseleave resumes)
+// Reduced-motion: renders one static frame and stops
+```
+
+### Animation Patterns
+
+- **Staged progress**: `var stage = Math.floor(t * stages)` to divide animation into discrete steps.
+- **Sub-stage timing**: `var tInStage = (t * stages) - stage` for progress within a step.
+- **Easing**: use `easeIO(t)` for smooth multi-segment motion.
+- **Softmax for attention**: `softmax(scores, temperature)` for attention weight visualization.
+
+---
+
+## Static SVG Figures (6 existing)
+
+Standalone SVGs in `site/assets/figures/`. These are not interactive — they are embedded in lesson markdown as standard images.
+
+### Adding a Static SVG
+
+1. Author an SVG following the style guide (`STYLE.md`).
+2. Save as `site/assets/figures/<NNN>-<slug>.svg` using the next available FIG number from `INDEX.md`.
+3. Add a row to the table in `INDEX.md`.
+4. Reference in lesson markdown:
+   ```markdown
+   ![FIG_NNN](../../site/assets/figures/NNN-slug.svg)
+   ```
+5. Verify at 480px, 720px, 1200px viewport widths.
+
+---
+
+## Embedding in Lessons
+
+### Interactive or Animated Figure
+
+```markdown
+```figure
+widget-name-slug
+```
+
+```figure
+widget-name-slug
+{"configKey": "configValue"}
+```
+```
+
+### Static SVG
+
+```markdown
+![FIG_005](../../site/assets/figures/005-transformer-attention-heads.svg)
+```
+
+---
+
+## Testing
+
+### Interactive Widgets
+
+1. Open the lesson on the deployed site or locally via `site/lesson.html?path=phases/XX-phase/YY-lesson`.
+2. Verify the figure mounts with no console errors.
+3. Drag every slider — output should update in real time.
+4. Test both light and dark themes (toggle top-right).
+5. Test at 320px, 768px, and 1200px viewport widths.
+
+### Animated Explainers
+
+1. Open the target lesson page.
+2. Verify the animation loops smoothly at 60 fps.
+3. Hover over the figure — animation should pause.
+4. Enable `prefers-reduced-motion` in browser DevTools — figure should show a static frame.
+
+---
+
+## Convention Summary
+
+| Rule | Details |
+|------|---------|
+| Language | Vanilla ES5 for module files, ES6+ for `figures.js` |
+| Dependencies | None — stdlib only |
+| Theming | CSS custom properties (`var(--blueprint, #3553ff)`) |
+| Reduced motion | Required — every entry point must check |
+| Coordinates | Always `.toFixed(1)` |
+| Figure naming | `kebab-case-slug` matching the concept |
+| Registration | `LF.register({...})` for interactive, `FIGURES` map for animated |
+| Embedding | ` ```figure ` fence in `docs/en.md` |
+| Caption | Every figure needs an educational `.lf-cap` |

--- a/site/assets/figures/INDEX.md
+++ b/site/assets/figures/INDEX.md
@@ -2,7 +2,9 @@
 
 Every figure shipped under `site/assets/figures/` is listed below. FIG numbers are global, monotonically increasing, and never reused.
 
-The aesthetic is documented in the `blueprint-diagram` Claude Code skill, which is distributed separately from this repo (per the project's "no vendor/tooling artifacts in repos" rule). The skill source lives under `~/.claude/skills/blueprint-diagram/` once installed; ask a maintainer for the install path or follow the [How to add](#how-to-add) section below for a manual workflow that does not require the skill.
+The visual style is defined in [`STYLE.md`](STYLE.md) — read it before authoring a new figure. For the interactive widget system (slider-driven, theme-aware figures embedded via the ` ```figure ` fence), see [`site/CONTRIBUTING-FIGURES.md`](../CONTRIBUTING-FIGURES.md).
+
+The aesthetic is also documented in the `blueprint-diagram` Claude Code skill, distributed separately from this repo. The skill source lives under `~/.claude/skills/blueprint-diagram/` once installed; ask a maintainer for the install path or follow the [How to add](#how-to-add) section below for a manual workflow that does not require the skill.
 
 | FIG | slug | phase | lesson | added | notes |
 |---|---|---|---|---|---|
@@ -25,6 +27,21 @@ The aesthetic is documented in the `blueprint-diagram` Claude Code skill, which 
 
 ## How to add
 
+### Interactive figure (slider-driven, theme-aware)
+
+1. Add a widget function in the appropriate `site/figures-<topic>.js` module file.
+2. Register it via `LF.register({ 'slug-name': fn })`.
+3. Embed in the lesson's `docs/en.md` with a ` ```figure ` fence block.
+4. See [`site/CONTRIBUTING-FIGURES.md`](../CONTRIBUTING-FIGURES.md) for the full walkthrough.
+
+### Animated SVG explainer (auto-loop, hover-pause)
+
+1. Add a function in `site/figures.js` using the `loop()` utility.
+2. Add to the `FIGURES` map at the bottom of the file.
+3. Embed via the same ` ```figure ` fence.
+
+### Static SVG diagram
+
 If you have the `blueprint-diagram` skill installed:
 
 1. Run the skill with a description of the concept.
@@ -32,7 +49,7 @@ If you have the `blueprint-diagram` skill installed:
 
 If you don't have the skill, do it manually:
 
-1. Author an SVG in the cream + blueprint aesthetic (cream `#fafaf5` paper, `#3553ff` blueprint blue strokes, JetBrains Mono uppercase labels with leader lines, no other chromatic accents).
+1. Follow the style conventions in [`STYLE.md`](STYLE.md) (cream `#fafaf5` paper, `#3553ff` blueprint blue strokes, JetBrains Mono uppercase labels with leader lines, no other chromatic accents).
 2. Save as `site/assets/figures/<NNN>-<slug>.svg` using the next available FIG number from the table above.
 3. Add a row to the table here with the FIG number, slug, target phase + lesson, today's date, and a one-line note.
 4. Reference the figure from the lesson markdown as `![FIG_NNN](../../site/assets/figures/<NNN>-<slug>.svg)`.

--- a/site/assets/figures/STYLE.md
+++ b/site/assets/figures/STYLE.md
@@ -1,0 +1,307 @@
+# Visual Style Guide — Blueprint Diagram Aesthetic
+
+This guide defines the visual language for all diagrams and figures across the curriculum. Every figure — interactive or static, animated or still — follows these conventions so the course feels like one coherent manual, not a collage.
+
+---
+
+## 1. Color Palette
+
+All colors are exposed as CSS custom properties. Interactive figures reference them via `var(--name, fallback)`. Static SVGs hardcode light-theme values.
+
+| Token | Light | Dark | Usage |
+|-------|-------|------|-------|
+| `--blueprint` | `#3553ff` | `#6b8eff` | Primary accent — active elements, strokes, links, labels, bar fills |
+| `--blueprint-tint` | `rgba(53,83,255,0.08)` | `rgba(107,142,255,0.12)` | Subtle fill — inactive cells, backgrounds |
+| `--blueprint-tint-strong` | `rgba(53,83,255,0.18)` | `rgba(107,142,255,0.22)` | Stronger tint — hovered cells, merged tokens |
+| `--ink` | `#1a1a1a` | `#e8e6dc` | Primary text |
+| `--ink-soft` | `#4a4a4a` | `#a8a6a0` | Secondary text, labels |
+| `--ink-mute` | `#7a7a78` | `#7a7878` | Muted labels, annotations, section markers |
+| `--rule-soft` | `rgba(26,26,26,0.16)` | `rgba(232,230,220,0.18)` | Grid lines, borders, neutral SVG strokes |
+| `--bg` | `#fafaf5` | `#0a0d1a` | Page / figure background |
+| `--bg-surface` | `#f3f1e8` | `#131830` | Card / inactive box fill |
+| `--warn` | `#b8870f` | `#d4a83d` | Warning / overflow / emphasis — animated beam, trail dots |
+| `--paper-rule` | `rgba(26,26,26,0.08)` | `rgba(232,230,220,0.08)` | Subtle background dot grid |
+
+### Rules
+- Never use chromatic accents beyond blueprint blue and warn amber. No reds, greens, or purples.
+- Interactive figures **must** use CSS variable references (`var(--blueprint)`) so they adapt to dark mode.
+- Static SVGs hardcode light values but follow the same palette.
+
+---
+
+## 2. Typography
+
+### Font Stack
+
+| Role | CSS Variable | Font | Fallback |
+|------|-------------|------|----------|
+| Body | `--font-body` | `Source Serif 4` | `Georgia, serif` |
+| Monospace | `--font-mono` | `JetBrains Mono` | `Consolas, monospace` |
+| Display | `--font-display` | `VT323` | `JetBrains Mono, monospace` |
+
+### Sizes (Interactive Figures)
+
+| Context | Size | Weight | Transform |
+|---------|------|--------|-----------|
+| Figure header (`lf-head`) | `0.68rem` | normal | uppercase, `0.16em` letter-spacing |
+| Control label (`lf-ctrl label`) | `0.7rem` | normal | uppercase, `0.08em` letter-spacing |
+| Large number (`lf-num`) | `2rem` | normal | tabular-nums |
+| Unit annotation (`lf-num small`) | `0.9rem` | normal | `0.04em` letter-spacing |
+| Meta line (`lf-meta`) | `0.7rem` | normal | `0.04em` letter-spacing |
+| Formula (`lf-formula`) | `0.72rem` | normal | normal case |
+| Caption (`lf-cap`) | `0.92rem` | normal | normal case |
+| Select dropdown (`lf-ctrl select`) | `0.82rem` | normal | normal case |
+
+### Sizes (Animated SVG Figures)
+
+| Context | Size | Letter-spacing |
+|---------|------|----------------|
+| Section labels | 11 | `0.16em` or `0.14em` |
+| Axis / token labels | 10 | `0.14em` |
+| Bar / tiny labels | 9 | none |
+| Formula / emphasis | 13 | `0.06em` |
+| Compact figure labels | 9–10 | `0.16em` |
+
+### Sizes (Static SVG Figures)
+
+| Context | Size | Letter-spacing |
+|---------|------|----------------|
+| Figure ID (top-left) | 6.5–7 | `1.5px` |
+| Section headings | 9 | `2px` |
+| Body / labels | 11 | `1.4–1.6px` |
+| Bottom markers | 10 | `2px` |
+| Phase/lesson (top-right) | 11 | `2.4px` |
+
+---
+
+## 3. Line Weights
+
+| `stroke-width` | When to use |
+|---------------|-------------|
+| `0.5` | Fine grid cells, decorative |
+| `0.6` | Background grid lines |
+| `0.8` | Dashed leader lines |
+| `1` | Standard grid lines, minor borders |
+| `1.2` | Structural lines, secondary borders |
+| `1.4` | Arrows, primary connection lines |
+| `1.5` | Box borders, important structure |
+| `1.6` | Chart data curves |
+| `2` | Emphasis lines, scan brackets, main data |
+
+### Dash Patterns
+
+| Pattern | Usage |
+|---------|-------|
+| `2 4` | Initial / light dashes |
+| `3 3` | Standard dashes (grid markers) |
+| `4 3` | Gradient descent / step paths |
+| `4 4` | Residual / trail arcs |
+
+---
+
+## 4. Spacing & Layout
+
+### Interactive Figure Container
+
+```
+.lf                    margin: 28px 0; border: 1px solid var(--rule-soft)
+.lf-head               padding: 12px 16px; border-bottom: 1px solid var(--rule-soft)
+.lf-body               padding: 16px
+.lf-grid               display: grid; 2 columns; gap: 12px 24px
+.lf-ctrl               flex column; gap: 4px
+.lf-out                margin-top: 18px; padding-top: 14px; dashed top border
+.lf-bar                height: 10px; margin-top: 12px
+.lf-cap                padding: 12px 16px; border-top: 1px solid var(--rule-soft)
+```
+
+- Grid collapses to 1 column at `640px` viewport width.
+- Animated SVG max-width: `760px`. Interactive widget SVG max-width: `560px`.
+
+### Chart Padding (`PAD`)
+
+| Figure type | PAD |
+|-------------|-----|
+| Interactive widgets | 28–36 |
+| Animated explainers | 56–60 |
+| Compact figures | 18 |
+
+### SVG ViewBox
+
+| Type | Dimensions | Notes |
+|------|-----------|-------|
+| Animated explainers | `760 × 540`, `760 × 460`, `820 × 620` | Full-width auto-height via `width: 100%; height: auto` |
+| Compact animated | `720 × 220..280` | Smaller panel figures |
+| Interactive SVG area | `520 × 200..280` | Inside `.lf-out`, scrolls on overflow |
+| Static figure icons | `120 × 120` | README card icons |
+| Static large diagrams | `1200 × 700..820` | Full-page technical diagrams |
+
+---
+
+## 5. Animation Principles
+
+### Two Animation Systems
+
+**System A — Auto-animated** (`figures.js`): Continuous loop with hover-pause.
+- A single `t` parameter floats `0 → 1` over a fixed period (6–14 seconds).
+- `mouseenter` pauses the loop. `mouseleave` resumes.
+- Respects `prefers-reduced-motion`: renders one static frame and stops.
+
+**System B — Interactive widgets** (`lesson-figures.js` + module files): Slider-driven, no auto-animation.
+- State object drives deterministic re-render on slider/select change.
+- `raf(step)` provides a `dt` (seconds elapsed) or `reduced` flag for optional micro-animations.
+
+### Key Rules
+- Animations must be **subtle and purposeful** — reveal structure or flow, never just decorate.
+- **Hover interaction** can pause, highlight, or reveal — never hide critical information.
+- **Easing**: use `easeIO` (cubic ease-in-out) for multi-segment motion:
+  ```js
+  function easeIO(t) { return t < .5 ? 2*t*t : 1 - Math.pow(-2*t+2, 2) / 2; }
+  ```
+- **Coordinate precision**: always `.toFixed(1)` on SVG coordinate values.
+- **Deterministic**: no randomness — use seeded or pre-computed data.
+
+### Reduced Motion Contract
+1. **CSS**: `@media (prefers-reduced-motion: reduce)` disables all transitions and animations.
+2. **JS**: Every animation entry point checks `matchMedia('(prefers-reduced-motion: reduce)').matches`.
+3. If reduced motion is preferred, render one complete static frame and stop.
+
+---
+
+## 6. Figure Types & DOM Structure
+
+### Interactive Widgets (slider-based)
+
+```html
+<div class="lf">
+  <div class="lf-head">
+    <span class="lf-label">UPPERCASE LABEL</span>
+    <span>interaction hint</span>
+  </div>
+  <div class="lf-body">
+    <div class="lf-grid"><!-- controls --></div>
+    <div class="lf-out">
+      <!-- SVG or output elements -->
+    </div>
+  </div>
+  <div class="lf-cap">Educational caption explaining the concept.</div>
+</div>
+```
+
+### Animated SVG Figures (auto-loop)
+
+```html
+<div class="lesson-figure lf-animated">
+  <svg viewBox="0 0 760 540" width="100%" role="img" aria-label="...">
+    <!-- animated SVG content -->
+  </svg>
+</div>
+```
+
+### Static SVG Figures (`site/assets/figures/`)
+
+```html
+<svg viewBox="0 0 1200 700" role="img" aria-label="...">
+  <rect width="1200" height="700" fill="#fafaf5"/>
+  <!-- paper dot pattern overlay -->
+  <!-- blueprint strokes with .bp class -->
+  <!-- JetBrains Mono labels with .mono class -->
+</svg>
+```
+
+---
+
+## 7. Helper Conventions
+
+### LF Toolkit (`window.LF`)
+
+| Method | Purpose | Signature |
+|--------|---------|-----------|
+| `el` | Create HTML element | `el(tag, attrs, kids)` |
+| `svgEl` | Create SVG element | `svgEl(tag, attrs, kids)` |
+| `slider` | Range input | `slider(state, key, label, min, max, step, fmt?)` |
+| `select` | Dropdown | `select(state, key, label, options)` |
+| `fmtInt` | Locale integer | `fmtInt(n)` → `"1,234"` |
+| `fmtSeq` | Human-readable count | `fmtSeq(2048)` → `"2K"` |
+| `clamp` | Clamp value | `clamp(x, lo, hi)` |
+| `lerp` | Linear interpolation | `lerp(a, b, t)` |
+| `raf` | Animation frame loop | `raf(step)` |
+| `register` | Register figure widget | `register({'name': fn})` |
+
+### Box + Arrow Pattern (for flow diagrams)
+
+```js
+// Box with rounded rect + centered text
+box(x, y, w, h, label, isActive) → <g>
+
+// Line with arrowhead marker
+arrow(x1, y1, x2, y2, dash?) → <line>
+
+// Arrowhead defs — module-scoped to avoid ID collisions
+arrowDefs() → <defs>
+```
+
+### State Object Convention
+
+```js
+var state = { param1: default1, param2: default2 };
+state._render = function () {
+  // 1. Clear SVG: while (svg.firstChild) svg.removeChild(svg.firstChild);
+  // 2. Rebuild all visual elements from state
+  // 3. Update text nodes for status, meta, formula
+};
+// Controls call state._render() automatically via slider/select
+state._render(); // initial render
+```
+
+---
+
+## 8. Accessibility
+
+- Every top-level SVG needs `role="img"` and `aria-label`.
+- Interactive controls use native `<label>` elements.
+- Figures are keyboard-navigable — sliders respond to arrow keys by default.
+- Reduced-motion detection is required (see §5).
+- Captions provide context that screen readers can access.
+
+---
+
+## 9. File Organization
+
+```
+site/
+  figures.js                   — 10 core animated SVG explainers
+  lesson-figures.js            — LF toolkit + 3 interactive widgets (mount system)
+  figures-math.js              — Phase 1 (math) widgets
+  figures-ml.js                — Phase 2 (ML) widgets
+  figures-dl.js                — Phase 3 (deep learning) widgets
+  figures-vision-speech.js     — Phases 4, 6 (vision, audio) widgets
+  figures-transformers.js      — Phases 5, 7 (NLP, transformers) widgets
+  figures-genai-rl.js          — Phases 8, 9 (generative AI, RL) widgets
+  figures-llms-systems.js      — Phases 10, 12, 13 (LLMs, multimodal, tools) widgets
+  figures-agents-alignment.js  — Phases 11, 14, 16, 18 (agents, alignment) widgets
+  figures-math2.js             — Phase 1 (advanced math) widgets
+  figures-nlp2.js              — Phase 5 (advanced NLP) widgets
+  figures-llms2.js             — Phase 10 (LLM internals) widgets
+  figures-infra.js             — Phase 17 (infrastructure) widgets
+  figures-frontier.js          — Phases 15, 19 (autonomy, capstones) widgets
+  assets/figures/              — Static SVG figures (FIG-NNN-slug.svg)
+    INDEX.md                   — Figure catalog
+    STYLE.md                   — This file
+```
+
+---
+
+## 10. Review Checklist
+
+Before submitting a figure PR, verify:
+
+- [ ] Colors use CSS variables, not hardcoded values (interactive figures)
+- [ ] `prefers-reduced-motion` is handled
+- [ ] SVG has `role="img"` and `aria-label`
+- [ ] All text uses the correct `font-family` (JetBrains Mono for labels)
+- [ ] Figure renders in both light and dark themes
+- [ ] No external dependencies
+- [ ] Coordinates use `.toFixed(1)`
+- [ ] Caption explains the educational concept
+- [ ] Figure self-terminates (no infinite loops, no API calls)
+- [ ] Works on mobile (grid collapses to 1 column)


### PR DESCRIPTION
<!-- Thanks for contributing. Fill out what applies. Delete sections that don't. -->

## What this PR does

Adds two new docs — a visual style guide (`STYLE.md`) and a contributor guide (`CONTRIBUTING-FIGURES.md`) — that document the existing figure system conventions so contributors can create and embed figures without reverse-engineering 7,000 lines of JS and CSS.

## Kind of change

- [ ] New lesson
- [ ] Fix to an existing lesson
- [ ] Translation
- [ ] New output (prompt, skill, agent, MCP server)
- [x] Docs / website / tooling

## Checklist

- [x] Code runs without errors with the listed dependencies
- [x] No comments in code files (docs explain, code is self-explanatory)
- [ ] Built from scratch first, then shown with a framework (for new lessons)
- [ ] Lesson folder matches `LESSON_TEMPLATE.md` structure
- [ ] ROADMAP.md row for the lesson is a markdown link (`[Name](phases/...)`), not bare text
- [ ] One lesson per commit (atomic per-lesson rule)
- [x] Tested locally / code output matches what `docs/en.md` claims

## Phase / lesson

N/A — site-wide docs.

## Notes for reviewer

- `STYLE.md` extracts the blueprint aesthetic (colors, typography, line weights, spacing, animation principles) that already exists in the codebase but was undocumented.
- `CONTRIBUTING-FIGURES.md` covers all three figure types: interactive widgets, animated explainers, and static SVGs.
- Updated `INDEX.md` to link to both new files and added interactive/animated figure instructions to the "How to add" section.