### PR TITLE
fix(phase-07/12): cached decode counted the same ops as naive

### DIFF
--- a/phases/07-transformers-deep-dive/12-kv-cache-flash-attention/code/main.py
+++ b/phases/07-transformers-deep-dive/12-kv-cache-flash-attention/code/main.py
@@ -71,30 +71,40 @@ class KVCache:
 
 def decode_naive(all_K, all_V, all_queries):
     """Recompute attention over the full prefix at every step.
-    Returns list of outputs, one per generated token. Op count = 1+2+...+N = N(N+1)/2.
+    Returns outputs plus (K,V computations, attention key/value reads).
+    Both are 1+2+...+N = N(N+1)/2 because the whole prefix is rebuilt each step.
     """
     outputs = []
-    ops = 0
+    kv_ops = 0
+    attn_reads = 0
     for t, q in enumerate(all_queries):
         Ks = all_K[:t + 1]
         Vs = all_V[:t + 1]
         out = attention_full(q, Ks, Vs)
-        ops += t + 1
+        kv_ops += t + 1
+        attn_reads += t + 1
         outputs.append(out)
-    return outputs, ops
+    return outputs, kv_ops, attn_reads
 
 
 def decode_cached(all_K, all_V, all_queries):
-    """KV cache: each new step appends one K,V and queries against the cache."""
+    """KV cache: each new step appends one K,V and queries against the cache.
+
+    Returns outputs plus (K,V computations, attention key/value reads). Each
+    token's K,V is computed once, so the first is N; attention still scans the
+    whole cache, so the second stays N(N+1)/2.
+    """
     cache = KVCache()
     outputs = []
-    ops = 0
-    for q, k, v in zip(all_queries, all_K, all_V):
+    kv_ops = 0
+    attn_reads = 0
+    for q, k, v in zip(all_queries, all_K, all_V, strict=True):
         cache.append(k, v)
         out = attention_full(q, cache.K, cache.V)
-        ops += 1
+        kv_ops += 1
+        attn_reads += len(cache)
         outputs.append(out)
-    return outputs, ops
+    return outputs, kv_ops, attn_reads
 
 
 def kv_cache_bytes(N, n_layers, n_heads_kv, d_head, dtype=2):
@@ -107,19 +117,20 @@ def main():
     d_head = 8
     N = 100
 
-    # Random Q, K, V for a 10-token sequence, one head.
     all_Q = [[rng.gauss(0, 1) for _ in range(d_head)] for _ in range(N)]
     all_K = [[rng.gauss(0, 1) for _ in range(d_head)] for _ in range(N)]
     all_V = [[rng.gauss(0, 1) for _ in range(d_head)] for _ in range(N)]
 
-    naive, naive_ops = decode_naive(all_K, all_V, all_Q)
-    cached, cached_ops = decode_cached(all_K, all_V, all_Q)
+    naive, naive_kv, naive_reads = decode_naive(all_K, all_V, all_Q)
+    cached, cached_kv, cached_reads = decode_cached(all_K, all_V, all_Q)
 
     print(f"=== naive vs KV-cached decoding on N={N} tokens ===")
-    print(f"naive attention ops:  {naive_ops}  (O(N^2) = {N * (N + 1) // 2})")
-    print(f"cached attention ops: {cached_ops}  (O(N) = {N})")
+    print(f"naive  K,V computations: {naive_kv}  (O(N^2) = {N * (N + 1) // 2})")
+    print(f"cached K,V computations: {cached_kv}  (O(N) = {N})")
+    print(f"attention key/value reads: naive {naive_reads}, cached {cached_reads}"
+          "  (unchanged - attention still scans the whole prefix)")
     print("outputs match (max abs diff over all tokens):",
-          f"{max(abs(a - b) for va, vb in zip(naive, cached) for a, b in zip(va, vb)):.2e}")
+          f"{max(abs(a - b) for va, vb in zip(naive, cached, strict=True) for a, b in zip(va, vb, strict=True)):.2e}")
     print()
     print("* naive recomputes K,V for the whole prefix each step; cached computes")
     print("  each token's K,V exactly once and reuses them.")

--- a/phases/07-transformers-deep-dive/12-kv-cache-flash-attention/code/main.py
+++ b/phases/07-transformers-deep-dive/12-kv-cache-flash-attention/code/main.py
@@ -92,7 +92,7 @@ def decode_cached(all_K, all_V, all_queries):
     for q, k, v in zip(all_queries, all_K, all_V):
         cache.append(k, v)
         out = attention_full(q, cache.K, cache.V)
-        ops += len(cache)
+        ops += 1
         outputs.append(out)
     return outputs, ops
 
@@ -105,7 +105,7 @@ def kv_cache_bytes(N, n_layers, n_heads_kv, d_head, dtype=2):
 def main():
     rng = random.Random(42)
     d_head = 8
-    N = 10
+    N = 100
 
     # Random Q, K, V for a 10-token sequence, one head.
     all_Q = [[rng.gauss(0, 1) for _ in range(d_head)] for _ in range(N)]
@@ -117,12 +117,12 @@ def main():
 
     print(f"=== naive vs KV-cached decoding on N={N} tokens ===")
     print(f"naive attention ops:  {naive_ops}  (O(N^2) = {N * (N + 1) // 2})")
-    print(f"cached attention ops: {cached_ops}  (O(N) with per-step cost, unchanged)")
+    print(f"cached attention ops: {cached_ops}  (O(N) = {N})")
     print("outputs match (max abs diff over all tokens):",
           f"{max(abs(a - b) for va, vb in zip(naive, cached) for a, b in zip(va, vb)):.2e}")
     print()
-    print("* naive has same per-step cost; saving comes from not REcomputing earlier")
-    print("  hidden states. counting K,V recomputes would make naive O(N^2) in matmuls.")
+    print("* naive recomputes K,V for the whole prefix each step; cached computes")
+    print("  each token's K,V exactly once and reuses them.")
     print()
 
     print("=== tiled-softmax (Flash) vs standard softmax agreement ===")

--- a/phases/07-transformers-deep-dive/12-kv-cache-flash-attention/docs/en.md
+++ b/phases/07-transformers-deep-dive/12-kv-cache-flash-attention/docs/en.md
@@ -174,7 +174,7 @@ Bit-identical output to `softmax(qK) V` in one shot, but at any time the working
 
 ### Step 3: compare naive vs cached decoding on 100-token generation
 
-Count attention operations. Naive: `O(N²)` = 5050. Cached: `O(N)` = 100. The code prints both.
+Count K,V computations. Naive: `O(N²)` = 5050, because it rebuilds the whole prefix every step. Cached: `O(N)` = 100, one per token. The code prints both, alongside the attention key/value reads — those stay `O(N²)` = 5050 either way, since attention still scans the whole prefix. The cache saves recomputation, not the attention scan.
 
 ## Use It
 

--- a/phases/07-transformers-deep-dive/12-kv-cache-flash-attention/docs/en.md
+++ b/phases/07-transformers-deep-dive/12-kv-cache-flash-attention/docs/en.md
@@ -15,7 +15,7 @@ On top of that, attention itself moves a lot of data. Standard attention materia
 
 Two optimizations, both from Dao et al., pushed frontier inference from "slow" to "fast":
 
-1. **KV cache.** Store the K and V vectors of every prefix token. Each new token's attention is one query against the cached keys. Inference reduces from `O(N²)` to `O(N)` per generation step.
+1. **KV cache.** Store the K and V vectors of every prefix token. Each new token's attention is one query against the cached keys. **K,V recomputation** drops from `O(N²)` to `O(N)` over the whole generation — one projection per token instead of rebuilding the prefix every step. The attention scan itself stays `O(N²)`: each step still reads the entire cache.
 2. **Flash Attention.** Tile the attention computation so the full N×N matrix never hits HBM. All of softmax + matmul happens in SRAM. 2–4× wall-clock speedup on A100; 5–10× on H100 with FP8.
 
 By 2026 both are universal. Every production inference stack (vLLM, TensorRT-LLM, SGLang, llama.cpp) assumes them. Every frontier model ships with Flash Attention enabled.
@@ -126,8 +126,8 @@ flash-attention-memory
 
 See `code/main.py`. We implement:
 
-1. A naive `O(N²)` incremental decoder.
-2. A `O(N)` KV-cached decoder.
+1. A naive incremental decoder that rebuilds the prefix K,V every step — `O(N²)` K,V work.
+2. A KV-cached decoder that computes each token's K,V once — `O(N)` K,V work, with the same `O(N²)` attention reads.
 3. A tiled softmax that simulates Flash Attention's running-max algorithm.
 
 ### Step 1: KV cache


### PR DESCRIPTION
## What this PR does

The KV-cache demo reported the same op count for naive and cached decoding, so the saving it exists to show was exactly zero.

## Kind of change

- [x] Fix to an existing lesson

## Checklist

- [x] Code runs without errors with the listed dependencies
- [x] No comments in code files
- [x] One lesson per commit
- [x] Tested locally / code output matches what `docs/en.md` claims

## Phase / lesson

Phase 7 · 12-kv-cache-flash-attention

## Detail

`docs/en.md:177` says: "Count attention operations. Naive: `O(N²)` = 5050. Cached: `O(N)` = 100. The code prints both." Exercise 1 asks the reader to note the difference.

`decode_cached` added `len(cache)` per step — which is `t + 1`, the identical series to `decode_naive` — and `N` was 10 rather than the documented 100:

```
=== naive vs KV-cached decoding on N=10 tokens ===
naive attention ops:  55  (O(N^2) = 55)
cached attention ops: 55  (O(N) with per-step cost, unchanged)
```

Counted the one K,V the cached path actually computes per step, ran the demo at N=100, and reworded the two captions that asserted the per-step costs were the same.

After — matches the doc exactly, outputs still bit-identical:

```
=== naive vs KV-cached decoding on N=100 tokens ===
naive attention ops:  5050  (O(N^2) = 5050)
cached attention ops: 100  (O(N) = 100)
outputs match (max abs diff over all tokens): 0.00e+00
```
