### PR TITLE
fix(phase-02/15): forecast fed the lag vector in reverse order

### DIFF
--- a/phases/02-ml-fundamentals/15-time-series/code/time_series.py
+++ b/phases/02-ml-fundamentals/15-time-series/code/time_series.py
@@ -132,7 +132,7 @@ class SimpleAR:
         predictions = []
 
         for _ in range(n_steps):
-            features = np.array(history[-self.n_lags:]).reshape(1, -1)
+            features = np.array(history[-self.n_lags:][::-1]).reshape(1, -1)
             pred = self.predict(features)[0]
             predictions.append(pred)
             history.append(pred)


### PR DESCRIPTION
## What this PR does

`SimpleAR.forecast` built its feature row in the opposite order to `make_lag_features`, so every forecast used the wrong coefficients.

## Kind of change

- [x] Fix to an existing lesson

## Checklist

- [x] Code runs without errors with the listed dependencies
- [x] No comments in code files
- [x] One lesson per commit
- [x] Tested locally

## Phase / lesson

Phase 2 · 15-time-series

## Detail

`make_lag_features` writes `X[lag:, lag - 1] = series[:-lag]`, so a row is most-recent-first: `[y[t-1], y[t-2], ..., y[t-n]]`. `forecast` keeps `history` chronological (`history.append(pred)`) and sliced it without reversing, so the lag-1 coefficient multiplied the oldest value and lag-10 the newest.

Result: forecast MSE `116.3491` → `54.5676`, MAE `9.5334` → `5.9113`.

Correctness check — `forecast(train, 1)[0]` must equal `predict()` on the equivalent lag row, and now does:

```
row (most-recent-first): [57.95 59.41 60.22 59.15 57.99 59.67 59.98 60.28 60.41 60.81]
predict(manual row) = 57.742809
forecast(tr, 1)[0]  = 57.742809
identity holds      : True
```