### PR TITLE
fix(phase-16/03): ACP audit trail was always empty

### DIFF
--- a/phases/16-multi-agent-and-swarms/03-communication-protocols/code/main.ts
+++ b/phases/16-multi-agent-and-swarms/03-communication-protocols/code/main.ts
@@ -182,7 +182,7 @@ class TaskManager {
     task.history.push(message);
     task.status = { state: "submitted", timestamp: Date.now() };
 
-    this.processTask(task, handler, message).catch((err) => {
+    await this.processTask(task, handler, message).catch((err) => {
       task.status = {
         state: "failed",
         timestamp: Date.now(),
@@ -516,12 +516,12 @@ class ProtocolGateway {
       return { error: `Agent ${targetAgent} not found in registry` };
     }
 
+    const task = await this.taskManager.sendMessage(targetAgent, message);
     const audit = await this.auditRunner.run(
       targetAgent,
       [message],
       sessionId
     );
-    const task = await this.taskManager.sendMessage(targetAgent, message);
 
     return { task, audit };
   }


### PR DESCRIPTION
## What this PR does

The ACP audit trail in the protocol capstone was always empty, so the section of the demo that exists to show it printed nothing.

## Kind of change

- [x] Fix to an existing lesson

## Checklist

- [x] Code runs without errors with the listed dependencies
- [x] No comments in code files
- [x] One lesson per commit
- [x] Tested locally / code output matches what `docs/en.md` claims

## Phase / lesson

Phase 16 · 03-communication-protocols

## Detail

`docs/en.md` says every agent execution produces a full audit entry with "the complete trajectory of tool calls and reasoning steps in between", and that the gateway wraps the execution in an audit trail with trajectory.

Two causes, both required:

1. `sendMessage` fired `this.processTask(...)` without awaiting, so it returned before the handler ran.
2. `delegateTask` called `auditRunner.run(...)` **before** dispatching, so `structuredClone(result.trajectory)` snapshotted an array the handler had not filled yet.

Before:

```
   Task state: working
   Artifacts: 0

4. Audit Trail (ACP)
   Trajectory steps: 0
```

After — await the handler, and audit after dispatch:

```
   Task state: completed
   Artifacts: 1

4. Audit Trail (ACP)
   Trajectory steps: 2
     - Searching for React 19 documentation
       Tool: web_search
     - Extracting key findings from search results
       Tool: doc_analysis
```

Verified with `node --experimental-strip-types code/main.ts`; the script exits 0 and the other sections are unchanged. Fixing only one of the two leaves `Trajectory steps: 0`.
