### PR TITLE
fix(phase-11/10): eval verdict was nondeterministic

### DIFF
--- a/phases/11-llm-engineering/10-evaluation/code/eval_framework.py
+++ b/phases/11-llm-engineering/10-evaluation/code/eval_framework.py
@@ -128,7 +128,7 @@ def simulate_judge_score(input_text, model_output, reference_output, criterion):
         if keyword_overlap > 0.3:
             base_score = min(5, base_score + 1)
 
-    seed = hash(f"{input_text}{model_output}{criterion}") % 100
+    seed = int(hashlib.md5(f"{input_text}{model_output}{criterion}".encode()).hexdigest(), 16) % 100
     if seed < 15:
         base_score = max(1, base_score - 1)
     elif seed > 85:


### PR DESCRIPTION
## What this PR does

The eval suite gave different SHIP/BLOCK verdicts for the same inputs on every run.

## Kind of change

- [x] Fix to an existing lesson

## Checklist

- [x] Code runs without errors with the listed dependencies
- [x] No comments in code files
- [x] One lesson per commit
- [x] Tested locally / code output matches what `docs/en.md` claims

## Phase / lesson

Phase 11 · 10-evaluation

## Detail

The judge's score jitter is seeded from `hash(f"{input_text}{model_output}{criterion}")`. `hash()` of a `str` is salted per interpreter process, so seeding *from the content* — whose only purpose is stability — produced a different verdict each run.

Six runs of the unmodified file:

```
   4   Decision: BLOCK
   6   Decision: SHIP
```

`docs/en.md` sells this as deterministic assertion checks plus regression testing, and `bootstrap_confidence_interval` a few lines below hand-rolls an LCG for exactly this reason — so reproducibility was clearly the intent.

Seeded from `hashlib.md5` instead (already imported). After — six runs, one verdict, and byte-identical output:

```
   6   Decision: SHIP

$ for i in 1 2 3; do python3 eval_framework.py | md5; done
daa6ee863adcc81bb62147aae24794bc
daa6ee863adcc81bb62147aae24794bc
daa6ee863adcc81bb62147aae24794bc
```
