### PR TITLE
fix(phase-02/10): total_error omitted the noise term

### DIFF
--- a/phases/02-ml-fundamentals/10-bias-variance/code/bias_variance.py
+++ b/phases/02-ml-fundamentals/10-bias-variance/code/bias_variance.py
@@ -58,7 +58,7 @@ def bias_variance_decomposition(
         mean_pred = predictions.mean(axis=0)
         bias_sq = np.mean((mean_pred - y_true) ** 2)
         variance = np.mean(predictions.var(axis=0))
-        total_error = np.mean(np.mean((predictions - y_true) ** 2, axis=1))
+        total_error = np.mean(np.mean((predictions - y_true) ** 2, axis=1)) + noise_std ** 2
 
         results[degree] = {
             "bias_sq": bias_sq,


### PR DESCRIPTION
## What this PR does

The bias-variance demo prints `Total` beside `B+V+N` so the reader can check the identity, but the two never matched.

## Kind of change

- [x] Fix to an existing lesson

## Checklist

- [x] Code runs without errors with the listed dependencies
- [x] No comments in code files
- [x] One lesson per commit
- [x] Tested locally / code output matches what `docs/en.md` claims

## Phase / lesson

Phase 2 · 10-bias-variance

## Detail

`docs/en.md` states `Expected Error = Bias^2 + Variance + Irreducible Noise`, and says `total_error` should approximately equal that sum. Total was measured against the noiseless `y_true`, so it equalled `bias^2 + variance` — every row short by exactly `noise_std^2 = 0.25`.

`E[(y - f_hat)^2] = E[(f - f_hat)^2] + sigma^2`, so adding `noise_std ** 2` is exact in expectation.

Before / after:

```
Degree      Bias^2    Variance       Noise       Total       B+V+N
     1      0.4310      0.0434      0.2500      0.4744      0.7244   <- before
     1      0.4310      0.0434      0.2500      0.7244      0.7244   <- after
     5      0.0012      0.0495      0.2500      0.0507      0.3007   <- before
     5      0.0012      0.0495      0.2500      0.3007      0.3007   <- after
```

A constant is added to every row, so `Optimal degree: 5` is unchanged.