### PR TITLE
docs(phase-00/01): add cargo init step to dev environment lesson

### DIFF
--- a/phases/00-setup-and-tooling/01-dev-environment/docs/en.md
+++ b/phases/00-setup-and-tooling/01-dev-environment/docs/en.md
@@ -103,6 +103,12 @@ rustc --version
 cargo --version
 ```
 
+Initialize a Cargo project in the course repo root so Rust lessons build and run with `cargo`. Use `--vcs none` since the repo is already under git:
+
+```bash
+cargo init --vcs none
+```
+
 ### Step 5: Julia (Optional)
 
 For math-heavy lessons where Julia shines.


### PR DESCRIPTION
## What this PR does

Adds a `cargo init --vcs none` step to Step 4 (Rust) of the Phase 0 dev environment lesson, so learners initialize a Cargo project right after installing the toolchain and can build/run Rust lessons with `cargo`.

This should address #259 

## Kind of change

- [x] Fix to an existing lesson

## Checklist

- [x] Code runs without errors with the listed dependencies (`cargo init` verified locally on a fresh clone)
- [x] One lesson per commit (atomic per-lesson rule)
- [x] Tested locally / code output matches what `docs/en.md` claims

## Phase / lesson

Phase 0 · 01-dev-environment

## Notes for reviewer

`target/` and `Cargo.lock` are already covered by the repo `.gitignore`. The instruction uses `--vcs none` so cargo skips its git integration and leaves the learner's local `.gitignore` untouched.