### PR TITLE
fix(phase-01): negative cross-entropy, all-zero stationary distribution, inverted Cohen's d

### DIFF
--- a/phases/01-math-foundations/13-numerical-stability/code/numerical.py
+++ b/phases/01-math-foundations/13-numerical-stability/code/numerical.py
@@ -60,7 +60,7 @@ def binary_cross_entropy_naive(y_true, y_pred):
 
 def binary_cross_entropy_stable(y_true, logit):
     max_val = max(0.0, -logit)
-    return max_val + math.log(math.exp(-max_val) + math.exp(-logit - max_val)) - y_true * logit
+    return max_val + math.log(math.exp(-max_val) + math.exp(-logit - max_val)) + (1 - y_true) * logit
 
 
 def numerical_gradient(f, x, h=1e-5):

--- a/phases/01-math-foundations/15-statistics-for-ml/code/statistics.py
+++ b/phases/01-math-foundations/15-statistics-for-ml/code/statistics.py
@@ -285,7 +285,7 @@ def cohens_d(data1, data2):
     pooled = math.sqrt(((n1 - 1) * v1 + (n2 - 1) * v2) / (n1 + n2 - 2))
     if pooled == 0:
         return 0.0
-    return (m2 - m1) / pooled
+    return (m1 - m2) / pooled
 
 
 def interpret_cohens_d(d):

--- a/phases/01-math-foundations/22-stochastic-processes/code/stochastic.py
+++ b/phases/01-math-foundations/22-stochastic-processes/code/stochastic.py
@@ -47,7 +47,7 @@ class MarkovChain:
         eigenvalues, eigenvectors = np.linalg.eig(self.P.T)
         idx = np.argmin(np.abs(eigenvalues - 1.0))
         stationary = np.real(eigenvectors[:, idx])
-        stationary = np.clip(stationary, 0, None)
+        stationary = np.abs(stationary)
         total = stationary.sum()
         if total > 0:
             stationary = stationary / total


### PR DESCRIPTION
## What this PR does

Three one-line fixes for wrong-math defects in Phase 1. Fixes #343.

## Kind of change

- [x] Fix to an existing lesson

## Checklist

- [x] Code runs without errors with the listed dependencies
- [x] No comments in code files (docs explain, code is self-explanatory)
- [x] One lesson per commit (atomic per-lesson rule)
- [x] Tested locally / code output matches what `docs/en.md` claims

## Phase / lesson

Phase 1 · 13-numerical-stability, 22-stochastic-processes, 15-statistics-for-ml

## The three fixes

**`13-numerical-stability` — `binary_cross_entropy_stable` returned negative cross-entropy.**
The function takes a logit, so it should compute `softplus(x) - y*x`. With `max_val = max(0, -logit)` the first term is the stable form of `log(1+e^-x)` = `softplus(-x)`, so every result was short by exactly the logit — `BCE(y=1, logit=6)` came out as `-5.9975` instead of `0.0025`. Pairing that term with `+(1-y)*x` gives the correct value and matches the standard BCEWithLogits form.

Round-trip check after the fix (not just "the negative numbers are gone"):

```
stable(y, x) == log1p(exp(-|x|)) + max(x,0) - y*x   for x in {-800,-10,-3,0,0.5,2,6,800}, y in {0,1}: True
stable(y, x) == binary_cross_entropy_naive(y, sigmoid_stable(x)):                                    True
```

It also stays finite at +-800, where the naive form overflows — which is the point of the lesson.

**`22-stochastic-processes` — stationary distribution printed `0.0000` for every state.**
LAPACK returns the lambda=1 eigenvector with an arbitrary sign; for this weather matrix it is all-negative, so `np.clip(v, 0, None)` zeroed it, the sum became 0, and the `if total > 0` guard skipped normalisation. Perron-Frobenius guarantees the vector is single-signed, so `np.abs` is the correct normalisation — and it is what `docs/en.md` already shows.

Before: `Sunny 0.0000 / Rainy 0.0000 / Cloudy 0.0000` against an empirical `0.5469 / 0.1826 / 0.2705`.
After: `Sunny 0.5455 / Rainy 0.1818 / Cloudy 0.2727` — exactly 6/11, 2/11, 3/11, matching `docs/en.md:94`. The convergence check below it now actually converges.

**`15-statistics-for-ml` — `cohens_d` sign matched neither the docs nor its sibling.**
`docs/en.md:301` defines `d = (mean_1 - mean_2) / pooled_std` and `t_statistic_two_sample` returns `(m1 - m2) / se`, but `cohens_d` returned `(m2 - m1) / pooled`, so the demo printed the two with opposite signs on adjacent lines. After: `cohens_d([1,2,3,4,5],[3,4,5,6,7])` = `-1.2649`, agreeing with `t` = `-2.0`.

## Notes for reviewer

Fix 3 changes only the reported sign — magnitudes are unchanged and `interpret_cohens_d` already takes `abs()`, so no verdict in the demo output flips.

While auditing the same file I also hit two quadrature problems in `statistics.py` that are **not** in this PR because the fix is a real rewrite rather than a one-liner: `_lower_incomplete_gamma_ratio` returns `p = 0.0352` for chi2=8, df=1 where `docs/en.md:247` states `p < 0.005` (exact: 0.00468), and `_regularized_beta` collapses to `p = 0.000000` at large df where the true value is 0.0636 — which is what makes the "statistical vs practical significance" demo print `Significant: True`. Happy to open a separate issue/PR for those with a continued-fraction implementation if you want them fixed.