### PR TITLE
fix: correct terminal shortcuts in 08-editor-setup (fixes #305)

### DIFF
--- a/phases/00-setup-and-tooling/08-editor-setup/docs/en.md
+++ b/phases/00-setup-and-tooling/08-editor-setup/docs/en.md
@@ -123,9 +123,8 @@ Useful shortcuts:
 | Action | macOS | Linux/Windows |
 |--------|-------|---------------|
 | Toggle terminal | `` Ctrl+` `` | `` Ctrl+` `` |
-| New terminal | `Ctrl+Shift+`` ` | `Ctrl+Shift+`` ` |
-| Split terminal | `Cmd+Shift+5` | `Ctrl+Shift+5` |
-
+| New terminal | `` Ctrl+Shift+` `` | `` Ctrl+Shift+` `` |
+| Split terminal | `Cmd+\` | `Ctrl+Shift+5` |
 Split terminals are useful: one for running your script, one for monitoring GPU with `nvidia-smi -l 1` or `watch -n 1 nvidia-smi`.
 
 ### Step 5: Remote Development (SSH into GPU Boxes)

--- a/phases/00-setup-and-tooling/08-editor-setup/docs/en.md
+++ b/phases/00-setup-and-tooling/08-editor-setup/docs/en.md
@@ -51,7 +51,7 @@ If `code` is not found on macOS, open VS Code, press `Cmd+Shift+P`, type "Shell 
 
 ### Step 2: Install Essential Extensions
 
-Open the integrated terminal in VS Code (`Ctrl+`` ` or `` Cmd+` ``) and install the extensions that matter for AI work:
+Open the integrated terminal in VS Code (`Ctrl+`` ` `` on all platforms, or via menu: View → Terminal) and install the extensions that matter for AI work:
 
 ```bash
 code --install-extension ms-python.python
@@ -124,7 +124,7 @@ Useful shortcuts:
 |--------|-------|---------------|
 | Toggle terminal | `` Ctrl+` `` | `` Ctrl+` `` |
 | New terminal | `Ctrl+Shift+`` ` | `Ctrl+Shift+`` ` |
-| Split terminal | `Cmd+\` | `Ctrl+\` |
+| Split terminal | `Cmd+Shift+5` | `Ctrl+Shift+5` |
 
 Split terminals are useful: one for running your script, one for monitoring GPU with `nvidia-smi -l 1` or `watch -n 1 nvidia-smi`.
 


### PR DESCRIPTION
<!-- Thanks for contributing. Fill out what applies. Delete sections that don't. -->

## What this PR does

<!-- Corrects incorrect VS Code terminal shortcuts in the 08-editor-setup lesson 
and clarifies the terminal open shortcut for macOS users. -->

## Kind of change
Check only this box:

 Fix to an existing lesson

## Checklist

Check only these (others don't apply to a doc fix):

 Tested locally / code output matches what docs/en.md claims



## Phase / lesson

<!-- Phase 0 · 08-editor-setup -->

## Notes for reviewer

<!-- Two shortcut errors fixed in docs/en.md:

1. Split terminal shortcut was listed as Cmd+\ (macOS) and Ctrl+\ (Linux/Windows).
   Correct shortcuts are Cmd+Shift+5 (macOS) and Ctrl+Shift+5 (Linux/Windows).

2. Opening terminal note referenced Cmd+` as a macOS shortcut.
   This is actually a window switcher, not terminal. 
   Clarified to Ctrl+` which works on all platforms.

No code changes — docs only. -->
