### PR TITLE
fix(phase-11/09): calculator got the operator token, not the expression

### DIFF
--- a/phases/11-llm-engineering/09-function-calling/code/function_calling.py
+++ b/phases/11-llm-engineering/09-function-calling/code/function_calling.py
@@ -216,13 +216,12 @@ def simulate_model_decision(user_message, tools, conversation_history):
         return calls
 
     if any(word in msg for word in ["calculate", "compute", "math", "what is", "how much"]):
+        expr = "".join(c for c in msg if c in "0123456789+-*/.() ").strip()
+        if expr and any(c in expr for c in "+-*/"):
+            return [{"name": "calculator", "arguments": {"expression": expr}}]
         for token in msg.split():
             if any(c in token for c in "+-*/"):
                 return [{"name": "calculator", "arguments": {"expression": token}}]
-        if "+" in msg or "-" in msg or "*" in msg or "/" in msg:
-            expr = "".join(c for c in msg if c in "0123456789+-*/.() ")
-            if expr.strip():
-                return [{"name": "calculator", "arguments": {"expression": expr.strip()}}]
         return [{"name": "calculator", "arguments": {"expression": "0"}}]
 
     if any(word in msg for word in ["search", "find", "look up", "google"]):

--- a/phases/11-llm-engineering/09-function-calling/code/function_calling.py
+++ b/phases/11-llm-engineering/09-function-calling/code/function_calling.py
@@ -1,5 +1,6 @@
 import json
 import math
+import re
 import time
 
 
@@ -216,9 +217,14 @@ def simulate_model_decision(user_message, tools, conversation_history):
         return calls
 
     if any(word in msg for word in ["calculate", "compute", "math", "what is", "how much"]):
-        expr = "".join(c for c in msg if c in "0123456789+-*/.() ").strip()
-        if expr and any(c in expr for c in "+-*/"):
-            return [{"name": "calculator", "arguments": {"expression": expr}}]
+        for run in re.findall(r"[0-9.+\-*/()\s]{3,}", msg):
+            expr = run.strip()
+            if not any(c.isdigit() for c in expr):
+                continue
+            if not any(c in expr for c in "+-*/"):
+                continue
+            if "error" not in calculator(expr):
+                return [{"name": "calculator", "arguments": {"expression": expr}}]
         for token in msg.split():
             if any(c in token for c in "+-*/"):
                 return [{"name": "calculator", "arguments": {"expression": token}}]


### PR DESCRIPTION
## What this PR does

The demo query in `docs/en.md` returned a syntax error instead of a result.

## Kind of change

- [x] Fix to an existing lesson

## Checklist

- [x] Code runs without errors with the listed dependencies
- [x] No comments in code files
- [x] One lesson per commit
- [x] Tested locally / code output matches what `docs/en.md` claims

## Phase / lesson

Phase 11 · 09-function-calling

## Detail

In `simulate_model_decision`, the per-token scan ran before whole-expression extraction, so for a spaced expression the first token merely *containing* an operator won — the bare `+`. The whole-expression branch below it was unreachable.

```
  User: Calculate (100 + 250) * 0.15
    Result: {"error": true, "message": "unexpected EOF while parsing (<string>, line 1)"}
```

Extract the expression first, keep the token scan as fallback. The TypeScript port (`code/main.ts`) already does whole-match extraction, which is what confirmed the intent.

After:

```
'Calculate (100 + 250) * 0.15' -> 52.5
'What is 2+2'                  -> 4.0
'how much is 7 * 6'            -> 42.0
'calculate 10/4'               -> 2.5
'compute the total'            -> 0.0   (unchanged fallback)
```

Note: #338 also touches this file, but in `run_code` — no line overlap.
