### PR TITLE
docs(phase-00): add macOS/MPS branch to env-check prompt

### DIFF
--- a/phases/00-setup-and-tooling/01-dev-environment/outputs/prompt-env-check.md
+++ b/phases/00-setup-and-tooling/01-dev-environment/outputs/prompt-env-check.md
@@ -16,7 +16,8 @@ When the user describes an issue:
 Common issues and fixes:
 
 - **Python version too old**: Install with `uv python install 3.12`
-- **CUDA not detected**: Check `nvidia-smi`, then reinstall PyTorch with the correct CUDA version
+- **CUDA not detected (Linux/Windows + NVIDIA)**: Check `nvidia-smi`, then reinstall PyTorch with the correct CUDA version
+- **macOS / Apple Silicon**: There is no CUDA on macOS — this is expected, not a failure. Do not use `--index-url .../cuXXX`; install plain `uv pip install torch torchvision torchaudio` and use the MPS (Metal) backend. Verify with `python -c "import torch; print(torch.backends.mps.is_available())"` (should print `True`)
 - **Node.js missing**: Install with `fnm install 22`
 - **Import errors after install**: Check you're in the right virtual environment with `which python`
 - **Permission errors**: Never use `sudo pip install`, use `uv` with a virtual environment instead


### PR DESCRIPTION
## What

The `prompt-env-check` diagnostician prompt (Phase 0, Lesson 1) told **all** users to handle "CUDA not detected" by running `nvidia-smi` and reinstalling PyTorch with a CUDA version. On macOS / Apple Silicon there is no CUDA and no `nvidia-smi`, so that advice loops with no resolution.

## Change

Split the CUDA bullet into two:

- **Linux/Windows + NVIDIA** — keep the existing `nvidia-smi` + CUDA-versioned reinstall path.
- **macOS / Apple Silicon** — new branch: no CUDA is expected (not a failure), do **not** use `--index-url .../cuXXX`, install plain `uv pip install torch torchvision torchaudio`, and verify the MPS (Metal) backend with `torch.backends.mps.is_available()`.

## Why

Following the original CUDA command on a Mac fails — `download.pytorch.org/whl/cu124` has no `macosx_arm64` wheels. Verified locally that the plain install yields a working MPS build:

```
torch 2.12.1
CUDA avail: False     # expected on Mac
MPS avail: True
```

`verify.py` passes 7/7 core checks after setup.

Refs #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)