### PR TITLE
fix: three lessons crash on their documented run path

### DIFF
--- a/phases/00-setup-and-tooling/12-debugging-and-profiling/code/debug_tools.py
+++ b/phases/00-setup-and-tooling/12-debugging-and-profiling/code/debug_tools.py
@@ -129,8 +129,8 @@ def demo_memory_tracking():
     print("\n--- 3. Memory Tracking (tracemalloc) ---")
     tracemalloc.start()
 
-    data = [torch.randn(100, 100) for _ in range(100)]
-    more_data = torch.randn(1000, 1000)
+    data = [[0.0] * 10000 for _ in range(100)]
+    more_data = [0.0] * 1000000
 
     snapshot = tracemalloc.take_snapshot()
     top_stats = snapshot.statistics("lineno")

--- a/phases/05-nlp-foundations-to-advanced/28-long-context-evaluation/code/main.py
+++ b/phases/05-nlp-foundations-to-advanced/28-long-context-evaluation/code/main.py
@@ -56,7 +56,8 @@ def run_niah_grid(lengths, depths, seed=0):
     needle = "the magic word is pineapple"
     expected = "pineapple"
     capacity = 20000
-    print(f"  {'depth\\len':<12}  " + "  ".join(f"{n:>6}" for n in lengths))
+    corner = "depth\\len"
+    print(f"  {corner:<12}  " + "  ".join(f"{n:>6}" for n in lengths))
     for d in depths:
         row = []
         for n in lengths:

--- a/phases/10-llms-from-scratch/05-scaling-distributed/code/main.py
+++ b/phases/10-llms-from-scratch/05-scaling-distributed/code/main.py
@@ -220,11 +220,10 @@ def training_cost_estimator(
     if num_gpus is None:
         mem = memory_calculator(params_billions, sharding="fsdp", num_gpus=1)
         num_gpus = max(1, int(np.ceil(mem["per_gpu_total_gb"] / spec["memory_gb"])) * 2)
-
-    verify = memory_calculator(params_billions, sharding="fsdp", num_gpus=num_gpus)
-    while verify["per_gpu_total_gb"] > spec["memory_gb"]:
-        num_gpus *= 2
         verify = memory_calculator(params_billions, sharding="fsdp", num_gpus=num_gpus)
+        while verify["per_gpu_total_gb"] > spec["memory_gb"] and num_gpus < 65536:
+            num_gpus *= 2
+            verify = memory_calculator(params_billions, sharding="fsdp", num_gpus=num_gpus)
 
     total_gpu_seconds = flops_total / (flops_per_gpu_per_sec * num_gpus)
     total_gpu_hours = total_gpu_seconds / 3600

--- a/phases/10-llms-from-scratch/05-scaling-distributed/code/main.py
+++ b/phases/10-llms-from-scratch/05-scaling-distributed/code/main.py
@@ -225,6 +225,8 @@ def training_cost_estimator(
             num_gpus *= 2
             verify = memory_calculator(params_billions, sharding="fsdp", num_gpus=num_gpus)
 
+    fit = memory_calculator(params_billions, sharding="fsdp", num_gpus=num_gpus)
+
     total_gpu_seconds = flops_total / (flops_per_gpu_per_sec * num_gpus)
     total_gpu_hours = total_gpu_seconds / 3600
     wall_clock_hours = total_gpu_hours
@@ -236,6 +238,8 @@ def training_cost_estimator(
         "gpu_type": gpu_type,
         "num_gpus": num_gpus,
         "total_flops": f"{flops_total:.2e}",
+        "per_gpu_memory_gb": fit["per_gpu_total_gb"],
+        "fits_in_gpu_memory": fit["per_gpu_total_gb"] <= spec["memory_gb"],
         "wall_clock_days": wall_clock_hours / 24,
         "total_gpu_hours": total_gpu_hours * num_gpus,
         "estimated_cost": total_cost,


### PR DESCRIPTION
## What this PR does

Fixes the three lessons that fail when run the way their docs describe. Fixes #341.

## Kind of change

- [x] Fix to an existing lesson

## Checklist

- [x] Code runs without errors with the listed dependencies
- [x] No comments in code files (docs explain, code is self-explanatory)
- [x] One lesson per commit (atomic per-lesson rule)
- [x] Tested locally / code output matches what `docs/en.md` claims

## Phase / lesson

Phase 10 · 05-scaling-distributed · Phase 5 · 28-long-context-evaluation · Phase 0 · 12-debugging-and-profiling

## The three fixes

**`10/05-scaling-distributed` — unbounded loop → `OverflowError`.**
`activation_memory` is not sharded by any branch, so `per_gpu_total_gb` is floored at 405 GB for the 405B row and the grow-until-it-fits loop can never exit; `num_gpus` doubles ~1000 times until `float /= int` overflows. The loop also overwrote the caller's explicit `num_gpus` — the number the lesson is about (`docs/en.md:27` pins Llama 3 405B to 16,384 H100s; `main()` passes exactly that). Scoped the loop to the branch that derives `num_gpus` itself, and bounded it. `verify` is unused after the loop, so indenting it is safe.

Before: crashes after the 70B row. After — the 405B row lands on the doc's own ~$100M figure, and the 8B/70B rows are byte-identical:

```
       8B   15.0T    512      41d     $1,767,677
      70B   15.0T   2048      90d    $15,467,172
     405B   15.0T  16384      65d    $89,488,636
     671B   14.8T   2048     850d   $146,287,037
```

**`05/28-long-context-evaluation` — `SyntaxError` before Python 3.12.**
A backslash inside an f-string expression part was only legalised by PEP 701 in 3.12, but `README.md:1061` documents the curriculum as Python 3.10+. Hoisted the literal into a local. Rendered output is unchanged (`depth\\len` header still prints identically) and the file now byte-compiles on 3.9/3.10/3.11.

**`00/12-debugging-and-profiling` — no-torch fallback `NameError`.**
`main()` explicitly handles torch being absent and then calls `demo_memory_tracking()`, which used `torch.randn`. The demo shows `tracemalloc`, which needs no tensors, so it now allocates plain Python lists — the torch path is unaffected and the fallback path completes.

## Verification

Each lesson run directly before and after. Repo smoke check on the branch:

```
$ python3 scripts/lesson_run.py
lesson_run.py (syntax) — 503 lesson(s), 585 python file(s): passed=495 failed=0 skipped=8
```

## Notes for reviewer

The 65536 bound in fix 1 is a safety stop, not a modelling claim — with an explicit `num_gpus` the loop no longer runs at all, so it only affects the auto-derive path. Happy to split this into three PRs if you'd rather review them separately.