### PR TITLE
fix(phase-02/01): sharpen ML diagram labels

### DIFF
--- a/phases/02-ml-fundamentals/01-what-is-machine-learning/docs/en.md
+++ b/phases/02-ml-fundamentals/01-what-is-machine-learning/docs/en.md
@@ -29,6 +29,10 @@ This shift from "programming rules" to "learning from data" is the core of machi
 Traditional programming and machine learning solve problems in opposite directions.
 
 ```mermaid
+---
+config:
+  htmlLabels: false
+---
 flowchart LR
     subgraph Traditional["Traditional Programming"]
         direction LR


### PR DESCRIPTION
## Summary

Fixes #363.

The diagram is Mermaid SVG, not a low-resolution image. Its HTML-based labels
could appear soft or clipped when enlarged.

This change uses native SVG text for only the affected diagram, keeping labels
crisp in both normal and expanded views.

## Validation

- `git diff --check`
- `python -B scripts\audit_lessons.py` — 503 lessons, 0 issues

## Screenshots

### After — normal view
[drag screenshot here]

### After — expanded view
<img width="1917" height="915" alt="Screenshot 2026-07-27 083123" src="https://github.com/user-attachments/assets/5d09a499-b3cf-4f07-b338-b75d3a956b35" />
