### PR TITLE
fix(site): guard null lessonQuizPromise and stale DOM elements in les…

### DIFF
--- a/site/lesson.html
+++ b/site/lesson.html
@@ -3085,11 +3085,11 @@
         panel.innerHTML = '<div class="ai-panel-header"><div class="ai-panel-icon">O</div><div class="ai-panel-title">What This Lesson Ships</div></div><div class="ai-panel-subtitle">Prompts, skills, and artifacts you can use right now</div><div id="outputsContent" class="panel-loading">Loading outputs...</div>';
         container.appendChild(panel);
 
+        var outputsEl = panel.querySelector('#outputsContent');
         ghApiFetch(lessonPath + '/outputs', function (err, data) {
-          var el = document.getElementById('outputsContent');
-          if (!el) return;
+          if (!outputsEl || !outputsEl.parentNode) return;
           if (err || !data || !Array.isArray(data) || data.length === 0) {
-            el.textContent = ''; var fb = document.createElement('div'); fb.className = 'panel-fallback'; var fbLink = document.createElement('a'); fbLink.href = REPO_TREE + lessonPath; fbLink.target = '_blank'; fbLink.rel = 'noopener'; fbLink.textContent = 'View lesson on GitHub'; fb.appendChild(fbLink); el.appendChild(fb);
+            outputsEl.textContent = ''; var fb = document.createElement('div'); fb.className = 'panel-fallback'; var fbLink = document.createElement('a'); fbLink.href = REPO_TREE + lessonPath; fbLink.target = '_blank'; fbLink.rel = 'noopener'; fbLink.textContent = 'View lesson on GitHub'; fb.appendChild(fbLink); outputsEl.appendChild(fb);
             return;
           }
 
@@ -3134,7 +3134,7 @@
             });
           });
           html += '</div>';
-          el.innerHTML = html;
+          outputsEl.innerHTML = html;
         });
       }
 
@@ -3144,11 +3144,11 @@
         panel.innerHTML = '<div class="ai-panel-header"><div class="ai-panel-icon">C</div><div class="ai-panel-title">Run the Code</div></div><div class="ai-panel-subtitle">Executable files from this lesson</div><div id="codeContent" class="panel-loading">Loading code files...</div>';
         container.appendChild(panel);
 
+        var codeEl = panel.querySelector('#codeContent');
         ghApiFetch(lessonPath + '/code', function (err, data) {
-          var el = document.getElementById('codeContent');
-          if (!el) return;
+          if (!codeEl || !codeEl.parentNode) return;
           if (err || !data || !Array.isArray(data) || data.length === 0) {
-            el.textContent = ''; var fb = document.createElement('div'); fb.className = 'panel-fallback'; var fbLink = document.createElement('a'); fbLink.href = REPO_TREE + lessonPath; fbLink.target = '_blank'; fbLink.rel = 'noopener'; fbLink.textContent = 'View lesson on GitHub'; fb.appendChild(fbLink); el.appendChild(fb);
+            codeEl.textContent = ''; var fb = document.createElement('div'); fb.className = 'panel-fallback'; var fbLink = document.createElement('a'); fbLink.href = REPO_TREE + lessonPath; fbLink.target = '_blank'; fbLink.rel = 'noopener'; fbLink.textContent = 'View lesson on GitHub'; fb.appendChild(fbLink); codeEl.appendChild(fb);
             return;
           }
 
@@ -3167,8 +3167,8 @@
             html += '</div>';
           });
           html += '</div>';
-          el.innerHTML = html;
-          el.querySelectorAll('.code-card-copy').forEach(function (btn) {
+          codeEl.innerHTML = html;
+          codeEl.querySelectorAll('.code-card-copy').forEach(function (btn) {
             btn.addEventListener('click', function () {
               var command = btn.getAttribute('data-command');
               navigator.clipboard.writeText(command).then(function () {

--- a/site/lesson.html
+++ b/site/lesson.html
@@ -3087,6 +3087,7 @@
 
         ghApiFetch(lessonPath + '/outputs', function (err, data) {
           var el = document.getElementById('outputsContent');
+          if (!el) return;
           if (err || !data || !Array.isArray(data) || data.length === 0) {
             el.textContent = ''; var fb = document.createElement('div'); fb.className = 'panel-fallback'; var fbLink = document.createElement('a'); fbLink.href = REPO_TREE + lessonPath; fbLink.target = '_blank'; fbLink.rel = 'noopener'; fbLink.textContent = 'View lesson on GitHub'; fb.appendChild(fbLink); el.appendChild(fb);
             return;
@@ -3145,6 +3146,7 @@
 
         ghApiFetch(lessonPath + '/code', function (err, data) {
           var el = document.getElementById('codeContent');
+          if (!el) return;
           if (err || !data || !Array.isArray(data) || data.length === 0) {
             el.textContent = ''; var fb = document.createElement('div'); fb.className = 'panel-fallback'; var fbLink = document.createElement('a'); fbLink.href = REPO_TREE + lessonPath; fbLink.target = '_blank'; fbLink.rel = 'noopener'; fbLink.textContent = 'View lesson on GitHub'; fb.appendChild(fbLink); el.appendChild(fb);
             return;
@@ -3265,11 +3267,15 @@
         panel.innerHTML = '<div class="ai-panel-header"><div class="ai-panel-icon">Q</div><div class="ai-panel-title">Test Your Understanding</div></div><div id="quizContent"><div class="panel-loading">Loading questions...</div></div>';
         container.appendChild(panel);
 
-        lessonQuizPromise.then(function (data) {
-          var questions = lessonQuizPanelQuestions(data);
-          if (!questions.length) questions = getQuizQuestions();
-          fillQuizPanel(panel.querySelector('#quizContent'), questions);
-        });
+        if (lessonQuizPromise) {
+          lessonQuizPromise.then(function (data) {
+            var questions = lessonQuizPanelQuestions(data);
+            if (!questions.length) questions = getQuizQuestions();
+            fillQuizPanel(panel.querySelector('#quizContent'), questions);
+          });
+        } else {
+          fillQuizPanel(panel.querySelector('#quizContent'), getQuizQuestions());
+        }
       }
 
       function fillQuizPanel(body, questions) {


### PR DESCRIPTION
## What this PR does

Guards against three `TypeError` crashes in `site/lesson.html` that caused every lesson page to show a "Render error" banner.

Problem:

<img width="1905" height="876" alt="image" src="https://github.com/user-attachments/assets/ad148b14-2a19-402f-8141-d1e0581f6009" />

Fixed result:
<img width="1895" height="909" alt="image" src="https://github.com/user-attachments/assets/7ec0c770-e284-4fe4-9a27-aaf3cef65b45" />

## Kind of change

- [x] Docs / website / tooling

## Checklist

- [x] Code runs without errors with the listed dependencies
- [x] No comments in code files (docs explain, code is self-explanatory)
- [x] Tested locally / code output matches what `docs/en.md` claims

## Phase / lesson

N/A — site infrastructure fix only (`site/lesson.html`)

## Notes for reviewer

Three bugs, one file, one commit:

1. **`renderQuizPanel` (~L3268)** — `lessonQuizPromise` is set to `null` in the retry path (`lessonQuizPromise = null`). Calling `.then()` on `null` threw `TypeError: Cannot read properties of null (reading 'then')` inside `renderLesson`, which was caught and surfaced as the visible "Render error" banner. Fixed by wrapping the call in `if (lessonQuizPromise)` and falling back to `getQuizQuestions()` so the panel still renders.

2. **`renderOutputsPanel` (~L3091)** — `ghApiFetch` is async. If the user navigates to a new lesson before the GitHub API responds, `document.getElementById('outputsContent')` returns `null` and the callback crashed on `el.textContent = ''`. Fixed with an early `if (!el) return;`.

3. **`renderCodePanel` (~L3149)** — Identical stale-DOM race condition for `codeContent`. Same fix applied.

No lesson content, quiz schemas, or build scripts were changed.