### PR TITLE
docs(phase-00/01): add macOS/Apple Silicon branch to Step 6 GPU setup

### DIFF
--- a/phases/00-setup-and-tooling/01-dev-environment/docs/en.md
+++ b/phases/00-setup-and-tooling/01-dev-environment/docs/en.md
@@ -115,17 +115,27 @@ julia -e 'println("Julia ", VERSION)'
 
 ### Step 6: GPU Setup (If You Have One)
 
+**NVIDIA (Linux / Windows):**
+
 ```bash
-# NVIDIA
 nvidia-smi
 
 # Install PyTorch with CUDA
 uv pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu124
 ```
 
+**macOS / Apple Silicon (M1/M2/M3/M4):** There is no CUDA on a Mac — that's expected, not a failure. Do **not** pass `--index-url .../cuXXX` (those wheels are Linux/Windows only, so the install fails). Install the plain build, which includes Apple's MPS (Metal) GPU backend:
+
+```bash
+uv pip install torch torchvision torchaudio
+```
+
+Verify (works on any platform):
+
 ```python
 import torch
-print(f"CUDA available: {torch.cuda.is_available()}")
+print(f"CUDA available: {torch.cuda.is_available()}")           # False on macOS — expected
+print(f"MPS available:  {torch.backends.mps.is_available()}")   # True on Apple Silicon
 if torch.cuda.is_available():
     print(f"GPU: {torch.cuda.get_device_name(0)}")
 ```


### PR DESCRIPTION
## What

Phase 0, Lesson 1 (Dev Environment) — Step 6 "GPU Setup" only documents the NVIDIA/CUDA install:

```bash
uv pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu124
```

On macOS / Apple Silicon the `cu124` index has no `macosx_arm64` wheels, so this exact command fails with:

> × No solution found when resolving dependencies … torch>=2.4.0 has no wheels with a matching platform tag (e.g., `macosx_..._arm64`)

Mac users following the lesson literally hit a dead end.

## Change

Split Step 6 into two clearly-labelled platform branches:

- **NVIDIA (Linux / Windows)** — unchanged `nvidia-smi` + `cu124` install.
- **macOS / Apple Silicon** — new branch: no CUDA is expected (not a failure); do **not** pass `--index-url .../cuXXX`; install the plain build (`uv pip install torch torchvision torchaudio`), which ships Apple's MPS (Metal) GPU backend.

Also extended the verification snippet to print `torch.backends.mps.is_available()` so Mac users get a meaningful signal instead of only a `CUDA available: False`.

## Scope / related

Doc-only, 1 file. Complements — does not overlap — the in-flight MPS work:
- #317 (macOS/MPS branch in `prompt-env-check.md`)
- #295 (MPS device support in `verify.py` and other code)

Neither of those touches this lesson's `en.md` GPU-install command, which is the gap this PR closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)