### PR TITLE
fix(phase-10/10): perplexity was different on every run

### DIFF
--- a/phases/10-llms-from-scratch/10-evaluation/code/main.py
+++ b/phases/10-llms-from-scratch/10-evaluation/code/main.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 from collections import Counter
 
@@ -110,7 +111,7 @@ def perplexity(log_probs):
 
 
 def token_log_probs_simulated(text, model_quality=0.8):
-    np.random.seed(hash(text) % 2**31)
+    np.random.seed(int(hashlib.sha256(text.encode()).hexdigest()[:8], 16) % 2**31)
     tokens = text.split()
     log_probs = []
     for i, token in enumerate(tokens):
@@ -188,7 +189,7 @@ def demo_model_bad(prompt):
 
 
 def demo_model_random(prompt):
-    np.random.seed(hash(prompt) % 2**31)
+    np.random.seed(int(hashlib.sha256(prompt.encode()).hexdigest()[:8], 16) % 2**31)
     words = ["yes", "no", "maybe", "42", "Paris", "unknown", "error"]
     return words[np.random.randint(len(words))]
 


### PR DESCRIPTION
## What this PR does

The evaluation lesson's perplexity numbers changed on every run, despite being explicitly seeded.

## Kind of change

- [x] Fix to an existing lesson

## Checklist

- [x] Code runs without errors with the listed dependencies
- [x] No comments in code files
- [x] One lesson per commit
- [x] Tested locally / code output matches what `docs/en.md` claims

## Phase / lesson

Phase 10 · 10-evaluation

## Detail

`token_log_probs_simulated` seeds from the text precisely so the same text yields the same simulated log-probs, and STEP 3 compares Strong / Medium / Weak on that basis. But `hash()` of a `str` is salted per interpreter process, so seeding *from the content* — whose only purpose is stability — produced different numbers each run.

Three consecutive runs of the unmodified file:

```
Strong model (quality=0.9): perplexity = 1.20
Strong model (quality=0.9): perplexity = 1.16
Strong model (quality=0.9): perplexity = 1.13
```

Seeded from `hashlib.sha256` instead. Two call sites use the same pattern and both are updated.

After — three runs, byte-identical output:

```
$ for i in 1 2 3; do python3 main.py | md5; done
c574f26767da2f723522af74a3436b92
c574f26767da2f723522af74a3436b92
c574f26767da2f723522af74a3436b92
```

The Strong < Medium < Weak ordering the lesson relies on is preserved: `1.13 / 1.44 / 2.52`.
