### PR TITLE
chore: remove unused subprocess import

### DIFF
--- a/phases/00-setup-and-tooling/01-dev-environment/code/verify.py
+++ b/phases/00-setup-and-tooling/01-dev-environment/code/verify.py
@@ -1,6 +1,5 @@
 import sys
 import shutil
-import subprocess
 
 CHECKS = [
     ("Python 3.10+", lambda: sys.version_info >= (3, 10), f"Python {sys.version}"),


### PR DESCRIPTION
<!-- Thanks for contributing. Fill out what applies. Delete sections that don't. -->

## What this PR does

Removes the unused `subprocess` import from the environment check script.

## Kind of change

- [ ] New lesson
- [ ] Fix to an existing lesson
- [ ] Translation
- [ ] New output (prompt, skill, agent, MCP server)
- [x] Docs / website / tooling

## Checklist

- [x] Code runs without errors with the listed dependencies
- [x] No comments in code files (docs explain, code is self-explanatory)
- [ ] Built from scratch first, then shown with a framework (for new lessons)
- [ ] Lesson folder matches `LESSON_TEMPLATE.md` structure
- [ ] ROADMAP.md row for the lesson is a markdown link (`[Name](phases/...)`), not bare text
- [ ] One lesson per commit (atomic per-lesson rule)
- [x] Tested locally / code output matches what `docs/en.md` claims

## Phase / lesson

00-setup-and-tooling/01-dev-environment

## Notes for reviewer

No functional changes.
