### PR TITLE
fix: update deprecated claude-sonnet-4 model ID to claude-sonnet-5

### DIFF
--- a/phases/00-setup-and-tooling/04-apis-and-keys/code/first_api_call.py
+++ b/phases/00-setup-and-tooling/04-apis-and-keys/code/first_api_call.py
@@ -12,7 +12,7 @@ def call_with_sdk():
 
     client = anthropic.Anthropic()
     response = client.messages.create(
-        model="claude-sonnet-4-20250514",
+        model="claude-sonnet-5",
         max_tokens=256,
         messages=[{"role": "user", "content": "What is a neural network in one sentence?"}]
     )
@@ -33,7 +33,7 @@ def call_raw_http():
         "anthropic-version": "2023-06-01",
     }
     body = json.dumps({
-        "model": "claude-sonnet-4-20250514",
+        "model": "claude-sonnet-5",
         "max_tokens": 256,
         "messages": [{"role": "user", "content": "What is a neural network in one sentence?"}],
     }).encode()

--- a/phases/00-setup-and-tooling/04-apis-and-keys/docs/en.md
+++ b/phases/00-setup-and-tooling/04-apis-and-keys/docs/en.md
@@ -60,7 +60,7 @@ import anthropic
 client = anthropic.Anthropic()
 
 response = client.messages.create(
-    model="claude-sonnet-4-20250514",
+    model="claude-sonnet-5",
     max_tokens=256,
     messages=[{"role": "user", "content": "What is a neural network in one sentence?"}]
 )
@@ -76,7 +76,7 @@ import Anthropic from "@anthropic-ai/sdk";
 const client = new Anthropic();
 
 const response = await client.messages.create({
-  model: "claude-sonnet-4-20250514",
+  model: "claude-sonnet-5",
   max_tokens: 256,
   messages: [{ role: "user", content: "What is a neural network in one sentence?" }],
 });
@@ -98,7 +98,7 @@ headers = {
     "anthropic-version": "2023-06-01",
 }
 body = json.dumps({
-    "model": "claude-sonnet-4-20250514",
+    "model": "claude-sonnet-5",
     "max_tokens": 256,
     "messages": [{"role": "user", "content": "What is a neural network in one sentence?"}],
 }).encode()

--- a/phases/11-llm-engineering/06-rag/docs/en.md
+++ b/phases/11-llm-engineering/06-rag/docs/en.md
@@ -362,7 +362,7 @@ client = anthropic.Anthropic()
 
 def generate(prompt):
     response = client.messages.create(
-        model="claude-sonnet-4-20250514",
+        model="claude-sonnet-5",
         max_tokens=1024,
         messages=[{"role": "user", "content": prompt}]
     )

--- a/phases/11-llm-engineering/07-advanced-rag/docs/en.md
+++ b/phases/11-llm-engineering/07-advanced-rag/docs/en.md
@@ -459,7 +459,7 @@ client = anthropic.Anthropic()
 
 def hyde_with_llm(query):
     response = client.messages.create(
-        model="claude-sonnet-4-20250514",
+        model="claude-sonnet-5",
         max_tokens=256,
         messages=[{
             "role": "user",

--- a/phases/11-llm-engineering/09-function-calling/docs/en.md
+++ b/phases/11-llm-engineering/09-function-calling/docs/en.md
@@ -612,7 +612,7 @@ OpenAI returns tool calls as `response.choices[0].message.tool_calls`. Each call
 # client = anthropic.Anthropic()
 #
 # response = client.messages.create(
-#     model="claude-sonnet-4-20250514",
+#     model="claude-sonnet-5",
 #     max_tokens=1024,
 #     tools=[{
 #         "name": "get_weather",
@@ -633,7 +633,7 @@ OpenAI returns tool calls as `response.choices[0].message.tool_calls`. Each call
 # result = get_weather(**tool_block.input)
 #
 # final = client.messages.create(
-#     model="claude-sonnet-4-20250514",
+#     model="claude-sonnet-5",
 #     max_tokens=1024,
 #     tools=[...],
 #     messages=[

--- a/phases/11-llm-engineering/10-evaluation/docs/en.md
+++ b/phases/11-llm-engineering/10-evaluation/docs/en.md
@@ -741,7 +741,7 @@ if __name__ == "__main__":
 #
 # providers:
 #   - openai:gpt-4o
-#   - anthropic:messages:claude-sonnet-4-20250514
+#   - anthropic:messages:claude-sonnet-5
 #
 # tests:
 #   - vars:

--- a/phases/11-llm-engineering/11-caching-cost/docs/en.md
+++ b/phases/11-llm-engineering/11-caching-cost/docs/en.md
@@ -758,7 +758,7 @@ if __name__ == "__main__":
 # client = anthropic.Anthropic()
 #
 # response = client.messages.create(
-#     model="claude-sonnet-4-20250514",
+#     model="claude-sonnet-5",
 #     max_tokens=1024,
 #     system=[
 #         {

--- a/phases/11-llm-engineering/13-production-app/code/production_app.py
+++ b/phases/11-llm-engineering/13-production-app/code/production_app.py
@@ -14,7 +14,7 @@ from typing import AsyncGenerator
 
 
 class ModelName(Enum):
-    CLAUDE_SONNET = "claude-sonnet-4-20250514"
+    CLAUDE_SONNET = "claude-sonnet-5"
     GPT_4O = "gpt-4o"
     GPT_4O_MINI = "gpt-4o-mini"
 

--- a/phases/11-llm-engineering/13-production-app/docs/en.md
+++ b/phases/11-llm-engineering/13-production-app/docs/en.md
@@ -143,7 +143,7 @@ Give up: return fallback response
 **Fallback model chain.** When your primary model is unavailable, fall through a chain:
 
 ```
-claude-sonnet-4-20250514 -> gpt-4o -> gpt-4o-mini -> cached response -> "Service temporarily unavailable"
+claude-sonnet-5 -> gpt-4o -> gpt-4o-mini -> cached response -> "Service temporarily unavailable"
 ```
 
 Each step trades quality for availability. The user always gets something.
@@ -296,7 +296,7 @@ from typing import AsyncGenerator
 
 
 class ModelName(Enum):
-    CLAUDE_SONNET = "claude-sonnet-4-20250514"
+    CLAUDE_SONNET = "claude-sonnet-5"
     GPT_4O = "gpt-4o"
     GPT_4O_MINI = "gpt-4o-mini"
 
@@ -1078,7 +1078,7 @@ Replace the simulated LLM calls with actual provider SDKs.
 #         yield delta
 #
 #
-# async def call_anthropic(prompt, model="claude-sonnet-4-20250514"):
+# async def call_anthropic(prompt, model="claude-sonnet-5"):
 #     client = anthropic.AsyncAnthropic()
 #     async with client.messages.stream(
 #         model=model,


### PR DESCRIPTION
## What this PR does

Replaces the deprecated `claude-sonnet-4-20250514` model ID with `claude-sonnet-5` across the lesson code and docs that reference it.

## Kind of change

- [ ] New lesson
- [x] Fix to an existing lesson
- [ ] Translation
- [ ] New output (prompt, skill, agent, MCP server)
- [ ] Docs / website / tooling

## Checklist

- [x] Code runs without errors with the listed dependencies
- [x] No comments in code files (docs explain, code is self-explanatory)
- [ ] Built from scratch first, then shown with a framework (for new lessons)
- [x] Lesson folder matches `LESSON_TEMPLATE.md` structure
- [ ] ROADMAP.md row for the lesson is a markdown link (`[Name](phases/...)`), not bare text
- [ ] One lesson per commit (atomic per-lesson rule)
- [x] Tested locally / code output matches what `docs/en.md` claims

## Phase / lesson

- Phase 0 · `04-apis-and-keys` (4 lines: code + docs)
- Phase 11 · `06-rag`
- Phase 11 · `07-advanced-rag`
- Phase 11 · `09-function-calling` (2 lines)
- Phase 11 · `10-evaluation`
- Phase 11 · `11-caching-cost`
- Phase 11 · `13-production-app` (4 lines: code + docs)

## Notes for reviewer

The old ID emits a deprecation warning:

```
DeprecationWarning: The model 'claude-sonnet-4-20250514' is deprecated and will reach end-of-life on June 15th, 2026.
```