### PR TITLE
fix(phase-14/38): coverage delta tripped on float error

### DIFF
--- a/phases/14-agent-engineering/38-verification-gates/code/main.py
+++ b/phases/14-agent-engineering/38-verification-gates/code/main.py
@@ -127,7 +127,7 @@ def _coverage_findings(art: Artifacts, floor: float) -> list[Finding]:
     if current < floor:
         findings.append(Finding("coverage.below_floor", "block",
                                 f"coverage {current:.2%} below floor {floor:.0%}"))
-    delta = previous - current
+    delta = round(previous - current, 9)
     if delta > COVERAGE_REGRESSION_DELTA:
         findings.append(Finding("coverage.regression", "block",
                                 f"coverage dropped {delta:.2%} (prev {previous:.2%} -> {current:.2%})"))

--- a/phases/14-agent-engineering/38-verification-gates/code/main.py
+++ b/phases/14-agent-engineering/38-verification-gates/code/main.py
@@ -14,6 +14,7 @@ import argparse
 import hashlib
 import hmac
 import json
+import math
 import os
 import sys
 import time
@@ -127,11 +128,13 @@ def _coverage_findings(art: Artifacts, floor: float) -> list[Finding]:
     if current < floor:
         findings.append(Finding("coverage.below_floor", "block",
                                 f"coverage {current:.2%} below floor {floor:.0%}"))
-    delta = round(previous - current, 9)
-    if delta > COVERAGE_REGRESSION_DELTA:
+    delta = previous - current
+    if delta > COVERAGE_REGRESSION_DELTA and not math.isclose(
+        delta, COVERAGE_REGRESSION_DELTA, rel_tol=1e-9
+    ):
         findings.append(Finding("coverage.regression", "block",
                                 f"coverage dropped {delta:.2%} (prev {previous:.2%} -> {current:.2%})"))
-    elif delta > 0:
+    elif delta > 0 and not math.isclose(delta, 0.0, abs_tol=1e-12):
         findings.append(Finding("coverage.minor_regression", "warn",
                                 f"coverage dropped {delta:.2%}"))
     return findings


### PR DESCRIPTION
## What this PR does

T-001, the lesson's documented clean-pass scenario, was blocked by float rounding.

## Kind of change

- [x] Fix to an existing lesson

## Checklist

- [x] Code runs without errors with the listed dependencies
- [x] No comments in code files
- [x] One lesson per commit
- [x] Tested locally / code output matches what `docs/en.md` claims

## Phase / lesson

Phase 14 · 38-verification-gates

## Detail

`docs/en.md` says the gate blocks only when coverage drops **more than** 1 percentage point. T-001 ships `current=0.84 / previous=0.85` — a drop of exactly 1 pp, so it should warn. But `0.85 - 0.84 == 0.010000000000000009`, which is `> 0.01`.

The output contradicted itself:

```
task T-001: passed=False findings=1
  [block] coverage.regression: coverage dropped 1.00% (prev 85.00% -> 84.00%)
```

After:

```
task T-001: passed=True findings=1
  [warn] coverage.minor_regression: coverage dropped 1.00%
```

T-002 and T-003 are unchanged.