### PR TITLE
Issue #308 - Fix Dockerfile apt install failures for Phase 0 Lesson 7

### DIFF
--- a/phases/00-setup-and-tooling/07-docker-for-ai/code/Dockerfile
+++ b/phases/00-setup-and-tooling/07-docker-for-ai/code/Dockerfile
@@ -4,23 +4,23 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    python3.12 \
-    python3.12-venv \
-    python3.12-dev \
+    python3.11 \
+    python3.11-venv \
+    python3.11-dev \
     python3-pip \
     git \
     curl \
     build-essential \
     && rm -rf /var/lib/apt/lists/*
 
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.12 1
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.11 1
 
 RUN python -m pip install --no-cache-dir --upgrade pip setuptools wheel
 
 RUN python -m pip install --no-cache-dir \
-    torch==2.3.1 \
-    torchvision==0.18.1 \
-    torchaudio==2.3.1 \
+    torch==2.4.1 \
+    torchvision \
+    torchaudio \
     --index-url https://download.pytorch.org/whl/cu124
 
 RUN python -m pip install --no-cache-dir \

--- a/phases/00-setup-and-tooling/07-docker-for-ai/docs/en.md
+++ b/phases/00-setup-and-tooling/07-docker-for-ai/docs/en.md
@@ -157,23 +157,23 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    python3.12 \
-    python3.12-venv \
-    python3.12-dev \
+    python3.11 \
+    python3.11-venv \
+    python3.11-dev \
     python3-pip \
     git \
     curl \
     build-essential \
     && rm -rf /var/lib/apt/lists/*
 
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.12 1
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.11 1
 
 RUN python -m pip install --no-cache-dir --upgrade pip setuptools wheel
 
 RUN python -m pip install --no-cache-dir \
-    torch==2.3.1 \
-    torchvision==0.18.1 \
-    torchaudio==2.3.1 \
+    torch==2.4.1 \
+    torchvision \
+    torchaudio \
     --index-url https://download.pytorch.org/whl/cu124
 
 RUN python -m pip install --no-cache-dir \


### PR DESCRIPTION
<!-- Thanks for contributing. Fill out what applies. Delete sections that don't. -->

## What this PR does

<!-- One-sentence summary. -->
This PR adresses the apt package install failures when building the Dockerfile for Phase 0 / Lesson 7
## Kind of change

- [ ] New lesson
- [x] Fix to an existing lesson
- [ ] Translation
- [ ] New output (prompt, skill, agent, MCP server)
- [ ] Docs / website / tooling

## Checklist

- [x] Code runs without errors with the listed dependencies
- [x] No comments in code files (docs explain, code is self-explanatory)
- [ ] Built from scratch first, then shown with a framework (for new lessons)
- [x] Lesson folder matches `LESSON_TEMPLATE.md` structure
- [x] ROADMAP.md row for the lesson is a markdown link (`[Name](phases/...)`), not bare text
- [x] One lesson per commit (atomic per-lesson rule)
- [x] Tested locally / code output matches what `docs/en.md` claims

## Phase / lesson

<!-- e.g. Phase 5 · 03-tokenizers -->

## Notes for reviewer

<!-- Anything surprising, any deviations from the template, open questions. -->
The package repository used doesn't have python3.12 in it's repositories