### PR TITLE
Fix/randomize quiz answers

### DIFF
--- a/phases/00-setup-and-tooling/03-gpu-setup-and-cloud/quiz.json
+++ b/phases/00-setup-and-tooling/03-gpu-setup-and-cloud/quiz.json
@@ -3,35 +3,60 @@
     {
       "stage": "pre",
       "question": "Why is a GPU faster than a CPU for training neural networks?",
-      "options": ["GPUs have higher clock speeds than CPUs", "GPUs can perform thousands of parallel matrix operations simultaneously", "GPUs have more RAM than CPUs", "GPUs use a more efficient programming language"],
+      "options": [
+        "GPUs have higher clock speeds than CPUs",
+        "GPUs can perform thousands of parallel matrix operations simultaneously",
+        "GPUs have more RAM than CPUs",
+        "GPUs use a more efficient programming language"
+      ],
       "correct": 1,
       "explanation": "GPUs have thousands of cores optimized for parallel computation, making them ideal for the matrix multiplications that dominate neural network training."
     },
     {
       "stage": "pre",
       "question": "What does VRAM refer to?",
-      "options": ["Virtual RAM used by the operating system for swap space", "Video RAM on the GPU, separate from system RAM", "The total RAM available across all devices", "A type of CPU cache memory"],
-      "correct": 1,
+      "options": [
+        "Video RAM on the GPU, separate from system RAM",
+        "Virtual RAM used by the operating system for swap space",
+        "The total RAM available across all devices",
+        "A type of CPU cache memory"
+      ],
+      "correct": 0,
       "explanation": "VRAM (Video RAM) is the dedicated memory on a GPU. It limits the size of models and batch sizes you can use during training, separate from your system's main RAM."
     },
     {
       "stage": "post",
       "question": "What command verifies that your NVIDIA GPU is detected and shows its current status?",
-      "options": ["gpu --status", "nvidia-smi", "torch.cuda.list_devices()", "lspci | grep gpu"],
-      "correct": 1,
+      "options": [
+        "gpu --status",
+        "torch.cuda.list_devices()",
+        "nvidia-smi",
+        "lspci | grep gpu"
+      ],
+      "correct": 2,
       "explanation": "nvidia-smi (NVIDIA System Management Interface) displays GPU utilization, memory usage, temperature, and running processes. It is the standard tool for verifying GPU availability."
     },
     {
       "stage": "post",
       "question": "When benchmarking GPU vs CPU matrix multiplication, why must you call torch.cuda.synchronize() before measuring GPU time?",
-      "options": ["To transfer data from CPU to GPU memory", "To ensure all GPU operations have completed before stopping the timer", "To reset the GPU clock speed to its base frequency", "To free unused GPU memory"],
-      "correct": 1,
+      "options": [
+        "To transfer data from CPU to GPU memory",
+        "To free unused GPU memory",
+        "To reset the GPU clock speed to its base frequency",
+        "To ensure all GPU operations have completed before stopping the timer"
+      ],
+      "correct": 3,
       "explanation": "GPU operations are asynchronous -- Python returns immediately while the GPU is still computing. synchronize() blocks until all GPU operations finish, giving accurate timing."
     },
     {
       "stage": "post",
       "question": "Using the fp16 rule of thumb, approximately how many parameters can fit in 24 GB of VRAM?",
-      "options": ["24 billion parameters", "12 billion parameters", "6 billion parameters", "48 billion parameters"],
+      "options": [
+        "24 billion parameters",
+        "12 billion parameters",
+        "6 billion parameters",
+        "48 billion parameters"
+      ],
       "correct": 1,
       "explanation": "In fp16, each parameter uses 2 bytes. 24 GB / 2 bytes = 12 billion parameters. This is a rough estimate; actual usage includes activations, gradients, and optimizer states."
     }

--- a/phases/00-setup-and-tooling/04-apis-and-keys/quiz.json
+++ b/phases/00-setup-and-tooling/04-apis-and-keys/quiz.json
@@ -3,35 +3,60 @@
     {
       "stage": "pre",
       "question": "What is an API key used for when calling an LLM service?",
-      "options": ["Encrypting the data sent to the server", "Authenticating your identity and authorizing requests", "Compressing requests to reduce bandwidth", "Selecting which programming language the server uses"],
+      "options": [
+        "Encrypting the data sent to the server",
+        "Authenticating your identity and authorizing requests",
+        "Compressing requests to reduce bandwidth",
+        "Selecting which programming language the server uses"
+      ],
       "correct": 1,
       "explanation": "An API key is a unique string that identifies your account, authorizes your requests, and allows the provider to track usage and billing."
     },
     {
       "stage": "pre",
       "question": "Why should API keys never be hardcoded directly in source code?",
-      "options": ["Hardcoded keys make the code run slower", "They can be accidentally committed to git and exposed publicly", "Python cannot read string literals longer than 50 characters", "API providers block keys that appear in source files"],
-      "correct": 1,
+      "options": [
+        "They can be accidentally committed to git and exposed publicly",
+        "Hardcoded keys make the code run slower",
+        "Python cannot read string literals longer than 50 characters",
+        "API providers block keys that appear in source files"
+      ],
+      "correct": 0,
       "explanation": "Hardcoded keys in source code risk being committed to version control and pushed to public repositories, where they can be scraped and abused by others."
     },
     {
       "stage": "post",
       "question": "What is the recommended way to store API keys for local development?",
-      "options": ["In a Python variable at the top of your script", "In a .env file that is listed in .gitignore", "In the README.md for easy access", "In the requirements.txt alongside package versions"],
-      "correct": 1,
+      "options": [
+        "In a Python variable at the top of your script",
+        "In the README.md for easy access",
+        "In a .env file that is listed in .gitignore",
+        "In the requirements.txt alongside package versions"
+      ],
+      "correct": 2,
       "explanation": "A .env file stores keys as environment variables and should be added to .gitignore so it is never committed to version control. SDKs read keys from environment variables automatically."
     },
     {
       "stage": "post",
       "question": "In the raw HTTP API call to Anthropic, which header carries the API key?",
-      "options": ["Authorization: Bearer sk-ant-...", "x-api-key: sk-ant-...", "Content-Type: application/json", "anthropic-version: 2023-06-01"],
-      "correct": 1,
+      "options": [
+        "Authorization: Bearer sk-ant-...",
+        "anthropic-version: 2023-06-01",
+        "Content-Type: application/json",
+        "x-api-key: sk-ant-..."
+      ],
+      "correct": 3,
       "explanation": "Anthropic's API uses the 'x-api-key' header for authentication, not the more common 'Authorization: Bearer' pattern. This is specific to their API design."
     },
     {
       "stage": "post",
       "question": "What happens when you exceed an API's rate limit?",
-      "options": ["Your API key is permanently revoked", "The server returns an error (typically HTTP 429) and you must wait before retrying", "Your request is queued and processed later automatically", "The API silently drops your request with no response"],
+      "options": [
+        "Your API key is permanently revoked",
+        "The server returns an error (typically HTTP 429) and you must wait before retrying",
+        "Your request is queued and processed later automatically",
+        "The API silently drops your request with no response"
+      ],
       "correct": 1,
       "explanation": "Rate limiting returns HTTP 429 (Too Many Requests). You need to wait and retry, typically with exponential backoff. Rate limits prevent abuse and ensure fair usage."
     }

--- a/phases/00-setup-and-tooling/05-jupyter-notebooks/quiz.json
+++ b/phases/00-setup-and-tooling/05-jupyter-notebooks/quiz.json
@@ -3,35 +3,60 @@
     {
       "stage": "pre",
       "question": "What is a Jupyter notebook?",
-      "options": ["A text editor for writing Python scripts", "An interactive document that mixes executable code cells with markdown text and inline outputs", "A version control system for data science projects", "A package manager for Python libraries"],
+      "options": [
+        "A text editor for writing Python scripts",
+        "An interactive document that mixes executable code cells with markdown text and inline outputs",
+        "A version control system for data science projects",
+        "A package manager for Python libraries"
+      ],
       "correct": 1,
       "explanation": "A Jupyter notebook (.ipynb) is an interactive environment where you can write and execute code in cells, see outputs inline, and mix code with formatted text explanations."
     },
     {
       "stage": "pre",
       "question": "What does the Jupyter kernel do?",
-      "options": ["Formats markdown cells into HTML", "Runs the code in cells and keeps variables in memory between executions", "Manages file storage for the notebook", "Connects the notebook to GitHub for version control"],
-      "correct": 1,
+      "options": [
+        "Runs the code in cells and keeps variables in memory between executions",
+        "Formats markdown cells into HTML",
+        "Manages file storage for the notebook",
+        "Connects the notebook to GitHub for version control"
+      ],
+      "correct": 0,
       "explanation": "The kernel is a separate Python process that executes cell code and maintains state (variables, imports) in memory. All cells in a notebook share the same kernel."
     },
     {
       "stage": "post",
       "question": "What is the difference between %timeit and %%time magic commands?",
-      "options": ["%timeit measures wall time, %%time measures CPU time", "%timeit runs code many times and averages, %%time runs code once", "%timeit works on single lines, %%time works on the whole notebook", "There is no difference, they are aliases"],
-      "correct": 1,
+      "options": [
+        "%timeit measures wall time, %%time measures CPU time",
+        "%timeit works on single lines, %%time works on the whole notebook",
+        "%timeit runs code many times and averages, %%time runs code once",
+        "There is no difference, they are aliases"
+      ],
+      "correct": 2,
       "explanation": "%timeit runs the statement many times for a statistical average (good for microbenchmarks). %%time runs the cell once and reports wall time (good for training runs)."
     },
     {
       "stage": "post",
       "question": "What is the most common cause of a notebook working on your machine but failing when someone runs it top to bottom?",
-      "options": ["Using a different Python version", "Out-of-order cell execution creating hidden dependencies on execution order", "Missing the %matplotlib inline magic command", "Using too many markdown cells"],
-      "correct": 1,
+      "options": [
+        "Using a different Python version",
+        "Using too many markdown cells",
+        "Missing the %matplotlib inline magic command",
+        "Out-of-order cell execution creating hidden dependencies on execution order"
+      ],
+      "correct": 3,
       "explanation": "Running cells out of order creates hidden state dependencies. A variable might exist because you ran cell 5 before cell 2. Kernel > Restart & Run All verifies linear execution."
     },
     {
       "stage": "post",
       "question": "When should you move code from a notebook into a .py script?",
-      "options": ["As soon as you write more than 10 lines of code", "When the code is a reusable utility, training pipeline, or production code", "Never -- notebooks are always better for AI work", "Only when you need to run on a GPU"],
+      "options": [
+        "As soon as you write more than 10 lines of code",
+        "When the code is a reusable utility, training pipeline, or production code",
+        "Never -- notebooks are always better for AI work",
+        "Only when you need to run on a GPU"
+      ],
       "correct": 1,
       "explanation": "The rule is 'explore in notebooks, ship in scripts.' Reusable utilities, training pipelines, and anything running in production should be .py files. Notebooks are for exploration and prototyping."
     }

--- a/phases/00-setup-and-tooling/06-python-environments/quiz.json
+++ b/phases/00-setup-and-tooling/06-python-environments/quiz.json
@@ -3,35 +3,60 @@
     {
       "stage": "pre",
       "question": "What problem do virtual environments solve?",
-      "options": ["They make Python code run faster by optimizing the interpreter", "They isolate project dependencies so different projects can use different package versions", "They provide a graphical interface for managing Python scripts", "They automatically update packages to the latest versions"],
+      "options": [
+        "They make Python code run faster by optimizing the interpreter",
+        "They isolate project dependencies so different projects can use different package versions",
+        "They provide a graphical interface for managing Python scripts",
+        "They automatically update packages to the latest versions"
+      ],
       "correct": 1,
       "explanation": "Virtual environments give each project its own isolated set of packages. Without them, installing PyTorch 2.4 for one project would overwrite PyTorch 2.1 needed by another."
     },
     {
       "stage": "pre",
       "question": "What is a lockfile in the context of Python dependency management?",
-      "options": ["A file that prevents other users from editing your code", "A file that pins every package to an exact version for reproducible installs", "A file that locks the Python interpreter version", "A file that encrypts your project dependencies"],
-      "correct": 1,
+      "options": [
+        "A file that pins every package to an exact version for reproducible installs",
+        "A file that prevents other users from editing your code",
+        "A file that locks the Python interpreter version",
+        "A file that encrypts your project dependencies"
+      ],
+      "correct": 0,
       "explanation": "A lockfile records the exact version of every package (including transitive dependencies) so anyone installing from it gets identical packages, ensuring reproducibility."
     },
     {
       "stage": "post",
       "question": "How can you verify that your pip and python commands are using the virtual environment and not the system Python?",
-      "options": ["Run 'pip --version' and check the version number", "Run 'which python' and confirm it shows .venv/bin/python, not /usr/bin/python", "Check if the terminal background color has changed", "Run 'python --check-env' to verify"],
-      "correct": 1,
+      "options": [
+        "Run 'pip --version' and check the version number",
+        "Check if the terminal background color has changed",
+        "Run 'which python' and confirm it shows .venv/bin/python, not /usr/bin/python",
+        "Run 'python --check-env' to verify"
+      ],
+      "correct": 2,
       "explanation": "'which python' (or 'where python' on Windows) shows the full path to the interpreter. If it points to .venv/bin/python, you are in the virtual environment."
     },
     {
       "stage": "post",
       "question": "Why is mixing pip and conda in the same environment problematic?",
-      "options": ["Pip packages are incompatible with conda's Python interpreter", "Pip installs can break conda's dependency tracking, causing hard-to-debug conflicts", "Conda cannot install packages that pip has already installed", "It doubles the disk space used by every package"],
-      "correct": 1,
+      "options": [
+        "Pip packages are incompatible with conda's Python interpreter",
+        "It doubles the disk space used by every package",
+        "Conda cannot install packages that pip has already installed",
+        "Pip installs can break conda's dependency tracking, causing hard-to-debug conflicts"
+      ],
+      "correct": 3,
       "explanation": "Conda maintains its own dependency solver. Pip installs bypass it, so conda no longer knows the true state of the environment. This leads to dependency conflicts that are painful to resolve."
     },
     {
       "stage": "post",
       "question": "Your PyTorch code reports 'CUDA not available' despite having an NVIDIA GPU. What is the most likely cause?",
-      "options": ["Your GPU does not support CUDA", "PyTorch was installed with a CUDA version incompatible with your GPU driver", "You forgot to import the torch.cuda module", "Virtual environments cannot access GPU hardware"],
+      "options": [
+        "Your GPU does not support CUDA",
+        "PyTorch was installed with a CUDA version incompatible with your GPU driver",
+        "You forgot to import the torch.cuda module",
+        "Virtual environments cannot access GPU hardware"
+      ],
       "correct": 1,
       "explanation": "PyTorch ships CUDA bindings compiled for specific CUDA versions. If the PyTorch CUDA version exceeds your driver's CUDA version, CUDA will not be available. Check with nvidia-smi and torch.version.cuda."
     }

--- a/phases/00-setup-and-tooling/07-docker-for-ai/quiz.json
+++ b/phases/00-setup-and-tooling/07-docker-for-ai/quiz.json
@@ -3,35 +3,60 @@
     {
       "stage": "pre",
       "question": "What is the primary difference between a Docker container and a virtual machine?",
-      "options": ["Containers are slower but more secure than VMs", "Containers share the host OS kernel while VMs run their own full OS", "Containers can only run Linux while VMs support any OS", "There is no practical difference"],
+      "options": [
+        "Containers are slower but more secure than VMs",
+        "Containers share the host OS kernel while VMs run their own full OS",
+        "Containers can only run Linux while VMs support any OS",
+        "There is no practical difference"
+      ],
       "correct": 1,
       "explanation": "Containers share the host kernel and isolate at the process level, making them start in seconds. VMs run a complete guest OS with its own kernel, requiring more resources and slower startup."
     },
     {
       "stage": "pre",
       "question": "What is a Dockerfile?",
-      "options": ["A configuration file for the Docker daemon", "A set of instructions for building a Docker image layer by layer", "A log file that records container activity", "A file that lists running containers"],
-      "correct": 1,
+      "options": [
+        "A set of instructions for building a Docker image layer by layer",
+        "A configuration file for the Docker daemon",
+        "A log file that records container activity",
+        "A file that lists running containers"
+      ],
+      "correct": 0,
       "explanation": "A Dockerfile contains sequential instructions (FROM, RUN, COPY, etc.) that Docker executes to build an image. Each instruction creates a cached layer."
     },
     {
       "stage": "post",
       "question": "Why are volume mounts critical for AI development with Docker?",
-      "options": ["Volumes make containers run faster by using host disk speed", "Volumes persist data (models, datasets, code) across container rebuilds so you don't re-download gigabytes each time", "Volumes are required for Python packages to install correctly", "Volumes allow multiple containers to share the same GPU"],
-      "correct": 1,
+      "options": [
+        "Volumes make containers run faster by using host disk speed",
+        "Volumes are required for Python packages to install correctly",
+        "Volumes persist data (models, datasets, code) across container rebuilds so you don't re-download gigabytes each time",
+        "Volumes allow multiple containers to share the same GPU"
+      ],
+      "correct": 2,
       "explanation": "Without volumes, everything inside a container is lost when it stops. Volume mounts map host directories into the container, so model weights (14+ GB) and datasets survive rebuilds."
     },
     {
       "stage": "post",
       "question": "What does the NVIDIA Container Toolkit enable?",
-      "options": ["Installing CUDA drivers inside the container", "Exposing host GPUs to Docker containers via the --gpus flag", "Running NVIDIA GPU containers on AMD hardware", "Compiling CUDA code during the Docker build process"],
-      "correct": 1,
+      "options": [
+        "Installing CUDA drivers inside the container",
+        "Compiling CUDA code during the Docker build process",
+        "Running NVIDIA GPU containers on AMD hardware",
+        "Exposing host GPUs to Docker containers via the --gpus flag"
+      ],
+      "correct": 3,
       "explanation": "The NVIDIA Container Toolkit is a runtime hook that exposes host GPUs to containers. The CUDA toolkit lives inside the container, but the GPU driver is shared from the host."
     },
     {
       "stage": "post",
       "question": "In a Docker Compose file for AI, how does the 'ai-dev' service reach the 'qdrant' vector database?",
-      "options": ["By using the host machine's IP address and port", "By using the service name 'qdrant' as the hostname, since Compose creates a shared network", "By mounting a shared volume between the two containers", "By configuring a VPN between the containers"],
+      "options": [
+        "By using the host machine's IP address and port",
+        "By using the service name 'qdrant' as the hostname, since Compose creates a shared network",
+        "By mounting a shared volume between the two containers",
+        "By configuring a VPN between the containers"
+      ],
       "correct": 1,
       "explanation": "Docker Compose automatically creates a shared network where services can reach each other by name. The ai-dev container connects to 'http://qdrant:6333' using the service name as hostname."
     }

--- a/phases/00-setup-and-tooling/10-terminal-and-shell/quiz.json
+++ b/phases/00-setup-and-tooling/10-terminal-and-shell/quiz.json
@@ -3,35 +3,60 @@
     {
       "stage": "pre",
       "question": "What does the pipe operator '|' do in a shell command?",
-      "options": ["Runs two commands in parallel", "Sends the standard output of one command as standard input to the next", "Saves the output of a command to a file", "Combines two files into one"],
+      "options": [
+        "Runs two commands in parallel",
+        "Sends the standard output of one command as standard input to the next",
+        "Saves the output of a command to a file",
+        "Combines two files into one"
+      ],
       "correct": 1,
       "explanation": "The pipe operator connects commands in a pipeline. For example, 'cat log.txt | grep error' sends the contents of log.txt as input to grep, which filters for lines containing 'error'."
     },
     {
       "stage": "pre",
       "question": "What happens to a running process when you close the terminal that started it?",
-      "options": ["The process continues running in the background", "The process receives a hangup signal (SIGHUP) and typically terminates", "The process pauses until you open a new terminal", "The process automatically migrates to a system service"],
-      "correct": 1,
+      "options": [
+        "The process receives a hangup signal (SIGHUP) and typically terminates",
+        "The process continues running in the background",
+        "The process pauses until you open a new terminal",
+        "The process automatically migrates to a system service"
+      ],
+      "correct": 0,
       "explanation": "Closing the terminal sends SIGHUP to child processes, which causes them to terminate by default. Tools like tmux, nohup, or screen prevent this."
     },
     {
       "stage": "post",
       "question": "What is the key advantage of tmux over using 'nohup command &' for long-running training jobs?",
-      "options": ["tmux uses less CPU than nohup", "tmux lets you detach, reattach, and see live output with multiple panes", "tmux automatically restarts failed processes", "tmux compresses the process output to save disk space"],
-      "correct": 1,
+      "options": [
+        "tmux uses less CPU than nohup",
+        "tmux automatically restarts failed processes",
+        "tmux lets you detach, reattach, and see live output with multiple panes",
+        "tmux compresses the process output to save disk space"
+      ],
+      "correct": 2,
       "explanation": "tmux creates persistent sessions you can detach from and reattach to later, with live output visible in multiple panes. nohup only logs to a file with no way to interact or reattach."
     },
     {
       "stage": "post",
       "question": "What does 'python train.py > output.log 2>&1' accomplish?",
-      "options": ["Runs train.py and saves only errors to output.log", "Runs train.py and redirects both standard output and standard error to output.log", "Runs train.py twice and logs the second run", "Runs train.py with double the memory allocation"],
-      "correct": 1,
+      "options": [
+        "Runs train.py and saves only errors to output.log",
+        "Runs train.py with double the memory allocation",
+        "Runs train.py twice and logs the second run",
+        "Runs train.py and redirects both standard output and standard error to output.log"
+      ],
+      "correct": 3,
       "explanation": "'> output.log' redirects stdout to the file. '2>&1' sends stderr to the same place as stdout. The result is both normal output and errors captured in one file."
     },
     {
       "stage": "post",
       "question": "Which command lets you access a remote Jupyter notebook running on port 8888 of a GPU box from your local browser?",
-      "options": ["scp -P 8888 user@gpu-box:~/notebook.ipynb", "ssh -L 8888:localhost:8888 user@gpu-box", "rsync -avz user@gpu-box:8888 localhost:8888", "ssh user@gpu-box --forward-port 8888"],
+      "options": [
+        "scp -P 8888 user@gpu-box:~/notebook.ipynb",
+        "ssh -L 8888:localhost:8888 user@gpu-box",
+        "rsync -avz user@gpu-box:8888 localhost:8888",
+        "ssh user@gpu-box --forward-port 8888"
+      ],
       "correct": 1,
       "explanation": "SSH local port forwarding (-L) maps a remote port to your local machine. After this command, opening localhost:8888 in your browser accesses the remote Jupyter server."
     }

--- a/phases/00-setup-and-tooling/11-linux-for-ai/quiz.json
+++ b/phases/00-setup-and-tooling/11-linux-for-ai/quiz.json
@@ -3,35 +3,60 @@
     {
       "stage": "pre",
       "question": "What does the '~' symbol represent in a Linux file path?",
-      "options": ["The root directory of the file system", "The current user's home directory", "The temporary files directory", "The directory where system programs are installed"],
+      "options": [
+        "The root directory of the file system",
+        "The current user's home directory",
+        "The temporary files directory",
+        "The directory where system programs are installed"
+      ],
       "correct": 1,
       "explanation": "The tilde (~) is a shortcut for the current user's home directory, typically /home/username on Linux. 'cd ~' takes you home from anywhere."
     },
     {
       "stage": "pre",
       "question": "What is the purpose of 'sudo' before a command?",
-      "options": ["It speeds up the command execution", "It runs the command with root (administrator) privileges", "It runs the command in a sandboxed environment", "It logs the command output to a system file"],
-      "correct": 1,
+      "options": [
+        "It runs the command with root (administrator) privileges",
+        "It speeds up the command execution",
+        "It runs the command in a sandboxed environment",
+        "It logs the command output to a system file"
+      ],
+      "correct": 0,
       "explanation": "sudo (superuser do) temporarily elevates your privileges to root level for a single command. Required for system-level operations like installing packages with apt."
     },
     {
       "stage": "post",
       "question": "You get 'Permission denied' when trying to run a shell script. What command fixes this?",
-      "options": ["sudo rm script.sh", "chmod +x script.sh", "chown root script.sh", "mv script.sh /usr/bin/"],
-      "correct": 1,
+      "options": [
+        "sudo rm script.sh",
+        "chown root script.sh",
+        "chmod +x script.sh",
+        "mv script.sh /usr/bin/"
+      ],
+      "correct": 2,
       "explanation": "chmod +x adds execute permission to the file. Without the execute bit set, the shell refuses to run the script even if you own it."
     },
     {
       "stage": "post",
       "question": "On a remote GPU box, your training data fills the disk. Which command shows the largest directories consuming space?",
-      "options": ["ls -la /", "du -h --max-depth=1 / | sort -hr | head -20", "cat /proc/meminfo", "free -h"],
-      "correct": 1,
+      "options": [
+        "ls -la /",
+        "free -h",
+        "cat /proc/meminfo",
+        "du -h --max-depth=1 / | sort -hr | head -20"
+      ],
+      "correct": 3,
       "explanation": "du -h shows disk usage per directory, --max-depth=1 limits to top-level directories, and sort -hr sorts by size in descending order. This reveals which directories are consuming the most space."
     },
     {
       "stage": "post",
       "question": "What is a key difference between the macOS and Linux versions of 'sed -i'?",
-      "options": ["Linux sed is faster than macOS sed", "macOS sed requires an empty string argument after -i ('sed -i \"\"'), while Linux does not", "Linux sed does not support regular expressions", "macOS sed cannot modify files in place"],
+      "options": [
+        "Linux sed is faster than macOS sed",
+        "macOS sed requires an empty string argument after -i ('sed -i \"\"'), while Linux does not",
+        "Linux sed does not support regular expressions",
+        "macOS sed cannot modify files in place"
+      ],
       "correct": 1,
       "explanation": "macOS uses BSD sed which requires 'sed -i \"\" pattern file', while Linux uses GNU sed which accepts 'sed -i pattern file'. This is a common gotcha when moving scripts between systems."
     }

--- a/phases/00-setup-and-tooling/12-debugging-and-profiling/quiz.json
+++ b/phases/00-setup-and-tooling/12-debugging-and-profiling/quiz.json
@@ -3,35 +3,60 @@
     {
       "stage": "pre",
       "question": "What makes debugging AI/ML code fundamentally different from debugging a typical web application?",
-      "options": ["AI code uses different programming languages", "AI bugs often don't crash -- they silently produce incorrect results with no error messages", "AI code cannot be debugged with standard tools like print statements", "AI code always requires a GPU to debug"],
+      "options": [
+        "AI code uses different programming languages",
+        "AI bugs often don't crash -- they silently produce incorrect results with no error messages",
+        "AI code cannot be debugged with standard tools like print statements",
+        "AI code always requires a GPU to debug"
+      ],
       "correct": 1,
       "explanation": "The worst AI bugs produce valid-looking output. A misconfigured training loop might run for hours without errors while the model learns nothing useful, unlike web apps that crash with stack traces."
     },
     {
       "stage": "pre",
       "question": "What does a profiler measure?",
-      "options": ["Whether the code produces correct output", "How much time and memory each part of the code consumes", "How many bugs exist in the codebase", "The code coverage of unit tests"],
-      "correct": 1,
+      "options": [
+        "How much time and memory each part of the code consumes",
+        "Whether the code produces correct output",
+        "How many bugs exist in the codebase",
+        "The code coverage of unit tests"
+      ],
+      "correct": 0,
       "explanation": "Profilers measure resource consumption -- execution time per function, memory allocation, and GPU utilization -- helping you find bottlenecks and optimize performance."
     },
     {
       "stage": "post",
       "question": "Your model achieves 99% accuracy on the test set. What AI-specific bug should you suspect first?",
-      "options": ["The model has too many parameters", "Data leakage -- test samples may have leaked into the training set", "The learning rate is too high", "The batch size is too large"],
-      "correct": 1,
+      "options": [
+        "The model has too many parameters",
+        "The learning rate is too high",
+        "Data leakage -- test samples may have leaked into the training set",
+        "The batch size is too large"
+      ],
+      "correct": 2,
       "explanation": "Suspiciously high accuracy often indicates data leakage -- overlap between training and test data, or features that contain the target label. Always check for train/test overlap."
     },
     {
       "stage": "post",
       "question": "What is the most common finding when profiling a training loop's time breakdown?",
-      "options": ["The backward pass takes 90% of the time", "Data loading takes more time than the forward and backward passes combined", "Writing logs takes the most time", "GPU memory allocation is the bottleneck"],
-      "correct": 1,
+      "options": [
+        "The backward pass takes 90% of the time",
+        "GPU memory allocation is the bottleneck",
+        "Writing logs takes the most time",
+        "Data loading takes more time than the forward and backward passes combined"
+      ],
+      "correct": 3,
       "explanation": "Data loading often takes 60%+ of training time when num_workers=0 in the DataLoader. The fix is setting num_workers > 0 to load data in parallel with GPU computation."
     },
     {
       "stage": "post",
       "question": "You see NaN loss at step 500. Which approach will help you find the root cause?",
-      "options": ["Restart training from scratch with a different random seed", "Use detect_nan to check for NaN/Inf in gradients and add breakpoint() at the failure point", "Increase the batch size to stabilize gradients", "Switch from Adam to SGD optimizer"],
+      "options": [
+        "Restart training from scratch with a different random seed",
+        "Use detect_nan to check for NaN/Inf in gradients and add breakpoint() at the failure point",
+        "Increase the batch size to stabilize gradients",
+        "Switch from Adam to SGD optimizer"
+      ],
       "correct": 1,
       "explanation": "First identify WHERE the NaN originates by checking gradients for each parameter. A conditional breakpoint at the NaN step lets you inspect tensor values interactively. Common causes: learning rate too high, log(0), or division by zero."
     }

--- a/phases/01-math-foundations/01-linear-algebra-intuition/quiz.json
+++ b/phases/01-math-foundations/01-linear-algebra-intuition/quiz.json
@@ -3,35 +3,60 @@
     {
       "stage": "pre",
       "question": "What does the dot product of two vectors measure?",
-      "options": ["The distance between the two vectors", "How similar or aligned the two vectors are", "The angle between the vectors in degrees", "The number of dimensions the vectors share"],
+      "options": [
+        "The distance between the two vectors",
+        "How similar or aligned the two vectors are",
+        "The angle between the vectors in degrees",
+        "The number of dimensions the vectors share"
+      ],
       "correct": 1,
       "explanation": "The dot product measures alignment: positive means same direction (similar), zero means perpendicular (unrelated), negative means opposite direction (dissimilar). This is the basis of similarity search in AI."
     },
     {
       "stage": "pre",
       "question": "In AI, what does 'embedding' refer to?",
-      "options": ["Inserting one model inside another", "A vector representation that captures the meaning of something (word, image, user)", "A technique for compressing model weights", "The process of converting code to machine instructions"],
-      "correct": 1,
+      "options": [
+        "A vector representation that captures the meaning of something (word, image, user)",
+        "Inserting one model inside another",
+        "A technique for compressing model weights",
+        "The process of converting code to machine instructions"
+      ],
+      "correct": 0,
       "explanation": "An embedding maps discrete objects (words, images, users) to continuous vectors in a high-dimensional space where similar items are close together. It is the bridge between real-world concepts and mathematical operations."
     },
     {
       "stage": "post",
       "question": "Three vectors v1=[1,0,0], v2=[0,1,0], v3=[2,1,0] are given. Are they linearly independent?",
-      "options": ["Yes, because there are three vectors in 3D space", "No, because v3 = 2*v1 + v2, so v3 is a linear combination of the others", "Yes, because none of the vectors are identical", "No, because they all have a zero component"],
-      "correct": 1,
+      "options": [
+        "Yes, because there are three vectors in 3D space",
+        "Yes, because none of the vectors are identical",
+        "No, because v3 = 2*v1 + v2, so v3 is a linear combination of the others",
+        "No, because they all have a zero component"
+      ],
+      "correct": 2,
       "explanation": "v3 = 2*v1 + v2, making the set linearly dependent. All three vectors lie in the xy-plane and cannot reach [0,0,1]. Despite having 3 vectors in 3D, they only span a 2D subspace."
     },
     {
       "stage": "post",
       "question": "What does the rank of a matrix tell you in the context of machine learning?",
-      "options": ["How fast the matrix can be multiplied", "The number of linearly independent columns, indicating how many dimensions of useful information it contains", "The maximum value in the matrix", "The number of non-zero entries in the matrix"],
-      "correct": 1,
+      "options": [
+        "How fast the matrix can be multiplied",
+        "The number of non-zero entries in the matrix",
+        "The maximum value in the matrix",
+        "The number of linearly independent columns, indicating how many dimensions of useful information it contains"
+      ],
+      "correct": 3,
       "explanation": "Rank equals the number of linearly independent columns. In ML, a rank-deficient feature matrix means redundant features, infinitely many weight solutions, and the need for regularization."
     },
     {
       "stage": "post",
       "question": "How does LoRA (Low-Rank Adaptation) use linear algebra to efficiently fine-tune large language models?",
-      "options": ["It removes unused rows from weight matrices to shrink the model", "It decomposes weight updates into two small low-rank matrices instead of updating the full weight matrix", "It converts all weights from float32 to int8", "It freezes the embedding layer and only trains the output head"],
+      "options": [
+        "It removes unused rows from weight matrices to shrink the model",
+        "It decomposes weight updates into two small low-rank matrices instead of updating the full weight matrix",
+        "It converts all weights from float32 to int8",
+        "It freezes the embedding layer and only trains the output head"
+      ],
       "correct": 1,
       "explanation": "LoRA decomposes a 4096x4096 weight update into two matrices of size 4096x16 and 16x4096 (rank-16), reducing trainable parameters from 16M to 131K by assuming updates live in a low-dimensional subspace."
     }

--- a/phases/01-math-foundations/02-vectors-matrices-operations/quiz.json
+++ b/phases/01-math-foundations/02-vectors-matrices-operations/quiz.json
@@ -3,35 +3,60 @@
     {
       "stage": "pre",
       "question": "For matrix multiplication (m x n) @ (n x p), what must be true about the dimensions?",
-      "options": ["m must equal p", "The inner dimensions n must match", "All dimensions must be equal", "m must be greater than p"],
+      "options": [
+        "m must equal p",
+        "The inner dimensions n must match",
+        "All dimensions must be equal",
+        "m must be greater than p"
+      ],
       "correct": 1,
       "explanation": "Matrix multiplication requires the number of columns in the first matrix (n) to equal the number of rows in the second matrix (n). The result has shape (m x p)."
     },
     {
       "stage": "pre",
       "question": "What is the identity matrix?",
-      "options": ["A matrix of all ones", "A square matrix with ones on the diagonal and zeros elsewhere that acts as the multiplicative identity", "A matrix where every element is unique", "The transpose of any given matrix"],
-      "correct": 1,
+      "options": [
+        "A square matrix with ones on the diagonal and zeros elsewhere that acts as the multiplicative identity",
+        "A matrix of all ones",
+        "A matrix where every element is unique",
+        "The transpose of any given matrix"
+      ],
+      "correct": 0,
       "explanation": "The identity matrix I has ones on the diagonal and zeros everywhere else. Multiplying any matrix by I returns the original matrix unchanged, like multiplying a number by 1."
     },
     {
       "stage": "post",
       "question": "What is the key difference between element-wise multiplication and matrix multiplication?",
-      "options": ["Element-wise is faster while matrix multiplication is more accurate", "Element-wise multiplies matching positions (same shape required), matrix multiplication takes dot products of rows and columns (inner dimensions must match)", "They produce the same result but use different notation", "Element-wise only works on vectors while matrix multiplication works on matrices"],
-      "correct": 1,
+      "options": [
+        "Element-wise is faster while matrix multiplication is more accurate",
+        "They produce the same result but use different notation",
+        "Element-wise multiplies matching positions (same shape required), matrix multiplication takes dot products of rows and columns (inner dimensions must match)",
+        "Element-wise only works on vectors while matrix multiplication works on matrices"
+      ],
+      "correct": 2,
       "explanation": "Element-wise (Hadamard) product multiplies corresponding elements and requires identical shapes. Matrix multiplication computes dot products between rows and columns with the rule (m,n)@(n,p)=(m,p)."
     },
     {
       "stage": "post",
       "question": "In the expression 'output = relu(W @ x + b)', what role does broadcasting play?",
-      "options": ["It broadcasts the computation across multiple GPUs", "It automatically stretches the bias vector b to match the shape of W @ x so they can be added", "It converts the data types of W and x to match", "It repeats the relu activation across all elements"],
-      "correct": 1,
+      "options": [
+        "It broadcasts the computation across multiple GPUs",
+        "It repeats the relu activation across all elements",
+        "It converts the data types of W and x to match",
+        "It automatically stretches the bias vector b to match the shape of W @ x so they can be added"
+      ],
+      "correct": 3,
       "explanation": "W @ x produces a column vector, and b is also a vector. Broadcasting stretches b across the batch dimension if needed, allowing element-wise addition without explicit shape matching."
     },
     {
       "stage": "post",
       "question": "What does a determinant of zero for a matrix indicate?",
-      "options": ["The matrix has all zero entries", "The matrix is singular: it crushes at least one dimension, cannot be inverted, and has no unique solution", "The matrix is the identity matrix", "The matrix performs a rotation"],
+      "options": [
+        "The matrix has all zero entries",
+        "The matrix is singular: it crushes at least one dimension, cannot be inverted, and has no unique solution",
+        "The matrix is the identity matrix",
+        "The matrix performs a rotation"
+      ],
       "correct": 1,
       "explanation": "A zero determinant means the transformation collapses space by at least one dimension (e.g., mapping 2D to a line). The matrix has no inverse, and linear systems using it have either no solution or infinitely many."
     }

--- a/phases/01-math-foundations/03-matrix-transformations/quiz.json
+++ b/phases/01-math-foundations/03-matrix-transformations/quiz.json
@@ -3,35 +3,60 @@
     {
       "stage": "pre",
       "question": "What is an eigenvector of a matrix?",
-      "options": ["The largest row in the matrix", "A vector that the matrix only scales (never rotates) when multiplied", "A vector perpendicular to all columns of the matrix", "The diagonal entries of the matrix expressed as a vector"],
+      "options": [
+        "The largest row in the matrix",
+        "A vector that the matrix only scales (never rotates) when multiplied",
+        "A vector perpendicular to all columns of the matrix",
+        "The diagonal entries of the matrix expressed as a vector"
+      ],
       "correct": 1,
       "explanation": "An eigenvector v satisfies Av = lambda*v, meaning the matrix A only stretches v by the scalar factor lambda (the eigenvalue) without changing its direction."
     },
     {
       "stage": "pre",
       "question": "What does the determinant of a 2D transformation matrix represent geometrically?",
-      "options": ["The angle of rotation applied by the matrix", "The factor by which the matrix scales area", "The number of eigenvectors the matrix has", "The trace of the matrix"],
-      "correct": 1,
+      "options": [
+        "The factor by which the matrix scales area",
+        "The angle of rotation applied by the matrix",
+        "The number of eigenvectors the matrix has",
+        "The trace of the matrix"
+      ],
+      "correct": 0,
       "explanation": "The determinant measures how much the transformation scales area. det=1 preserves area (rotation), det=2 doubles area, det=0 crushes to a lower dimension, and det=-1 preserves area but flips orientation."
     },
     {
       "stage": "post",
       "question": "Why does the order of matrix transformations matter? (i.e., why is R @ S different from S @ R?)",
-      "options": ["Matrix addition is not commutative", "Matrix multiplication is not commutative: rotating then scaling gives a different result than scaling then rotating", "The determinants are different for each order", "One order produces a larger matrix than the other"],
-      "correct": 1,
+      "options": [
+        "Matrix addition is not commutative",
+        "The determinants are different for each order",
+        "Matrix multiplication is not commutative: rotating then scaling gives a different result than scaling then rotating",
+        "One order produces a larger matrix than the other"
+      ],
+      "correct": 2,
       "explanation": "Matrix multiplication is not commutative. Rotating (1,0) by 90 degrees then scaling by (2,0.5) gives (0,0.5), but scaling first then rotating gives (0,2). The geometric operations compose differently."
     },
     {
       "stage": "post",
       "question": "In a recurrent neural network, what happens when the weight matrix has eigenvalues with magnitude greater than 1?",
-      "options": ["The network learns faster", "Outputs explode exponentially over time steps (exploding gradient problem)", "The network becomes more stable", "The eigenvalues converge to 1 over training"],
-      "correct": 1,
+      "options": [
+        "The network learns faster",
+        "The eigenvalues converge to 1 over training",
+        "The network becomes more stable",
+        "Outputs explode exponentially over time steps (exploding gradient problem)"
+      ],
+      "correct": 3,
       "explanation": "Repeated multiplication by a matrix amplifies the eigenvalue directions. Eigenvalues > 1 cause exponential growth (exploding gradients), while eigenvalues < 1 cause exponential decay (vanishing gradients)."
     },
     {
       "stage": "post",
       "question": "The matrix A = [[2, 1], [1, 2]] has eigenvalues 3 and 1. What does eigendecomposition A = V @ D @ V^(-1) reveal?",
-      "options": ["A is equivalent to two rotations", "A stretches space by 3x along the [1,1] direction and leaves the [1,-1] direction unchanged", "A compresses all vectors by a factor of 2", "A has rank 1 and maps all vectors to a line"],
+      "options": [
+        "A is equivalent to two rotations",
+        "A stretches space by 3x along the [1,1] direction and leaves the [1,-1] direction unchanged",
+        "A compresses all vectors by a factor of 2",
+        "A has rank 1 and maps all vectors to a line"
+      ],
       "correct": 1,
       "explanation": "The eigenvalue 3 with eigenvector [1,1] means A stretches 3x along the diagonal. The eigenvalue 1 with eigenvector [1,-1] means A leaves the anti-diagonal unchanged. D holds {3,1}, V holds the eigenvectors."
     }

--- a/phases/01-math-foundations/05-chain-rule-and-autodiff/quiz.json
+++ b/phases/01-math-foundations/05-chain-rule-and-autodiff/quiz.json
@@ -3,35 +3,60 @@
     {
       "stage": "pre",
       "question": "What does the chain rule in calculus state?",
-      "options": ["The derivative of a sum is the sum of derivatives", "The derivative of composed functions is the product of their individual derivatives", "The integral of a product is the product of integrals", "Functions can only be differentiated if they are linear"],
+      "options": [
+        "The derivative of a sum is the sum of derivatives",
+        "The derivative of composed functions is the product of their individual derivatives",
+        "The integral of a product is the product of integrals",
+        "Functions can only be differentiated if they are linear"
+      ],
       "correct": 1,
       "explanation": "For y = f(g(x)), the chain rule says dy/dx = f'(g(x)) * g'(x). You multiply the derivatives at each link in the chain. This is the mathematical basis of backpropagation."
     },
     {
       "stage": "pre",
       "question": "What is a computational graph?",
-      "options": ["A plot of loss vs training steps", "A directed graph where nodes are operations and edges carry values forward or gradients backward", "A diagram showing the architecture of a neural network", "A graph database used for storing training data"],
-      "correct": 1,
+      "options": [
+        "A directed graph where nodes are operations and edges carry values forward or gradients backward",
+        "A plot of loss vs training steps",
+        "A diagram showing the architecture of a neural network",
+        "A graph database used for storing training data"
+      ],
+      "correct": 0,
       "explanation": "A computational graph represents the sequence of operations in a computation. Data flows forward through the graph, and gradients flow backward during backpropagation."
     },
     {
       "stage": "post",
       "question": "Why does PyTorch use reverse-mode autodiff (backpropagation) instead of forward-mode?",
-      "options": ["Reverse mode is more numerically accurate", "Reverse mode computes all gradients in one backward pass, while forward mode needs one pass per input variable -- neural networks have millions of inputs but one loss output", "Reverse mode uses less memory", "Forward mode cannot handle non-linear functions"],
-      "correct": 1,
+      "options": [
+        "Reverse mode is more numerically accurate",
+        "Reverse mode uses less memory",
+        "Reverse mode computes all gradients in one backward pass, while forward mode needs one pass per input variable -- neural networks have millions of inputs but one loss output",
+        "Forward mode cannot handle non-linear functions"
+      ],
+      "correct": 2,
       "explanation": "Neural networks have millions of weight inputs but produce a single scalar loss. Reverse mode needs one backward pass total. Forward mode would need one pass per weight -- millions of passes -- making it impractical."
     },
     {
       "stage": "post",
       "question": "In the Value class autograd engine, why does the backward function use '+=' instead of '=' for accumulating gradients?",
-      "options": ["To average the gradients across multiple samples", "Because a value used in multiple operations receives gradient contributions from each one, which must be summed", "To prevent numerical overflow in the gradients", "Because Python does not support the '=' operator in closures"],
-      "correct": 1,
+      "options": [
+        "To average the gradients across multiple samples",
+        "Because Python does not support the '=' operator in closures",
+        "To prevent numerical overflow in the gradients",
+        "Because a value used in multiple operations receives gradient contributions from each one, which must be summed"
+      ],
+      "correct": 3,
       "explanation": "When a value feeds into multiple operations (e.g., x used in both x*y and x+z), its total gradient is the sum of all incoming gradient contributions. Using '=' would overwrite earlier contributions."
     },
     {
       "stage": "post",
       "question": "What is gradient checking and when should you use it?",
-      "options": ["Checking that gradients are below a threshold to prevent exploding gradients", "Comparing autodiff gradients against numerical finite-difference gradients to verify correctness of the backward pass", "Checking that all parameters received non-zero gradients during training", "Monitoring gradient magnitudes during training to detect vanishing gradients"],
+      "options": [
+        "Checking that gradients are below a threshold to prevent exploding gradients",
+        "Comparing autodiff gradients against numerical finite-difference gradients to verify correctness of the backward pass",
+        "Checking that all parameters received non-zero gradients during training",
+        "Monitoring gradient magnitudes during training to detect vanishing gradients"
+      ],
       "correct": 1,
       "explanation": "Gradient checking computes numerical derivatives via (f(x+h) - f(x-h)) / 2h and compares them to autodiff gradients. Use it when adding new operations to your autograd engine or debugging training failures."
     }

--- a/phases/01-math-foundations/06-probability-and-distributions/quiz.json
+++ b/phases/01-math-foundations/06-probability-and-distributions/quiz.json
@@ -3,35 +3,60 @@
     {
       "stage": "pre",
       "question": "What is the difference between a probability mass function (PMF) and a probability density function (PDF)?",
-      "options": ["PMFs are used for continuous variables, PDFs for discrete variables", "PMFs give exact probabilities for discrete outcomes, while PDFs give densities for continuous variables that must be integrated over an interval to get probability", "There is no difference; they are the same concept with different names", "PMFs always sum to 0.5, PDFs integrate to 1"],
+      "options": [
+        "PMFs are used for continuous variables, PDFs for discrete variables",
+        "PMFs give exact probabilities for discrete outcomes, while PDFs give densities for continuous variables that must be integrated over an interval to get probability",
+        "There is no difference; they are the same concept with different names",
+        "PMFs always sum to 0.5, PDFs integrate to 1"
+      ],
       "correct": 1,
       "explanation": "For discrete variables, the PMF gives P(X=k) directly. For continuous variables, the PDF f(x) is a density -- P(a<=X<=b) requires integrating f(x) from a to b. The density at a single point is not a probability."
     },
     {
       "stage": "pre",
       "question": "What does the Central Limit Theorem state?",
-      "options": ["All data follows a normal distribution", "The mean of many independent random samples converges to a normal distribution regardless of the source distribution", "Large datasets always have low variance", "The probability of rare events decreases as sample size increases"],
-      "correct": 1,
+      "options": [
+        "The mean of many independent random samples converges to a normal distribution regardless of the source distribution",
+        "All data follows a normal distribution",
+        "Large datasets always have low variance",
+        "The probability of rare events decreases as sample size increases"
+      ],
+      "correct": 0,
       "explanation": "The CLT says that the average of many independent random variables approaches a Gaussian, no matter what the original distribution looks like. This explains why the normal distribution appears everywhere."
     },
     {
       "stage": "post",
       "question": "Why does softmax subtract the maximum logit before exponentiating (the 'softmax trick')?",
-      "options": ["To make all probabilities equal", "To prevent numerical overflow from exponentiating large numbers while producing mathematically identical results", "To normalize the logits to have mean zero", "To speed up the computation by reducing the number of exponentiations"],
-      "correct": 1,
+      "options": [
+        "To make all probabilities equal",
+        "To normalize the logits to have mean zero",
+        "To prevent numerical overflow from exponentiating large numbers while producing mathematically identical results",
+        "To speed up the computation by reducing the number of exponentiations"
+      ],
+      "correct": 2,
       "explanation": "exp(100) overflows to infinity. Subtracting max(logits) shifts all values so the largest is 0. exp(0)=1 is safe. The subtraction cancels out in the normalization, giving identical probabilities."
     },
     {
       "stage": "post",
       "question": "Cross-entropy loss for classification simplifies to -log(q(true_class)). What does this mean intuitively?",
-      "options": ["Multiply the predicted probabilities by the true labels", "Penalize the model based on how low its predicted probability is for the correct class -- lower prediction means higher loss", "Average the log probabilities across all classes", "Compute the entropy of the true distribution"],
-      "correct": 1,
+      "options": [
+        "Multiply the predicted probabilities by the true labels",
+        "Compute the entropy of the true distribution",
+        "Average the log probabilities across all classes",
+        "Penalize the model based on how low its predicted probability is for the correct class -- lower prediction means higher loss"
+      ],
+      "correct": 3,
       "explanation": "If the model predicts 0.9 for the correct class, loss = -log(0.9) = 0.105 (low). If it predicts 0.01, loss = -log(0.01) = 4.6 (high). The loss punishes low confidence in the correct answer."
     },
     {
       "stage": "post",
       "question": "Why do language models work with log probabilities instead of raw probabilities?",
-      "options": ["Log probabilities are easier to interpret visually", "Multiplying many small probabilities causes numerical underflow to zero; log probabilities convert products to sums, avoiding this", "Log probabilities are required by the transformer architecture", "Raw probabilities cannot represent values less than 0.01"],
+      "options": [
+        "Log probabilities are easier to interpret visually",
+        "Multiplying many small probabilities causes numerical underflow to zero; log probabilities convert products to sums, avoiding this",
+        "Log probabilities are required by the transformer architecture",
+        "Raw probabilities cannot represent values less than 0.01"
+      ],
       "correct": 1,
       "explanation": "P(sentence) = P(word1) * P(word2) * ... quickly underflows to 0.0 with float64. Log P(sentence) = log P(word1) + log P(word2) + ... stays in a finite range. Products become sums."
     }

--- a/phases/01-math-foundations/07-bayes-theorem/quiz.json
+++ b/phases/01-math-foundations/07-bayes-theorem/quiz.json
@@ -3,35 +3,60 @@
     {
       "stage": "pre",
       "question": "In Bayes' theorem, what is the 'prior'?",
-      "options": ["The probability of the evidence", "Your belief about a hypothesis before observing any evidence", "The probability of the evidence given the hypothesis", "The final updated probability after seeing evidence"],
+      "options": [
+        "The probability of the evidence",
+        "Your belief about a hypothesis before observing any evidence",
+        "The probability of the evidence given the hypothesis",
+        "The final updated probability after seeing evidence"
+      ],
       "correct": 1,
       "explanation": "The prior P(A) represents your initial belief about hypothesis A before seeing any data. It gets updated to the posterior P(A|B) after observing evidence B."
     },
     {
       "stage": "pre",
       "question": "A rare disease affects 1 in 10,000 people. A 99% accurate test returns positive. What is the approximate probability you have the disease?",
-      "options": ["99%", "About 1%", "50%", "10%"],
-      "correct": 1,
+      "options": [
+        "About 1%",
+        "99%",
+        "50%",
+        "10%"
+      ],
+      "correct": 0,
       "explanation": "Despite 99% test accuracy, the disease is so rare (0.01%) that most positive results come from healthy people (false positives). Bayes' theorem gives P(sick|positive) = ~0.98%, not 99%."
     },
     {
       "stage": "post",
       "question": "What is Laplace smoothing in a Naive Bayes classifier and why is it necessary?",
-      "options": ["It normalizes feature values to have zero mean and unit variance", "It adds a small count to every feature to prevent zero probabilities from unseen words, which would zero out the entire product", "It smooths the decision boundary between classes", "It reduces the dimensionality of the feature space"],
-      "correct": 1,
+      "options": [
+        "It normalizes feature values to have zero mean and unit variance",
+        "It smooths the decision boundary between classes",
+        "It adds a small count to every feature to prevent zero probabilities from unseen words, which would zero out the entire product",
+        "It reduces the dimensionality of the feature space"
+      ],
+      "correct": 2,
       "explanation": "Without smoothing, a word never seen in spam training data gets P(word|spam)=0, making the entire product zero regardless of other strong spam indicators. Adding 1 to each count prevents this."
     },
     {
       "stage": "post",
       "question": "How does MAP (Maximum A Posteriori) estimation differ from MLE (Maximum Likelihood Estimation)?",
-      "options": ["MAP uses a larger dataset than MLE", "MAP incorporates a prior distribution over parameters, equivalent to adding regularization, while MLE only uses the likelihood", "MAP is faster to compute than MLE", "MLE always produces better results than MAP"],
-      "correct": 1,
+      "options": [
+        "MAP uses a larger dataset than MLE",
+        "MLE always produces better results than MAP",
+        "MAP is faster to compute than MLE",
+        "MAP incorporates a prior distribution over parameters, equivalent to adding regularization, while MLE only uses the likelihood"
+      ],
+      "correct": 3,
       "explanation": "MAP maximizes P(data|params) * P(params) while MLE maximizes P(data|params) alone. The prior P(params) acts as regularization -- a Gaussian prior equals L2 regularization, a Laplace prior equals L1."
     },
     {
       "stage": "post",
       "question": "In sequential Bayesian updating, you start with Beta(1,1) and observe 7 heads and 3 tails. What is the posterior?",
-      "options": ["Beta(7, 3)", "Beta(8, 4)", "Beta(1.7, 1.3)", "Normal(0.7, 0.1)"],
+      "options": [
+        "Beta(7, 3)",
+        "Beta(8, 4)",
+        "Beta(1.7, 1.3)",
+        "Normal(0.7, 0.1)"
+      ],
       "correct": 1,
       "explanation": "The Beta-Binomial conjugate update adds successes to the first parameter and failures to the second: Beta(1+7, 1+3) = Beta(8, 4). The posterior mean is 8/12 = 0.667."
     }

--- a/phases/01-math-foundations/08-optimization/quiz.json
+++ b/phases/01-math-foundations/08-optimization/quiz.json
@@ -3,35 +3,60 @@
     {
       "stage": "pre",
       "question": "What does 'optimization' mean in the context of training a neural network?",
-      "options": ["Making the code run faster", "Finding the model weights that minimize the loss function", "Reducing the number of parameters in the model", "Choosing the best hardware for training"],
+      "options": [
+        "Making the code run faster",
+        "Finding the model weights that minimize the loss function",
+        "Reducing the number of parameters in the model",
+        "Choosing the best hardware for training"
+      ],
       "correct": 1,
       "explanation": "Training a neural network IS optimization. The loss function measures how wrong the model is, and optimization finds the weight values that make it as small as possible."
     },
     {
       "stage": "pre",
       "question": "What happens if the learning rate is too large during gradient descent?",
-      "options": ["Training converges faster to the global minimum", "The optimizer overshoots the minimum and the loss diverges (bounces or increases)", "The gradients become zero", "The model automatically reduces the learning rate"],
-      "correct": 1,
+      "options": [
+        "The optimizer overshoots the minimum and the loss diverges (bounces or increases)",
+        "Training converges faster to the global minimum",
+        "The gradients become zero",
+        "The model automatically reduces the learning rate"
+      ],
+      "correct": 0,
       "explanation": "A learning rate that is too large causes each step to overshoot the valley, potentially bouncing between walls or diverging entirely. The loss increases instead of decreasing."
     },
     {
       "stage": "post",
       "question": "How does Adam differ from vanilla gradient descent?",
-      "options": ["Adam uses a fixed learning rate while GD uses adaptive rates", "Adam tracks running averages of gradients and squared gradients to give each weight its own adaptive learning rate", "Adam computes exact second derivatives while GD uses first derivatives", "Adam processes the full dataset per step while GD uses mini-batches"],
-      "correct": 1,
+      "options": [
+        "Adam uses a fixed learning rate while GD uses adaptive rates",
+        "Adam computes exact second derivatives while GD uses first derivatives",
+        "Adam tracks running averages of gradients and squared gradients to give each weight its own adaptive learning rate",
+        "Adam processes the full dataset per step while GD uses mini-batches"
+      ],
+      "correct": 2,
       "explanation": "Adam maintains per-weight first moment (gradient direction) and second moment (gradient magnitude) estimates. Dividing by sqrt(second moment) gives small steps for weights with large gradients and large steps for weights with small gradients."
     },
     {
       "stage": "post",
       "question": "Why is the noise in mini-batch SGD considered beneficial rather than just a nuisance?",
-      "options": ["Noise reduces memory usage during training", "Noise helps the optimizer escape shallow local minima and saddle points that a noiseless optimizer would get stuck in", "Noise is not beneficial; it always slows convergence", "Noise makes the loss function convex"],
-      "correct": 1,
+      "options": [
+        "Noise reduces memory usage during training",
+        "Noise makes the loss function convex",
+        "Noise is not beneficial; it always slows convergence",
+        "Noise helps the optimizer escape shallow local minima and saddle points that a noiseless optimizer would get stuck in"
+      ],
+      "correct": 3,
       "explanation": "The stochastic noise from random mini-batches provides random perturbations that can push the optimizer out of shallow local minima and saddle points, leading to better generalization."
     },
     {
       "stage": "post",
       "question": "What does a cosine annealing learning rate schedule do?",
-      "options": ["Increases the learning rate throughout training following a cosine curve", "Starts with a high learning rate and smoothly decreases it following a cosine curve, with optional warmup", "Alternates the learning rate between two fixed values", "Sets the learning rate to the cosine of the current epoch number"],
+      "options": [
+        "Increases the learning rate throughout training following a cosine curve",
+        "Starts with a high learning rate and smoothly decreases it following a cosine curve, with optional warmup",
+        "Alternates the learning rate between two fixed values",
+        "Sets the learning rate to the cosine of the current epoch number"
+      ],
       "correct": 1,
       "explanation": "Cosine annealing smoothly reduces the learning rate from lr_max to lr_min following a half-cosine curve. This provides large steps early for fast progress and small steps late for fine convergence."
     }

--- a/phases/01-math-foundations/09-information-theory/quiz.json
+++ b/phases/01-math-foundations/09-information-theory/quiz.json
@@ -3,35 +3,60 @@
     {
       "stage": "pre",
       "question": "What does 'entropy' measure in information theory?",
-      "options": ["The energy of a physical system", "The average surprise or uncertainty in a probability distribution", "The number of bits in a binary message", "The error rate of a communication channel"],
+      "options": [
+        "The energy of a physical system",
+        "The average surprise or uncertainty in a probability distribution",
+        "The number of bits in a binary message",
+        "The error rate of a communication channel"
+      ],
       "correct": 1,
       "explanation": "Entropy H(P) = -sum(p(x) * log(p(x))) measures the average amount of surprise across all outcomes. High entropy means high uncertainty (uniform distribution). Low entropy means the outcome is predictable."
     },
     {
       "stage": "pre",
       "question": "What is the cross-entropy loss commonly used for in neural networks?",
-      "options": ["Regression tasks with continuous outputs", "Classification tasks, measuring how far predicted probabilities are from true labels", "Generating new data samples", "Regularizing model weights to prevent overfitting"],
-      "correct": 1,
+      "options": [
+        "Classification tasks, measuring how far predicted probabilities are from true labels",
+        "Regression tasks with continuous outputs",
+        "Generating new data samples",
+        "Regularizing model weights to prevent overfitting"
+      ],
+      "correct": 0,
       "explanation": "Cross-entropy loss H(P,Q) = -sum(p(x)*log(q(x))) measures the difference between the true distribution (labels) and the model's predicted distribution. It is THE standard loss for classification."
     },
     {
       "stage": "post",
       "question": "Why is minimizing cross-entropy equivalent to minimizing KL divergence during training?",
-      "options": ["Because KL divergence is always zero during training", "Because cross-entropy = entropy + KL divergence, and the entropy of the true labels is constant, so minimizing cross-entropy minimizes KL divergence", "Because cross-entropy and KL divergence are the same formula", "Because the model's entropy equals zero at convergence"],
-      "correct": 1,
+      "options": [
+        "Because KL divergence is always zero during training",
+        "Because cross-entropy and KL divergence are the same formula",
+        "Because cross-entropy = entropy + KL divergence, and the entropy of the true labels is constant, so minimizing cross-entropy minimizes KL divergence",
+        "Because the model's entropy equals zero at convergence"
+      ],
+      "correct": 2,
       "explanation": "H(P,Q) = H(P) + D_KL(P||Q). Since the true distribution P doesn't change during training, H(P) is constant. Minimizing H(P,Q) is the same as minimizing D_KL(P||Q) -- pushing the model toward the true distribution."
     },
     {
       "stage": "post",
       "question": "A language model has perplexity 50 on a test set. What does this mean?",
-      "options": ["The model makes 50 errors per sentence", "On average, the model is as uncertain as if it were choosing uniformly from 50 possible next tokens at each step", "The model has 50 layers", "The model was trained for 50 epochs"],
-      "correct": 1,
+      "options": [
+        "The model makes 50 errors per sentence",
+        "The model was trained for 50 epochs",
+        "The model has 50 layers",
+        "On average, the model is as uncertain as if it were choosing uniformly from 50 possible next tokens at each step"
+      ],
+      "correct": 3,
       "explanation": "Perplexity = e^(cross-entropy). A perplexity of 50 means the model's uncertainty at each token is equivalent to picking randomly from 50 equally likely options. Lower perplexity means better predictions."
     },
     {
       "stage": "post",
       "question": "How does mutual information differ from Pearson correlation for feature selection?",
-      "options": ["Mutual information is faster to compute", "Mutual information detects any statistical dependency (linear or nonlinear) while correlation only detects linear relationships", "Pearson correlation works for any data type while mutual information only works for continuous data", "They always give the same feature rankings"],
+      "options": [
+        "Mutual information is faster to compute",
+        "Mutual information detects any statistical dependency (linear or nonlinear) while correlation only detects linear relationships",
+        "Pearson correlation works for any data type while mutual information only works for continuous data",
+        "They always give the same feature rankings"
+      ],
       "correct": 1,
       "explanation": "Mutual information I(X;Y) captures all statistical dependencies between variables, including nonlinear and non-monotonic ones. Pearson correlation only measures linear association, missing many important relationships."
     }

--- a/phases/01-math-foundations/10-dimensionality-reduction/quiz.json
+++ b/phases/01-math-foundations/10-dimensionality-reduction/quiz.json
@@ -3,35 +3,60 @@
     {
       "stage": "pre",
       "question": "What is the 'curse of dimensionality'?",
-      "options": ["High-dimensional data takes too long to download", "As dimensions grow, distances become meaningless, volume concentrates in corners, and you need exponentially more data", "Neural networks cannot process data with more than 100 features", "High-dimensional data always contains noise"],
+      "options": [
+        "High-dimensional data takes too long to download",
+        "As dimensions grow, distances become meaningless, volume concentrates in corners, and you need exponentially more data",
+        "Neural networks cannot process data with more than 100 features",
+        "High-dimensional data always contains noise"
+      ],
       "correct": 1,
       "explanation": "In high dimensions, all pairwise distances converge to similar values, data points spread to corners, and maintaining sample density requires exponentially more data. Dimensionality reduction counteracts these effects."
     },
     {
       "stage": "pre",
       "question": "What does PCA find?",
-      "options": ["The most important features by name", "The orthogonal directions of maximum variance in the data", "Clusters of similar data points", "The optimal number of features to keep"],
-      "correct": 1,
+      "options": [
+        "The orthogonal directions of maximum variance in the data",
+        "The most important features by name",
+        "Clusters of similar data points",
+        "The optimal number of features to keep"
+      ],
+      "correct": 0,
       "explanation": "PCA computes the eigenvectors of the covariance matrix, which are orthogonal directions ranked by how much data variance they capture. The first principal component points along the direction of maximum spread."
     },
     {
       "stage": "post",
       "question": "After running PCA on 784-dimensional MNIST data with k=50 components, you find 95% of variance is captured. What does this tell you?",
-      "options": ["Only 50 pixels matter in each image", "The data effectively lives in a ~50-dimensional subspace; the remaining 734 dimensions are mostly noise or redundancy", "95% of images belong to the same class", "The model will achieve 95% accuracy"],
-      "correct": 1,
+      "options": [
+        "Only 50 pixels matter in each image",
+        "95% of images belong to the same class",
+        "The data effectively lives in a ~50-dimensional subspace; the remaining 734 dimensions are mostly noise or redundancy",
+        "The model will achieve 95% accuracy"
+      ],
+      "correct": 2,
       "explanation": "95% explained variance with 50 components means the essential structure of 784-dimensional data is captured by just 50 directions. The rest carries only 5% of the variation -- mostly noise."
     },
     {
       "stage": "post",
       "question": "Why should you NOT use t-SNE as preprocessing before training a classifier?",
-      "options": ["t-SNE is too slow for large datasets", "t-SNE is designed for visualization only: it distorts global distances, is stochastic, and the output coordinates have no consistent meaning across runs", "t-SNE reduces data to exactly 2 dimensions which is too few", "t-SNE requires the labels to be known in advance"],
-      "correct": 1,
+      "options": [
+        "t-SNE is too slow for large datasets",
+        "t-SNE requires the labels to be known in advance",
+        "t-SNE reduces data to exactly 2 dimensions which is too few",
+        "t-SNE is designed for visualization only: it distorts global distances, is stochastic, and the output coordinates have no consistent meaning across runs"
+      ],
+      "correct": 3,
       "explanation": "t-SNE preserves local neighborhoods but distorts global structure. Distances between clusters are meaningless, and different runs produce different layouts. Use PCA for preprocessing and t-SNE/UMAP only for visualization."
     },
     {
       "stage": "post",
       "question": "When would you choose kernel PCA over standard PCA?",
-      "options": ["When you have more samples than features", "When the data lies on a nonlinear manifold that standard PCA cannot separate, like concentric circles", "When you need the fastest possible computation", "When you want interpretable principal components"],
+      "options": [
+        "When you have more samples than features",
+        "When the data lies on a nonlinear manifold that standard PCA cannot separate, like concentric circles",
+        "When you need the fastest possible computation",
+        "When you want interpretable principal components"
+      ],
       "correct": 1,
       "explanation": "Standard PCA finds linear subspaces. If data has nonlinear structure (e.g., two concentric rings), PCA projects both onto the same line. Kernel PCA maps data to a higher-dimensional space where the structure becomes linear."
     }

--- a/phases/01-math-foundations/11-singular-value-decomposition/quiz.json
+++ b/phases/01-math-foundations/11-singular-value-decomposition/quiz.json
@@ -3,35 +3,60 @@
     {
       "stage": "pre",
       "question": "What advantage does SVD have over eigendecomposition?",
-      "options": ["SVD is always faster to compute", "SVD works on any matrix of any shape, while eigendecomposition requires square matrices with full eigenvector sets", "SVD produces smaller output matrices", "SVD does not require numerical computation"],
+      "options": [
+        "SVD is always faster to compute",
+        "SVD works on any matrix of any shape, while eigendecomposition requires square matrices with full eigenvector sets",
+        "SVD produces smaller output matrices",
+        "SVD does not require numerical computation"
+      ],
       "correct": 1,
       "explanation": "Eigendecomposition only works on square matrices that have n linearly independent eigenvectors. SVD decomposes ANY m x n matrix into U * Sigma * V^T with no restrictions on shape or rank."
     },
     {
       "stage": "pre",
       "question": "What does 'low-rank approximation' mean?",
-      "options": ["Removing rows with low values from a matrix", "Approximating a matrix by keeping only its most important components, producing a simpler matrix with fewer independent directions", "Converting a matrix to a lower precision data type", "Sorting the rows of a matrix by their magnitude"],
-      "correct": 1,
+      "options": [
+        "Approximating a matrix by keeping only its most important components, producing a simpler matrix with fewer independent directions",
+        "Removing rows with low values from a matrix",
+        "Converting a matrix to a lower precision data type",
+        "Sorting the rows of a matrix by their magnitude"
+      ],
+      "correct": 0,
       "explanation": "A rank-k approximation keeps only the top k singular values and their vectors, discarding the rest. The Eckart-Young theorem proves this is the BEST possible approximation of that rank."
     },
     {
       "stage": "post",
       "question": "In SVD A = U * Sigma * V^T, what geometric operation does each factor represent?",
-      "options": ["U scales, Sigma rotates, V^T translates", "V^T rotates in input space, Sigma scales along principal axes, U rotates into output space", "U compresses, Sigma expands, V^T normalizes", "All three factors perform the same operation: rotation"],
-      "correct": 1,
+      "options": [
+        "U scales, Sigma rotates, V^T translates",
+        "U compresses, Sigma expands, V^T normalizes",
+        "V^T rotates in input space, Sigma scales along principal axes, U rotates into output space",
+        "All three factors perform the same operation: rotation"
+      ],
+      "correct": 2,
       "explanation": "SVD reveals that every matrix performs: (1) V^T rotates inputs to align with principal directions, (2) Sigma stretches/compresses along each axis, (3) U rotates the result into the output space. Rotate, scale, rotate."
     },
     {
       "stage": "post",
       "question": "Why does sklearn implement PCA using SVD instead of eigendecomposition of the covariance matrix?",
-      "options": ["SVD produces different results that are more accurate for ML", "SVD works directly on the data matrix without forming the covariance matrix, avoiding squaring the condition number and improving numerical stability", "SVD is easier to parallelize on GPUs", "SVD does not require centering the data"],
-      "correct": 1,
+      "options": [
+        "SVD produces different results that are more accurate for ML",
+        "SVD does not require centering the data",
+        "SVD is easier to parallelize on GPUs",
+        "SVD works directly on the data matrix without forming the covariance matrix, avoiding squaring the condition number and improving numerical stability"
+      ],
+      "correct": 3,
       "explanation": "Forming A^T*A squares the singular values (and condition number). If A has singular values [1000, 0.001], A^T*A has eigenvalues [10^6, 10^-6] -- 6 digits of precision lost. SVD avoids this by working directly on A."
     },
     {
       "stage": "post",
       "question": "How does truncated SVD enable recommendation systems to predict missing ratings?",
-      "options": ["It fills missing entries with the average rating", "It decomposes the ratings matrix into latent user and movie profiles; the dot product of a user profile with a movie profile predicts the missing rating", "It clusters similar users together and copies their ratings", "It trains a neural network on the observed ratings"],
+      "options": [
+        "It fills missing entries with the average rating",
+        "It decomposes the ratings matrix into latent user and movie profiles; the dot product of a user profile with a movie profile predicts the missing rating",
+        "It clusters similar users together and copies their ratings",
+        "It trains a neural network on the observed ratings"
+      ],
       "correct": 1,
       "explanation": "SVD decomposes the ratings matrix into user profiles (U), latent factor importance (Sigma), and movie profiles (V^T). The low-rank reconstruction fills in missing entries based on the latent factors (genre, era, style) that explain user preferences."
     }

--- a/phases/01-math-foundations/13-numerical-stability/quiz.json
+++ b/phases/01-math-foundations/13-numerical-stability/quiz.json
@@ -16,12 +16,12 @@
       "stage": "pre",
       "question": "Why does 0.1 + 0.2 not equal 0.3 in floating-point arithmetic?",
       "options": [
-        "Python rounds all decimals to integers",
         "0.1 and 0.2 cannot be represented exactly in binary floating point",
+        "Python rounds all decimals to integers",
         "The CPU has a bug in its addition circuit",
         "0.3 is not a valid floating-point number"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "The number 0.1 is a repeating fraction in binary (like 1/3 in decimal). Float32 truncates it, so the stored value is approximately 0.100000001490116. The accumulated error makes the sum differ from 0.3."
     },
     {
@@ -29,11 +29,11 @@
       "question": "In the stable softmax implementation, why do you subtract max(logits) before exponentiating?",
       "options": [
         "It makes the output probabilities more uniform",
-        "It prevents exp() from overflowing by ensuring the largest exponent is 0",
         "It converts logits from float16 to float32",
+        "It prevents exp() from overflowing by ensuring the largest exponent is 0",
         "It normalizes the logits to have zero mean"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "After subtracting max(logits), the largest value is 0 and exp(0) = 1, which cannot overflow. All other values are negative, so their exponentials are less than 1. The probabilities are mathematically identical to the naive version."
     },
     {
@@ -41,11 +41,11 @@
       "question": "When using centered finite differences for gradient checking, what happens if the step size h is too small (e.g., 1e-15)?",
       "options": [
         "The approximation becomes more accurate",
-        "Catastrophic cancellation destroys the result because f(x+h) and f(x-h) are nearly identical",
+        "The gradient automatically becomes zero",
         "The function evaluation becomes faster",
-        "The gradient automatically becomes zero"
+        "Catastrophic cancellation destroys the result because f(x+h) and f(x-h) are nearly identical"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "When h is extremely small, f(x+h) and f(x-h) differ only in their last few significant digits. Subtracting them cancels the leading digits, leaving mostly rounding noise. Typical good values are h = 1e-5 to 1e-7."
     },
     {

--- a/phases/01-math-foundations/17-linear-systems/quiz.json
+++ b/phases/01-math-foundations/17-linear-systems/quiz.json
@@ -16,12 +16,12 @@
       "stage": "pre",
       "question": "Why is partial pivoting used in Gaussian elimination?",
       "options": [
-        "It reduces the time complexity from O(n^3) to O(n^2)",
         "It selects the largest available pivot to minimize error amplification from dividing by small numbers",
+        "It reduces the time complexity from O(n^3) to O(n^2)",
         "It ensures the result is always an integer",
         "It eliminates the need for back substitution"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Without pivoting, dividing by a small pivot amplifies rounding errors. Partial pivoting swaps rows to place the largest absolute value in the pivot position, keeping the multipliers small and the computation numerically stable."
     },
     {
@@ -29,11 +29,11 @@
       "question": "Why is Cholesky decomposition preferred over LU for solving (X^T X + lambda I) w = X^T y in ridge regression?",
       "options": [
         "Cholesky works on any matrix while LU requires square matrices",
-        "The matrix X^T X + lambda I is symmetric positive definite, so Cholesky is twice as fast as LU and requires half the storage",
         "Cholesky gives a more accurate answer than LU",
+        "The matrix X^T X + lambda I is symmetric positive definite, so Cholesky is twice as fast as LU and requires half the storage",
         "LU decomposition cannot handle regularization terms"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "When lambda > 0, X^T X + lambda I is always symmetric positive definite. Cholesky factors A = LL^T in O(n^3/3) operations — roughly half the O(2n^3/3) of LU — and needs only the lower triangle. It exploits the symmetry that LU does not."
     },
     {
@@ -41,11 +41,11 @@
       "question": "A matrix has condition number kappa = 10^8. You are using float64 (~15 digits of precision). How many digits of the solution can you trust?",
       "options": [
         "About 15 digits",
-        "About 7 digits (15 - log10(10^8) = 15 - 8)",
+        "Zero digits — the solution is meaningless",
         "About 8 digits",
-        "Zero digits — the solution is meaningless"
+        "About 7 digits (15 - log10(10^8) = 15 - 8)"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "You lose approximately log10(kappa) digits of precision. With kappa = 10^8, you lose about 8 digits from float64's ~15 digits, leaving about 7 trustworthy digits. If kappa approaches 10^16, the solution becomes meaningless in float64."
     },
     {

--- a/phases/01-math-foundations/20-fourier-transform/quiz.json
+++ b/phases/01-math-foundations/20-fourier-transform/quiz.json
@@ -16,12 +16,12 @@
       "stage": "pre",
       "question": "What is the time complexity of the Fast Fourier Transform (FFT) compared to the direct DFT?",
       "options": [
-        "Both are O(N^2)",
         "FFT is O(N log N), DFT is O(N^2)",
+        "Both are O(N^2)",
         "FFT is O(N), DFT is O(N log N)",
         "FFT is O(log N), DFT is O(N)"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "The direct DFT computes N outputs, each summing over N inputs: O(N^2). The Cooley-Tukey FFT splits the signal into even/odd halves recursively, doing O(N) work at each of log2(N) levels, giving O(N log N). For N = 1 million, this is 20 million vs 1 trillion operations."
     },
     {
@@ -29,11 +29,11 @@
       "question": "What does the convolution theorem state?",
       "options": [
         "Convolution in the time domain equals addition in the frequency domain",
-        "Convolution in the time domain equals pointwise multiplication in the frequency domain",
         "Convolution always increases the length of a signal",
+        "Convolution in the time domain equals pointwise multiplication in the frequency domain",
         "Convolution and correlation are identical operations"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "The convolution theorem states that convolution in the time domain equals pointwise multiplication in the frequency domain: x * h = IFFT(FFT(x) . FFT(h)). This is why FFT-based convolution is O(N log N) instead of O(N*M) for large kernels."
     },
     {
@@ -41,11 +41,11 @@
       "question": "Why does zero-padding a signal before FFT NOT increase the true frequency resolution?",
       "options": [
         "Zero-padding introduces noise that cancels the improvement",
-        "Zero-padding interpolates between existing frequency bins but cannot reveal frequency detail absent from the original samples",
+        "The FFT algorithm ignores zero-padded samples",
         "Zero-padding only works for power-of-2 signal lengths",
-        "The FFT algorithm ignores zero-padded samples"
+        "Zero-padding interpolates between existing frequency bins but cannot reveal frequency detail absent from the original samples"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "True frequency resolution depends on the observation time T = N/fs. Zero-padding adds more frequency bins (finer grid) but only interpolates the existing spectrum — it gives a smoother-looking result without resolving frequencies closer than 1/T Hz apart."
     },
     {

--- a/phases/01-math-foundations/21-graph-theory/quiz.json
+++ b/phases/01-math-foundations/21-graph-theory/quiz.json
@@ -16,12 +16,12 @@
       "stage": "pre",
       "question": "What data structure does BFS use and what does it find?",
       "options": [
-        "Stack; finds connected components",
         "Queue; finds shortest paths in unweighted graphs",
+        "Stack; finds connected components",
         "Priority queue; finds minimum spanning tree",
         "Hash map; finds duplicate nodes"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "BFS uses a queue (FIFO) to explore all neighbors at distance k before moving to distance k+1. This guarantees that the first time a node is discovered, it is via a shortest path from the source."
     },
     {
@@ -29,11 +29,11 @@
       "question": "The graph Laplacian L = D - A of a connected graph has how many zero eigenvalues?",
       "options": [
         "Zero",
-        "Exactly one",
         "Equal to the number of nodes",
+        "Exactly one",
         "Equal to the number of edges"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "The number of zero eigenvalues of the Laplacian equals the number of connected components. A connected graph has exactly one connected component, so exactly one zero eigenvalue. A graph with k disconnected pieces has k zero eigenvalues."
     },
     {
@@ -41,11 +41,11 @@
       "question": "In GNN message passing, what does h_v^(k+1) = sigma(W * mean({h_u^(k) : u in neighbors(v)})) compute?",
       "options": [
         "The shortest path from v to all other nodes",
-        "A new feature vector for node v by aggregating neighbor features, transforming with learned weights, and applying a nonlinearity",
+        "The PageRank score of node v",
         "The degree of node v at layer k+1",
-        "The PageRank score of node v"
+        "A new feature vector for node v by aggregating neighbor features, transforming with learned weights, and applying a nonlinearity"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "Each node collects features from its neighbors (mean aggregation), multiplies by a learned weight matrix W, and applies an activation function sigma. After k rounds, each node has information from its k-hop neighborhood."
     },
     {

--- a/phases/01-math-foundations/22-stochastic-processes/quiz.json
+++ b/phases/01-math-foundations/22-stochastic-processes/quiz.json
@@ -16,12 +16,12 @@
       "stage": "pre",
       "question": "In a 1D random walk, how does the expected distance from the origin scale with the number of steps n?",
       "options": [
-        "Linearly: proportional to n",
         "As the square root: proportional to sqrt(n)",
+        "Linearly: proportional to n",
         "Logarithmically: proportional to log(n)",
         "It stays constant regardless of n"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Each step is +/-1 with equal probability. The variance after n steps is n, so the standard deviation (typical distance from origin) is sqrt(n). After 10,000 steps, the expected distance is about 100, not 10,000."
     },
     {
@@ -29,11 +29,11 @@
       "question": "What is the stationary distribution of a Markov chain?",
       "options": [
         "The initial distribution of states",
-        "The distribution that does not change under the transition matrix: pi * P = pi",
         "The distribution of states after exactly one transition",
+        "The distribution that does not change under the transition matrix: pi * P = pi",
         "The uniform distribution over all states"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "The stationary distribution pi satisfies pi * P = pi — applying the transition matrix leaves it unchanged. It represents the long-run fraction of time spent in each state. For an irreducible, aperiodic chain, any initial distribution converges to pi."
     },
     {
@@ -41,11 +41,11 @@
       "question": "In Langevin dynamics x_{t+1} = x_t - dt * grad(U) + sqrt(2*T*dt) * z, what happens as temperature T approaches 0?",
       "options": [
         "The process becomes a pure random walk",
-        "The process becomes pure gradient descent (deterministic optimization)",
+        "The process freezes at the initial position",
         "The process diverges to infinity",
-        "The process freezes at the initial position"
+        "The process becomes pure gradient descent (deterministic optimization)"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "At T = 0, the noise term sqrt(2*T*dt)*z vanishes, leaving x_{t+1} = x_t - dt * grad(U), which is standard gradient descent. At high T, the noise dominates and the process is nearly a random walk. Intermediate T balances exploration and exploitation."
     },
     {

--- a/phases/02-ml-fundamentals/03-logistic-regression/quiz.json
+++ b/phases/02-ml-fundamentals/03-logistic-regression/quiz.json
@@ -17,12 +17,12 @@
     "stage": "pre",
     "question": "Why is logistic regression called 'regression' even though it is used for classification?",
     "options": [
-      "It predicts continuous values that are then rounded",
       "The name comes from the logistic (sigmoid) function it uses, not from regression analysis",
+      "It predicts continuous values that are then rounded",
       "It was originally designed for regression and later adapted",
       "It minimizes mean squared error like linear regression"
     ],
-    "correct": 1,
+    "correct": 0,
     "explanation": "The name comes from the logistic function (sigmoid). Despite the name, logistic regression is a classification algorithm that outputs class probabilities."
   },
   {
@@ -31,11 +31,11 @@
     "question": "Why is binary cross-entropy used instead of MSE for logistic regression?",
     "options": [
       "Cross-entropy is faster to compute",
-      "MSE with sigmoid creates a non-convex cost surface with local minima, while cross-entropy is convex",
       "MSE can only be used with linear models",
+      "MSE with sigmoid creates a non-convex cost surface with local minima, while cross-entropy is convex",
       "Cross-entropy works only when the dataset is balanced"
     ],
-    "correct": 1,
+    "correct": 2,
     "explanation": "MSE combined with the sigmoid activation creates a non-convex cost surface with many local minima. Binary cross-entropy with sigmoid is convex, guaranteeing a single global minimum."
   },
   {
@@ -44,11 +44,11 @@
     "question": "A spam filter has precision = 0.95 and recall = 0.60. What does this mean in practical terms?",
     "options": [
       "95% of all emails are correctly classified, and 60% of spam is caught",
-      "When it flags an email as spam, it is correct 95% of the time, but it only catches 60% of actual spam",
+      "The model is 95% accurate on the test set and 60% on the training set",
       "60% of flagged emails are spam, and 95% of all spam is caught",
-      "The model is 95% accurate on the test set and 60% on the training set"
+      "When it flags an email as spam, it is correct 95% of the time, but it only catches 60% of actual spam"
     ],
-    "correct": 1,
+    "correct": 3,
     "explanation": "Precision = 0.95 means 95% of emails predicted as spam are actually spam (few false alarms). Recall = 0.60 means only 60% of actual spam is caught (40% slips through)."
   },
   {

--- a/phases/02-ml-fundamentals/05-support-vector-machines/quiz.json
+++ b/phases/02-ml-fundamentals/05-support-vector-machines/quiz.json
@@ -17,12 +17,12 @@
     "stage": "pre",
     "question": "What does the SVM maximize when finding the decision boundary?",
     "options": [
-      "The number of correctly classified training points",
       "The margin -- the distance between the decision boundary and the nearest points of each class",
+      "The number of correctly classified training points",
       "The total distance from all points to the boundary",
       "The complexity of the decision boundary"
     ],
-    "correct": 1,
+    "correct": 0,
     "explanation": "SVMs find the hyperplane that maximizes the margin between the two classes. A wider margin leads to better generalization on unseen data."
   },
   {
@@ -31,11 +31,11 @@
     "question": "What happens when you increase the C parameter in an SVM?",
     "options": [
       "The margin gets wider and more misclassifications are allowed",
-      "The margin gets narrower, fewer misclassifications are tolerated, and the model may overfit",
       "The kernel function changes from linear to RBF",
+      "The margin gets narrower, fewer misclassifications are tolerated, and the model may overfit",
       "The number of support vectors always increases"
     ],
-    "correct": 1,
+    "correct": 2,
     "explanation": "Large C penalizes misclassifications heavily, producing a narrow margin that closely fits the training data. This can lead to overfitting. Small C allows more violations for a wider, more regularized margin."
   },
   {
@@ -44,11 +44,11 @@
     "question": "How does the kernel trick enable SVMs to learn nonlinear boundaries?",
     "options": [
       "It replaces the SVM with a neural network",
-      "It computes dot products in a high-dimensional space without explicitly mapping data to that space",
+      "It adds polynomial features to the input data directly",
       "It removes outliers from the dataset before training",
-      "It adds polynomial features to the input data directly"
+      "It computes dot products in a high-dimensional space without explicitly mapping data to that space"
     ],
-    "correct": 1,
+    "correct": 3,
     "explanation": "The kernel trick replaces every dot product x_i . x_j with K(x_i, x_j), computing the dot product in a high-dimensional (even infinite-dimensional for RBF) feature space without ever constructing it."
   },
   {

--- a/phases/02-ml-fundamentals/07-unsupervised-learning/quiz.json
+++ b/phases/02-ml-fundamentals/07-unsupervised-learning/quiz.json
@@ -17,12 +17,12 @@
     "stage": "pre",
     "question": "What does K-Means require you to specify before training?",
     "options": [
-      "The exact cluster centers",
       "The number of clusters K",
+      "The exact cluster centers",
       "The labels for each data point",
       "The distance metric to use"
     ],
-    "correct": 1,
+    "correct": 0,
     "explanation": "K-Means requires the number of clusters K as input. It then iteratively assigns points to the nearest centroid and recomputes centroids until convergence."
   },
   {
@@ -31,11 +31,11 @@
     "question": "K-Means fails on two interlocking half-moon shapes but DBSCAN succeeds. Why?",
     "options": [
       "DBSCAN uses more data than K-Means",
-      "DBSCAN finds clusters based on density, so it can discover arbitrary shapes, while K-Means assumes spherical clusters",
       "DBSCAN always outperforms K-Means on every dataset",
+      "DBSCAN finds clusters based on density, so it can discover arbitrary shapes, while K-Means assumes spherical clusters",
       "K-Means cannot handle 2D data"
     ],
-    "correct": 1,
+    "correct": 2,
     "explanation": "K-Means assigns points to the nearest centroid, producing spherical (convex) clusters. DBSCAN grows clusters from dense regions, discovering any shape as long as the cluster is connected by density."
   },
   {
@@ -44,11 +44,11 @@
     "question": "What is the silhouette score measuring?",
     "options": [
       "The total number of clusters found",
-      "How similar each point is to its own cluster compared to the nearest other cluster",
+      "The percentage of outliers in the data",
       "The speed of the clustering algorithm",
-      "The percentage of outliers in the data"
+      "How similar each point is to its own cluster compared to the nearest other cluster"
     ],
-    "correct": 1,
+    "correct": 3,
     "explanation": "Silhouette score = (b - a) / max(a, b), where a is mean intra-cluster distance and b is mean nearest-cluster distance. It ranges from -1 (wrong cluster) to +1 (well-clustered)."
   },
   {

--- a/phases/02-ml-fundamentals/08-feature-engineering/quiz.json
+++ b/phases/02-ml-fundamentals/08-feature-engineering/quiz.json
@@ -17,12 +17,12 @@
     "stage": "pre",
     "question": "What is one-hot encoding?",
     "options": [
-      "Replacing each category with its frequency in the dataset",
       "Creating one binary column per category, with exactly one column set to 1 per row",
+      "Replacing each category with its frequency in the dataset",
       "Converting all features to values between 0 and 1",
       "Encoding the target variable as a probability"
     ],
-    "correct": 1,
+    "correct": 0,
     "explanation": "One-hot encoding creates a binary column for each unique category. For a color feature with values red/blue/green, it produces three columns: is_red, is_blue, is_green."
   },
   {
@@ -31,11 +31,11 @@
     "question": "What is the data leakage risk with target encoding?",
     "options": [
       "It makes the model too slow to train",
-      "It replaces categories with the mean target value, which can leak information from the test set if not computed on training data only",
       "It creates too many features",
+      "It replaces categories with the mean target value, which can leak information from the test set if not computed on training data only",
       "It only works with binary targets"
     ],
-    "correct": 1,
+    "correct": 2,
     "explanation": "Target encoding replaces each category with the mean target for that category. If computed on the full dataset (including test data), test labels leak into training features, inflating performance estimates."
   },
   {
@@ -44,11 +44,11 @@
     "question": "TF-IDF weights a word by its inverse document frequency. What is the effect?",
     "options": [
       "Common words like 'the' get high weight because they appear frequently",
-      "Rare, distinctive words get higher weight while common words get lower weight",
+      "Only the most frequent word in each document is kept",
       "All words get equal weight regardless of frequency",
-      "Only the most frequent word in each document is kept"
+      "Rare, distinctive words get higher weight while common words get lower weight"
     ],
-    "correct": 1,
+    "correct": 3,
     "explanation": "IDF = log(total docs / docs containing word). Common words (appearing in many documents) get low IDF. Rare, distinctive words get high IDF, making them more influential in the representation."
   },
   {

--- a/phases/02-ml-fundamentals/14-naive-bayes/quiz.json
+++ b/phases/02-ml-fundamentals/14-naive-bayes/quiz.json
@@ -17,12 +17,12 @@
     "stage": "pre",
     "question": "What does Laplace smoothing prevent in Naive Bayes?",
     "options": [
-      "Overfitting to large datasets",
       "Zero probabilities for words never seen in a class during training",
+      "Overfitting to large datasets",
       "Slow training on high-dimensional data",
       "Class imbalance in the dataset"
     ],
-    "correct": 1,
+    "correct": 0,
     "explanation": "Without smoothing, a word that never appeared in 'spam' training emails would get P(word|spam) = 0, making the entire product zero regardless of other strong evidence. Laplace smoothing adds 1 to each count."
   },
   {
@@ -31,11 +31,11 @@
     "question": "The naive independence assumption is clearly wrong for text. Why does Naive Bayes still classify well?",
     "options": [
       "It only works on very small vocabularies where independence holds",
-      "Classification only needs correct class rankings, not correct probability estimates, and the assumption introduces stable errors that affect all classes similarly",
       "Modern implementations secretly remove the independence assumption",
+      "Classification only needs correct class rankings, not correct probability estimates, and the assumption introduces stable errors that affect all classes similarly",
       "It only works when features are truly independent"
     ],
-    "correct": 1,
+    "correct": 2,
     "explanation": "NB needs to rank classes correctly, not estimate exact probabilities. The independence assumption is high bias but low variance, making it stable with limited data. Correlated features double-count evidence for the correct class too."
   },
   {
@@ -44,11 +44,11 @@
     "question": "When should you use Multinomial NB versus Gaussian NB?",
     "options": [
       "Multinomial for regression, Gaussian for classification",
-      "Multinomial for word count/frequency features, Gaussian for continuous real-valued features",
+      "They are interchangeable -- always use whichever is faster",
       "Multinomial for binary data, Gaussian for multi-class problems",
-      "They are interchangeable -- always use whichever is faster"
+      "Multinomial for word count/frequency features, Gaussian for continuous real-valued features"
     ],
-    "correct": 1,
+    "correct": 3,
     "explanation": "Multinomial NB models feature counts (word frequencies in text). Gaussian NB assumes features follow normal distributions, suitable for continuous features like measurements or sensor readings."
   },
   {

--- a/phases/02-ml-fundamentals/15-time-series/quiz.json
+++ b/phases/02-ml-fundamentals/15-time-series/quiz.json
@@ -17,12 +17,12 @@
     "stage": "pre",
     "question": "What does it mean for a time series to be stationary?",
     "options": [
-      "The values never change over time",
       "Its statistical properties (mean, variance, autocorrelation) do not change over time",
+      "The values never change over time",
       "It has no seasonal patterns",
       "It always trends upward"
     ],
-    "correct": 1,
+    "correct": 0,
     "explanation": "A stationary series has constant mean, variance, and autocorrelation structure over time. Most forecasting methods assume stationarity. Non-stationary series need differencing or detrending first."
   },
   {
@@ -31,11 +31,11 @@
     "question": "What is the purpose of differencing a time series?",
     "options": [
       "To increase the number of data points",
-      "To remove trend and make the series stationary by modeling changes between consecutive values",
       "To convert regression into classification",
+      "To remove trend and make the series stationary by modeling changes between consecutive values",
       "To normalize the values between 0 and 1"
     ],
-    "correct": 1,
+    "correct": 2,
     "explanation": "Differencing replaces each value with the change from the previous value: diff[t] = value[t] - value[t-1]. This removes trend, making the series closer to stationary."
   },
   {
@@ -44,11 +44,11 @@
     "question": "Lag features convert a time series into a supervised learning problem. What is a lag-3 feature for predicting y[t]?",
     "options": [
       "The average of the next 3 values: (y[t+1] + y[t+2] + y[t+3]) / 3",
-      "The value 3 time steps ago: y[t-3]",
+      "The difference between the current value and 3 steps ahead",
       "The 3rd derivative of the series",
-      "The difference between the current value and 3 steps ahead"
+      "The value 3 time steps ago: y[t-3]"
     ],
-    "correct": 1,
+    "correct": 3,
     "explanation": "A lag-3 feature is y[t-3]: the value 3 time steps in the past. Using past values as input features lets standard ML models (regression, trees) make time series predictions without specialized algorithms."
   },
   {

--- a/phases/02-ml-fundamentals/16-anomaly-detection/quiz.json
+++ b/phases/02-ml-fundamentals/16-anomaly-detection/quiz.json
@@ -17,12 +17,12 @@
     "stage": "pre",
     "question": "A temperature of 90F is normal in summer but anomalous in winter. What type of anomaly is this?",
     "options": [
-      "Point anomaly",
       "Contextual anomaly",
+      "Point anomaly",
       "Collective anomaly",
       "Statistical anomaly"
     ],
-    "correct": 1,
+    "correct": 0,
     "explanation": "A contextual anomaly is a value that is unusual given its context (time, location). The value itself might be normal in a different context. Same data point, different interpretation based on surrounding conditions."
   },
   {
@@ -31,11 +31,11 @@
     "question": "The Z-score method flags points more than 3 standard deviations from the mean. When does this approach fail?",
     "options": [
       "When the data is perfectly normally distributed",
-      "When the data is multimodal, skewed, or when outliers in the training data inflate the mean and std",
       "When there are exactly 3 anomalies in the dataset",
+      "When the data is multimodal, skewed, or when outliers in the training data inflate the mean and std",
       "When the features are standardized"
     ],
-    "correct": 1,
+    "correct": 2,
     "explanation": "Z-score assumes a single Gaussian distribution. It fails on multimodal data (multiple clusters), skewed distributions, and when outliers in training data shift the mean/std, making real anomalies harder to detect."
   },
   {
@@ -44,11 +44,11 @@
     "question": "How does Isolation Forest detect anomalies differently from distance-based methods?",
     "options": [
       "It uses neural networks instead of trees",
-      "It isolates points using random splits; anomalies require fewer splits to isolate because they are few and different",
+      "It only works on text data",
       "It computes distances to every other point in the dataset",
-      "It only works on text data"
+      "It isolates points using random splits; anomalies require fewer splits to isolate because they are few and different"
     ],
-    "correct": 1,
+    "correct": 3,
     "explanation": "Isolation Forest randomly partitions data with tree splits. Anomalies, being rare and different, end up isolated (in their own leaf) with fewer splits. Short average path length = more anomalous."
   },
   {

--- a/phases/02-ml-fundamentals/18-feature-selection/quiz.json
+++ b/phases/02-ml-fundamentals/18-feature-selection/quiz.json
@@ -17,12 +17,12 @@
     "stage": "pre",
     "question": "What is the key difference between filter and wrapper feature selection methods?",
     "options": [
-      "Filter methods use a model to evaluate features; wrapper methods use statistics",
       "Filter methods score features using statistics without a model; wrapper methods train a model to evaluate feature subsets",
+      "Filter methods use a model to evaluate features; wrapper methods use statistics",
       "Filter methods are always more accurate than wrapper methods",
       "Wrapper methods can only select one feature at a time"
     ],
-    "correct": 1,
+    "correct": 0,
     "explanation": "Filter methods (variance threshold, mutual information, correlation) score features with statistical measures. Wrapper methods (RFE, forward selection) train models repeatedly to evaluate different feature subsets."
   },
   {
@@ -31,11 +31,11 @@
     "question": "Mutual information can detect relationships that Pearson correlation cannot. What kind?",
     "options": [
       "Linear relationships between continuous features",
-      "Nonlinear relationships such as quadratic or periodic dependencies",
       "Relationships between categorical features only",
+      "Nonlinear relationships such as quadratic or periodic dependencies",
       "Relationships that require more than 1000 data points"
     ],
-    "correct": 1,
+    "correct": 2,
     "explanation": "Pearson correlation only measures linear association. A quadratic relationship (y = x^2) has zero correlation but high mutual information. MI captures any statistical dependency between variables."
   },
   {
@@ -44,11 +44,11 @@
     "question": "L1 (Lasso) regularization performs feature selection as part of training. How?",
     "options": [
       "It removes features with low variance before training starts",
-      "It drives the weights of irrelevant features to exactly zero, effectively eliminating them from the model",
+      "It trains separate models for each feature",
       "It ranks features by correlation with the target",
-      "It trains separate models for each feature"
+      "It drives the weights of irrelevant features to exactly zero, effectively eliminating them from the model"
     ],
-    "correct": 1,
+    "correct": 3,
     "explanation": "L1 regularization adds |w| penalty to the loss. The geometry of the L1 constraint (diamond shape) causes some weight solutions to land exactly at zero, producing sparse models that automatically select features."
   },
   {

--- a/phases/03-deep-learning-core/03-backpropagation/quiz.json
+++ b/phases/03-deep-learning-core/03-backpropagation/quiz.json
@@ -1,35 +1,60 @@
 [
   {
     "question": "What is the chain rule in the context of neural networks?",
-    "options": ["A rule for chaining layers together", "If y = f(g(x)), then dy/dx = f'(g(x)) * g'(x) -- multiply derivatives along the path", "A method for initializing weights", "A technique for batching data"],
+    "options": [
+      "A rule for chaining layers together",
+      "If y = f(g(x)), then dy/dx = f'(g(x)) * g'(x) -- multiply derivatives along the path",
+      "A method for initializing weights",
+      "A technique for batching data"
+    ],
     "correct": 1,
     "explanation": "The chain rule lets you compute the derivative of a composite function by multiplying the local derivatives at each step. Backpropagation applies this systematically through the computational graph.",
     "stage": "pre"
   },
   {
     "question": "Why is backpropagation more efficient than computing each gradient independently?",
-    "options": ["It uses less memory", "It computes all gradients in a single backward pass instead of one forward pass per parameter", "It only works on small networks", "It avoids using the chain rule"],
-    "correct": 1,
+    "options": [
+      "It computes all gradients in a single backward pass instead of one forward pass per parameter",
+      "It uses less memory",
+      "It only works on small networks",
+      "It avoids using the chain rule"
+    ],
+    "correct": 0,
     "explanation": "Computing gradients independently requires one forward pass per parameter (millions of passes for a large network). Backpropagation computes all gradients in one backward pass by reusing intermediate values stored during the forward pass.",
     "stage": "pre"
   },
   {
     "question": "In the backward pass, why do we use '+=' instead of '=' when accumulating gradients?",
-    "options": ["It's a Python convention", "A value might be used in multiple operations, so its gradient is the sum of gradients from all paths", "It prevents overflow", "It makes the code run faster"],
-    "correct": 1,
+    "options": [
+      "It's a Python convention",
+      "It prevents overflow",
+      "A value might be used in multiple operations, so its gradient is the sum of gradients from all paths",
+      "It makes the code run faster"
+    ],
+    "correct": 2,
     "explanation": "When a Value is used as input to multiple operations (e.g., x used in both x*w1 and x*w2), its total gradient is the sum of the gradients flowing back from each operation. Using += accumulates these correctly.",
     "stage": "post"
   },
   {
     "question": "What causes the vanishing gradient problem in deep sigmoid networks?",
-    "options": ["The learning rate is too small", "Sigmoid's derivative has a maximum of 0.25, so gradients shrink exponentially through layers", "The network has too many parameters", "The loss function is poorly chosen"],
-    "correct": 1,
+    "options": [
+      "The learning rate is too small",
+      "The loss function is poorly chosen",
+      "The network has too many parameters",
+      "Sigmoid's derivative has a maximum of 0.25, so gradients shrink exponentially through layers"
+    ],
+    "correct": 3,
     "explanation": "The sigmoid derivative peaks at 0.25 (when z=0). Each layer multiplies the gradient by at most 0.25, so after 10 layers the gradient is at most 0.25^10 = ~0.000001 of the original signal.",
     "stage": "post"
   },
   {
     "question": "Why does topological sort matter in the backward pass?",
-    "options": ["It makes the code cleaner", "It ensures each node's gradient is fully accumulated before propagating to its children", "It speeds up the forward pass", "It reduces memory usage"],
+    "options": [
+      "It makes the code cleaner",
+      "It ensures each node's gradient is fully accumulated before propagating to its children",
+      "It speeds up the forward pass",
+      "It reduces memory usage"
+    ],
     "correct": 1,
     "explanation": "Topological sort ensures we process nodes in the correct order: a node's gradient must be fully accumulated from all downstream paths before we propagate through it. Without this ordering, gradients would be incomplete.",
     "stage": "post"

--- a/phases/03-deep-learning-core/05-loss-functions/quiz.json
+++ b/phases/03-deep-learning-core/05-loss-functions/quiz.json
@@ -1,35 +1,60 @@
 [
   {
     "question": "What does the loss function represent in neural network training?",
-    "options": ["The number of incorrect predictions", "A differentiable measure of how wrong the model's predictions are, which the optimizer minimizes", "The size of the training dataset", "The learning rate schedule"],
+    "options": [
+      "The number of incorrect predictions",
+      "A differentiable measure of how wrong the model's predictions are, which the optimizer minimizes",
+      "The size of the training dataset",
+      "The learning rate schedule"
+    ],
     "correct": 1,
     "explanation": "The loss function maps predictions and targets to a single scalar that the optimizer minimizes via gradient descent. It must be differentiable so gradients can be computed.",
     "stage": "pre"
   },
   {
     "question": "Why is cross-entropy preferred over MSE for classification tasks?",
-    "options": ["Cross-entropy is faster to compute", "Cross-entropy punishes confident wrong predictions exponentially via -log(p), while MSE gives weak gradients near 0 and 1", "MSE only works for regression", "Cross-entropy doesn't require labels"],
-    "correct": 1,
+    "options": [
+      "Cross-entropy punishes confident wrong predictions exponentially via -log(p), while MSE gives weak gradients near 0 and 1",
+      "Cross-entropy is faster to compute",
+      "MSE only works for regression",
+      "Cross-entropy doesn't require labels"
+    ],
+    "correct": 0,
     "explanation": "When a model confidently predicts the wrong class (p near 0 for true class), -log(p) produces a huge loss and strong gradient. MSE produces weak gradients in the same situation because sigmoid is flat near 0 and 1.",
     "stage": "pre"
   },
   {
     "question": "What happens if you use MSE loss for binary classification?",
-    "options": ["Training diverges immediately", "The model can minimize loss by predicting 0.5 for everything, achieving MSE=0.25 without learning", "The model trains normally", "Gradients explode"],
-    "correct": 1,
+    "options": [
+      "Training diverges immediately",
+      "The model trains normally",
+      "The model can minimize loss by predicting 0.5 for everything, achieving MSE=0.25 without learning",
+      "Gradients explode"
+    ],
+    "correct": 2,
     "explanation": "With MSE on a balanced binary dataset, predicting 0.5 for every input gives MSE=0.25 -- the minimum achievable without discrimination. The model satisfies the loss without learning any useful patterns.",
     "stage": "post"
   },
   {
     "question": "What does label smoothing do and why is it useful?",
-    "options": ["It removes noisy labels from the dataset", "It replaces hard 0/1 targets with soft values like 0.1/0.9, preventing overconfident predictions and improving generalization", "It applies a moving average to the loss", "It smooths the learning rate schedule"],
-    "correct": 1,
+    "options": [
+      "It removes noisy labels from the dataset",
+      "It smooths the learning rate schedule",
+      "It applies a moving average to the loss",
+      "It replaces hard 0/1 targets with soft values like 0.1/0.9, preventing overconfident predictions and improving generalization"
+    ],
+    "correct": 3,
     "explanation": "Label smoothing changes targets from [0,0,1,0] to [0.025,0.025,0.925,0.025] (with alpha=0.1). This prevents the model from pushing logits to infinity to achieve hard targets, reducing overconfidence.",
     "stage": "post"
   },
   {
     "question": "In contrastive loss (InfoNCE), what role does the temperature parameter play?",
-    "options": ["It controls the learning rate", "It controls how sharp the similarity distribution is -- lower temperature means harder separation between positives and negatives", "It sets the number of negative samples", "It determines the embedding dimension"],
+    "options": [
+      "It controls the learning rate",
+      "It controls how sharp the similarity distribution is -- lower temperature means harder separation between positives and negatives",
+      "It sets the number of negative samples",
+      "It determines the embedding dimension"
+    ],
     "correct": 1,
     "explanation": "Temperature divides the similarity scores before softmax. Lower temperature (e.g., 0.07) creates a sharper distribution where the model must clearly separate positives from negatives. Higher temperature is more forgiving.",
     "stage": "post"

--- a/phases/03-deep-learning-core/07-regularization/quiz.json
+++ b/phases/03-deep-learning-core/07-regularization/quiz.json
@@ -1,35 +1,60 @@
 [
   {
     "question": "What is overfitting in neural networks?",
-    "options": ["The model is too small to learn the data", "The model memorizes training data instead of learning generalizable patterns, showing a large gap between train and test accuracy", "The model trains too slowly", "The loss function is wrong"],
+    "options": [
+      "The model is too small to learn the data",
+      "The model memorizes training data instead of learning generalizable patterns, showing a large gap between train and test accuracy",
+      "The model trains too slowly",
+      "The loss function is wrong"
+    ],
     "correct": 1,
     "explanation": "Overfitting occurs when a model achieves high training accuracy but poor test accuracy. It has memorized the training data's noise rather than learning the underlying patterns.",
     "stage": "pre"
   },
   {
     "question": "How does dropout regularize a neural network?",
-    "options": ["It removes the worst-performing neurons permanently", "It randomly zeroes neurons during training, forcing the network to learn redundant representations", "It reduces the learning rate", "It removes outliers from the training data"],
-    "correct": 1,
+    "options": [
+      "It randomly zeroes neurons during training, forcing the network to learn redundant representations",
+      "It removes the worst-performing neurons permanently",
+      "It reduces the learning rate",
+      "It removes outliers from the training data"
+    ],
+    "correct": 0,
     "explanation": "During each forward pass, dropout randomly sets neuron outputs to zero with probability p. This prevents co-adaptation (neurons relying on specific others) and is equivalent to training an ensemble of 2^N subnetworks.",
     "stage": "pre"
   },
   {
     "question": "Why do transformers use LayerNorm instead of BatchNorm?",
-    "options": ["LayerNorm is faster to compute", "LayerNorm normalizes across features per sample (batch-independent), which works with variable sequence lengths and small batch sizes", "BatchNorm causes gradient explosion", "LayerNorm was invented more recently"],
-    "correct": 1,
+    "options": [
+      "LayerNorm is faster to compute",
+      "BatchNorm causes gradient explosion",
+      "LayerNorm normalizes across features per sample (batch-independent), which works with variable sequence lengths and small batch sizes",
+      "LayerNorm was invented more recently"
+    ],
+    "correct": 2,
     "explanation": "BatchNorm depends on batch statistics, which are noisy with small batches and meaningless with batch size 1 (common during generation). LayerNorm normalizes across features within each sample, independent of batch size.",
     "stage": "post"
   },
   {
     "question": "What is the key difference between RMSNorm and LayerNorm?",
-    "options": ["RMSNorm uses batch statistics", "RMSNorm skips the mean subtraction, only dividing by the root mean square, giving ~10% speedup with equal accuracy", "RMSNorm adds learnable parameters", "RMSNorm only works on CNNs"],
-    "correct": 1,
+    "options": [
+      "RMSNorm uses batch statistics",
+      "RMSNorm only works on CNNs",
+      "RMSNorm adds learnable parameters",
+      "RMSNorm skips the mean subtraction, only dividing by the root mean square, giving ~10% speedup with equal accuracy"
+    ],
+    "correct": 3,
     "explanation": "RMSNorm removes the mean subtraction step from LayerNorm, which contributes little to accuracy but adds computation. LLaMA, Mistral, and most modern LLMs use RMSNorm for this efficiency gain.",
     "stage": "post"
   },
   {
     "question": "Why is it critical to call model.eval() before running inference in PyTorch?",
-    "options": ["It speeds up computation", "It disables dropout and switches BatchNorm to use running statistics instead of batch statistics, giving deterministic outputs", "It frees GPU memory", "It enables gradient computation"],
+    "options": [
+      "It speeds up computation",
+      "It disables dropout and switches BatchNorm to use running statistics instead of batch statistics, giving deterministic outputs",
+      "It frees GPU memory",
+      "It enables gradient computation"
+    ],
     "correct": 1,
     "explanation": "Without model.eval(), dropout randomly zeroes neurons during inference (causing random output variation) and BatchNorm uses current-batch statistics instead of the stable running averages accumulated during training.",
     "stage": "post"

--- a/phases/03-deep-learning-core/08-weight-initialization/quiz.json
+++ b/phases/03-deep-learning-core/08-weight-initialization/quiz.json
@@ -1,35 +1,60 @@
 [
   {
     "question": "What happens if you initialize all weights in a neural network to zero?",
-    "options": ["The network trains normally but slowly", "All neurons compute identical outputs and receive identical gradients, so the network has only 1 effective neuron per layer", "The network diverges", "Zero init is the recommended default"],
+    "options": [
+      "The network trains normally but slowly",
+      "All neurons compute identical outputs and receive identical gradients, so the network has only 1 effective neuron per layer",
+      "The network diverges",
+      "Zero init is the recommended default"
+    ],
     "correct": 1,
     "explanation": "With zero weights, every neuron in a layer computes the same function, receives the same gradient, and updates identically. This 'symmetry' means hundreds of parameters behave as one.",
     "stage": "pre"
   },
   {
     "question": "Why does the scale of random weight initialization matter?",
-    "options": ["Larger weights train faster", "If variance is too high, activations explode; if too low, activations vanish -- both prevent training", "Scale only matters for the output layer", "It doesn't matter as long as weights are nonzero"],
-    "correct": 1,
+    "options": [
+      "If variance is too high, activations explode; if too low, activations vanish -- both prevent training",
+      "Larger weights train faster",
+      "Scale only matters for the output layer",
+      "It doesn't matter as long as weights are nonzero"
+    ],
+    "correct": 0,
     "explanation": "Each layer multiplies variance by fan_in * Var(w). If this product is > 1, signal explodes exponentially through layers. If < 1, it vanishes. Proper initialization keeps this product at exactly 1.",
     "stage": "pre"
   },
   {
     "question": "What is the formula for Kaiming/He initialization variance?",
-    "options": ["Var(w) = 1/fan_in", "Var(w) = 2/fan_in", "Var(w) = 2/(fan_in + fan_out)", "Var(w) = 1/(fan_in + fan_out)"],
-    "correct": 1,
+    "options": [
+      "Var(w) = 1/fan_in",
+      "Var(w) = 2/(fan_in + fan_out)",
+      "Var(w) = 2/fan_in",
+      "Var(w) = 1/(fan_in + fan_out)"
+    ],
+    "correct": 2,
     "explanation": "Kaiming init uses Var(w) = 2/fan_in. The factor of 2 compensates for ReLU zeroing half the activations (negative values become 0), which effectively halves the fan_in.",
     "stage": "post"
   },
   {
     "question": "When should you use Xavier/Glorot initialization instead of Kaiming/He?",
-    "options": ["Always -- Xavier is universally better", "When using sigmoid or tanh activations, which don't zero half the outputs like ReLU", "When training on small datasets", "When using Adam optimizer"],
-    "correct": 1,
+    "options": [
+      "Always -- Xavier is universally better",
+      "When using Adam optimizer",
+      "When training on small datasets",
+      "When using sigmoid or tanh activations, which don't zero half the outputs like ReLU"
+    ],
+    "correct": 3,
     "explanation": "Xavier init uses Var(w) = 2/(fan_in + fan_out), designed for activations that are roughly linear near zero (sigmoid, tanh). Kaiming's extra factor of 2 compensates for ReLU's half-zeroing, which Xavier doesn't need.",
     "stage": "post"
   },
   {
     "question": "Why does GPT-2 scale residual layer weights by 1/sqrt(2N)?",
-    "options": ["To speed up training", "Each residual addition increases variance, so scaling prevents the accumulated signal from growing unbounded through N layers", "To reduce the number of parameters", "To improve tokenization"],
+    "options": [
+      "To speed up training",
+      "Each residual addition increases variance, so scaling prevents the accumulated signal from growing unbounded through N layers",
+      "To reduce the number of parameters",
+      "To improve tokenization"
+    ],
     "correct": 1,
     "explanation": "Residual connections add sublayer output to the input: x = x + sublayer(x). Each addition increases variance. With N residual layers, variance grows proportionally to N. Scaling by 1/sqrt(2N) keeps the signal stable.",
     "stage": "post"

--- a/phases/03-deep-learning-core/13-debugging-neural-networks/quiz.json
+++ b/phases/03-deep-learning-core/13-debugging-neural-networks/quiz.json
@@ -1,35 +1,60 @@
 [
   {
     "question": "Why is neural network debugging harder than traditional software debugging?",
-    "options": ["Neural networks use different programming languages", "Networks can produce wrong outputs without any error messages or crashes -- the code runs but the results are silently incorrect", "Neural networks can't be tested", "There are no debugging tools for neural networks"],
+    "options": [
+      "Neural networks use different programming languages",
+      "Networks can produce wrong outputs without any error messages or crashes -- the code runs but the results are silently incorrect",
+      "Neural networks can't be tested",
+      "There are no debugging tools for neural networks"
+    ],
     "correct": 1,
     "explanation": "Traditional bugs crash or throw exceptions. Neural network bugs produce a number that's just wrong -- a loss that doesn't decrease, accuracy that plateaus, or outputs that are subtly incorrect. No error message tells you what went wrong.",
     "stage": "pre"
   },
   {
     "question": "What is the 'overfit one batch' debugging technique?",
-    "options": ["Training on the full dataset until it overfits", "Training on a single small batch until the loss reaches near-zero, verifying the model can memorize at least a few examples", "Using a very large batch size", "Overfitting the validation set"],
-    "correct": 1,
+    "options": [
+      "Training on a single small batch until the loss reaches near-zero, verifying the model can memorize at least a few examples",
+      "Training on the full dataset until it overfits",
+      "Using a very large batch size",
+      "Overfitting the validation set"
+    ],
+    "correct": 0,
     "explanation": "If your model can't memorize a tiny batch (e.g., 4-8 samples) to near-zero loss, something is fundamentally broken: wrong architecture, broken loss function, or incorrect training loop. This is the first diagnostic to run.",
     "stage": "pre"
   },
   {
     "question": "Your loss is NaN after a few training steps. What is the most likely cause?",
-    "options": ["The dataset is too small", "Exploding gradients or numerical overflow, often from a learning rate that's too high or missing gradient clipping", "The model has too few parameters", "The activation function is wrong"],
-    "correct": 1,
+    "options": [
+      "The dataset is too small",
+      "The model has too few parameters",
+      "Exploding gradients or numerical overflow, often from a learning rate that's too high or missing gradient clipping",
+      "The activation function is wrong"
+    ],
+    "correct": 2,
     "explanation": "NaN loss typically comes from numerical overflow: gradients explode, weights grow unbounded, and operations like log(0) or exp(1000) produce infinity/NaN. Lower the learning rate or add gradient clipping.",
     "stage": "post"
   },
   {
     "question": "Your training loss decreases but validation loss stays flat from the start. What does this indicate?",
-    "options": ["The model is overfitting", "The model is learning training data patterns but they don't generalize -- likely a data pipeline issue (train/val data mismatch) or severe overfitting", "The learning rate is too low", "The model needs more layers"],
-    "correct": 1,
+    "options": [
+      "The model is overfitting",
+      "The model needs more layers",
+      "The learning rate is too low",
+      "The model is learning training data patterns but they don't generalize -- likely a data pipeline issue (train/val data mismatch) or severe overfitting"
+    ],
+    "correct": 3,
     "explanation": "If validation loss never improves, the model is either memorizing training noise (overfitting), or there's a data pipeline bug where train and validation distributions are fundamentally different.",
     "stage": "post"
   },
   {
     "question": "What should you check first when your loss curve is completely flat (loss doesn't decrease at all)?",
-    "options": ["Try a different architecture", "Verify gradients are nonzero, the learning rate is high enough, and the loss function actually depends on the model's predictions", "Add more training data", "Switch to a different optimizer"],
+    "options": [
+      "Try a different architecture",
+      "Verify gradients are nonzero, the learning rate is high enough, and the loss function actually depends on the model's predictions",
+      "Add more training data",
+      "Switch to a different optimizer"
+    ],
     "correct": 1,
     "explanation": "A flat loss means the model isn't updating. Common causes: zero gradients (dead neurons, detached tensors), learning rate too small, or a loss function that doesn't flow gradients to the model (e.g., using .item() before .backward()).",
     "stage": "post"

--- a/phases/04-computer-vision/05-transfer-learning/quiz.json
+++ b/phases/04-computer-vision/05-transfer-learning/quiz.json
@@ -3,35 +3,60 @@
     {
       "stage": "pre",
       "question": "You have 500 labelled images for a new task close to the ImageNet distribution. Which regime makes the most sense?",
-      "options": ["Train a ResNet-50 from scratch", "Freeze an ImageNet-pretrained backbone and train only a new linear head", "Fine-tune every layer with the same large LR", "Ignore pretrained weights; small datasets work best with small models"],
+      "options": [
+        "Train a ResNet-50 from scratch",
+        "Freeze an ImageNet-pretrained backbone and train only a new linear head",
+        "Fine-tune every layer with the same large LR",
+        "Ignore pretrained weights; small datasets work best with small models"
+      ],
       "correct": 1,
       "explanation": "With 500 images you do not have enough signal to train a deep network from scratch or to safely fine-tune all layers end-to-end without destroying pretrained features. Freezing the backbone and training only a new head (linear probe) uses the pretrained features directly and is the standard recipe for small, close-domain datasets."
     },
     {
       "stage": "pre",
       "question": "Why do early conv layers of an ImageNet-pretrained network transfer well to medical images even though ImageNet contains no X-rays?",
-      "options": ["PyTorch re-initialises early layers automatically", "Early layers encode generic visual primitives — edges, orientations, contrast — that are shared across almost any visual domain; only late layers specialise to ImageNet categories", "ImageNet secretly contains medical data", "Transfer only works when domains match"],
-      "correct": 1,
+      "options": [
+        "Early layers encode generic visual primitives — edges, orientations, contrast — that are shared across almost any visual domain; only late layers specialise to ImageNet categories",
+        "PyTorch re-initialises early layers automatically",
+        "ImageNet secretly contains medical data",
+        "Transfer only works when domains match"
+      ],
+      "correct": 0,
       "explanation": "Gabor-like filters and simple texture detectors are the features early CNN layers learn on any natural-image corpus. They reflect the statistics of light, shadow, and edges that hold across photography, medical imaging, microscopy, and satellite data. Late layers progressively specialise, which is why fine-tuning focuses on the last few blocks."
     },
     {
       "stage": "post",
       "question": "When fine-tuning end-to-end with discriminative learning rates, why should early layers get a smaller LR than late layers?",
-      "options": ["Early layers have fewer parameters", "Early layers encode general features you want to preserve; late layers encode task-specific features that must move; a smaller LR on early layers prevents feature drift and catastrophic forgetting", "PyTorch requires layer-wise LR for correctness", "A smaller LR in the early layers speeds up training"],
-      "correct": 1,
+      "options": [
+        "Early layers have fewer parameters",
+        "PyTorch requires layer-wise LR for correctness",
+        "Early layers encode general features you want to preserve; late layers encode task-specific features that must move; a smaller LR on early layers prevents feature drift and catastrophic forgetting",
+        "A smaller LR in the early layers speeds up training"
+      ],
+      "correct": 2,
       "explanation": "Early layers already encode the right visual primitives; you want tiny updates so those features are preserved. Late layers need to move toward the new task. One learning rate for the whole model forces a compromise that hurts both ends. Discriminative LRs let each stage move at its own pace, which is the empirical sweet spot for fine-tuning."
     },
     {
       "stage": "post",
       "question": "You fine-tune a ResNet on a 10-class medical dataset of 800 grayscale images (replicated to 3 channels). Accuracy is 10% (random chance for 10 classes). What is the most likely cause?",
-      "options": ["You used the wrong loss function", "BatchNorm running statistics are from ImageNet RGB photos and badly mismatch the grayscale-medical distribution, so the first few BN layers produce noise that propagates forward", "ResNet cannot handle grayscale input", "800 images is simply too few for any transfer learning"],
-      "correct": 1,
+      "options": [
+        "You used the wrong loss function",
+        "800 images is simply too few for any transfer learning",
+        "ResNet cannot handle grayscale input",
+        "BatchNorm running statistics are from ImageNet RGB photos and badly mismatch the grayscale-medical distribution, so the first few BN layers produce noise that propagates forward"
+      ],
+      "correct": 3,
       "explanation": "BatchNorm keeps running_mean and running_var from ImageNet. On a small, distribution-shifted dataset those buffers never adapt fast enough during a short fine-tune, and BN normalises activations with the wrong stats. Fixes: freeze BN statistics, switch to GroupNorm, or pretrain BN stats with a BN-only warmup pass on the target dataset."
     },
     {
       "stage": "post",
       "question": "You compare two runs: (a) linear probe on frozen ImageNet backbone, 82% accuracy; (b) end-to-end fine-tune, 78% accuracy. What should you conclude?",
-      "options": ["Fine-tuning is not helpful; ship the linear probe", "A fine-tune that ends below the linear probe is almost always a training bug — LR too high, BN mishandled, or scheduler/optimizer misconfigured; diagnose before concluding anything about transfer", "The dataset is too large", "Pretrained weights are bad"],
+      "options": [
+        "Fine-tuning is not helpful; ship the linear probe",
+        "A fine-tune that ends below the linear probe is almost always a training bug — LR too high, BN mishandled, or scheduler/optimizer misconfigured; diagnose before concluding anything about transfer",
+        "The dataset is too large",
+        "Pretrained weights are bad"
+      ],
       "correct": 1,
       "explanation": "Fine-tuning should always beat or match the linear probe, since the linear probe is a special case of fine-tuning with backbone LR = 0. If fine-tune is worse, the pipeline is actively destroying pretrained features. The fix is to lower backbone LR, apply discriminative LRs, or freeze BN — not to abandon fine-tuning."
     }

--- a/phases/04-computer-vision/07-semantic-segmentation-unet/quiz.json
+++ b/phases/04-computer-vision/07-semantic-segmentation-unet/quiz.json
@@ -3,35 +3,60 @@
     {
       "stage": "pre",
       "question": "Why does U-Net need skip connections between the encoder and decoder?",
-      "options": ["To speed up training", "The encoder compresses spatial detail to gain context; the decoder cannot reconstruct sharp boundaries without access to the encoder's high-resolution feature maps, and skips supply exactly that", "Because transposed convolutions require extra inputs", "To match PyTorch shape conventions"],
+      "options": [
+        "To speed up training",
+        "The encoder compresses spatial detail to gain context; the decoder cannot reconstruct sharp boundaries without access to the encoder's high-resolution feature maps, and skips supply exactly that",
+        "Because transposed convolutions require extra inputs",
+        "To match PyTorch shape conventions"
+      ],
       "correct": 1,
       "explanation": "Without skips, a U-Net's decoder is producing H x W predictions from a very low-resolution bottleneck, which cannot resolve crisp edges. Skip connections splice the encoder's high-resolution, low-semantic features into the decoder's low-resolution, high-semantic features so both context and detail are available at every output stage."
     },
     {
       "stage": "pre",
       "question": "A segmentation task has 99% background pixels and 1% tumour pixels. You train with plain cross-entropy and reach 99% pixel accuracy. What happened?",
-      "options": ["The model converged", "The model learned to predict background for every pixel; pixel accuracy is dominated by the majority class and ignores the class you actually care about", "The loss function was implemented incorrectly", "The optimizer failed"],
-      "correct": 1,
+      "options": [
+        "The model learned to predict background for every pixel; pixel accuracy is dominated by the majority class and ignores the class you actually care about",
+        "The model converged",
+        "The loss function was implemented incorrectly",
+        "The optimizer failed"
+      ],
+      "correct": 0,
       "explanation": "Pixel accuracy on an imbalanced dataset is a useless metric. The network collects the easy 99% by always predicting background and produces empty tumour masks. The fix: combine cross-entropy with Dice loss (overlap-based, scale-free) and report IoU/Dice per foreground class."
     },
     {
       "stage": "post",
       "question": "Which task type separates individual cars of the same class from each other?",
-      "options": ["Semantic segmentation", "Instance segmentation", "Both produce the same output", "Neither — that requires a detection model instead"],
-      "correct": 1,
+      "options": [
+        "Semantic segmentation",
+        "Both produce the same output",
+        "Instance segmentation",
+        "Neither — that requires a detection model instead"
+      ],
+      "correct": 2,
       "explanation": "Semantic segmentation labels every pixel with a class but merges touching instances of the same class into one blob. Instance segmentation keeps instance IDs, so each car, each person, each apple is a separate predicted mask. Panoptic segmentation unifies both: semantic labels for stuff, instance IDs for things."
     },
     {
       "stage": "post",
       "question": "You swap U-Net's bilinear upsample + 3x3 conv for a ConvTranspose2d with kernel_size=2, stride=2 and see checkerboard artifacts in the output. Why?",
-      "options": ["Transposed conv is broken in PyTorch", "When kernel_size is not evenly divisible by stride, output pixels receive unequal contributions from input pixels, producing a periodic pattern in the output that looks like a checkerboard", "The learning rate was too low", "Batch norm has to be added before transposed conv"],
-      "correct": 1,
+      "options": [
+        "Transposed conv is broken in PyTorch",
+        "Batch norm has to be added before transposed conv",
+        "The learning rate was too low",
+        "When kernel_size is not evenly divisible by stride, output pixels receive unequal contributions from input pixels, producing a periodic pattern in the output that looks like a checkerboard"
+      ],
+      "correct": 3,
       "explanation": "Checkerboard artifacts come from uneven overlap of the transposed convolution's receptive field across output positions. Using kernel_size = stride * n (e.g. kernel 4, stride 2) or replacing transposed conv with bilinear upsample + conv eliminates the artifacts. The modern default is bilinear + conv for this reason."
     },
     {
       "stage": "post",
       "question": "You report mIoU = 0.78 on a 10-class segmentation task. Why should you also publish per-class IoU?",
-      "options": ["Per-class IoU is required by PyTorch", "Mean IoU hides individual class failures; a mIoU of 0.78 is consistent with eight classes at 0.9 and two at 0.3, which is a very different deployment story than all classes near 0.78", "Per-class IoU is always higher than mIoU", "It is only needed for medical imaging"],
+      "options": [
+        "Per-class IoU is required by PyTorch",
+        "Mean IoU hides individual class failures; a mIoU of 0.78 is consistent with eight classes at 0.9 and two at 0.3, which is a very different deployment story than all classes near 0.78",
+        "Per-class IoU is always higher than mIoU",
+        "It is only needed for medical imaging"
+      ],
       "correct": 1,
       "explanation": "An aggregate mean compresses the distribution of per-class scores, which is exactly what the reader needs to decide whether the model is ready to ship. Two weak classes in an otherwise strong model may make the system unusable for the intended task; a flat profile means the model needs a uniform data upgrade. Always publish per-class metrics alongside the mean."
     }

--- a/phases/04-computer-vision/08-instance-segmentation-mask-rcnn/quiz.json
+++ b/phases/04-computer-vision/08-instance-segmentation-mask-rcnn/quiz.json
@@ -3,35 +3,60 @@
     {
       "stage": "pre",
       "question": "Why did Mask R-CNN replace RoIPool with RoIAlign?",
-      "options": ["RoIAlign is faster on GPUs", "RoIPool rounds box coordinates to integers at multiple steps, misaligning the feature map from the input pixels by up to a feature-map pixel; RoIAlign uses bilinear sampling with no rounding, preserving localisation", "RoIPool only works on CPU", "RoIPool was a copyright issue"],
+      "options": [
+        "RoIAlign is faster on GPUs",
+        "RoIPool rounds box coordinates to integers at multiple steps, misaligning the feature map from the input pixels by up to a feature-map pixel; RoIAlign uses bilinear sampling with no rounding, preserving localisation",
+        "RoIPool only works on CPU",
+        "RoIPool was a copyright issue"
+      ],
       "correct": 1,
       "explanation": "RoIPool's rounding costs up to a stride-sized misalignment (e.g. 32 pixels on a stride-32 feature map). RoIAlign samples at exact float coordinates via bilinear interpolation. The change lifted mask AP by 3-4 points on COCO in the original paper and is now standard in every detector that cares about localisation."
     },
     {
       "stage": "pre",
       "question": "Mask R-CNN's mask head outputs a 28x28 mask per class per proposal. Why per class?",
-      "options": ["Because binary masks need per-class channels for backprop", "Decoupling mask prediction from classification: the mask head only has to learn the shape for each class separately, so the classifier's decision does not affect which mask is produced, only which channel is read at inference", "Binary masks overflow in a single channel", "The paper required it"],
-      "correct": 1,
+      "options": [
+        "Decoupling mask prediction from classification: the mask head only has to learn the shape for each class separately, so the classifier's decision does not affect which mask is produced, only which channel is read at inference",
+        "Because binary masks need per-class channels for backprop",
+        "Binary masks overflow in a single channel",
+        "The paper required it"
+      ],
+      "correct": 0,
       "explanation": "Producing one mask per class per proposal decouples mask shape learning from classification. At inference you read only the channel matching the predicted class. This multi-task decoupling matters because mask shape and class probability are different targets that train with different gradients."
     },
     {
       "stage": "post",
       "question": "torchvision's Mask R-CNN prediction dict has `labels` that start at 1, not 0. Why?",
-      "options": ["Legacy bug", "Class 0 is reserved for background; user classes are always 1-based so the classifier head can treat background as a real class with its own logits and gradients", "torchvision uses 1-based indexing throughout", "Training data determined it"],
-      "correct": 1,
+      "options": [
+        "Legacy bug",
+        "torchvision uses 1-based indexing throughout",
+        "Class 0 is reserved for background; user classes are always 1-based so the classifier head can treat background as a real class with its own logits and gradients",
+        "Training data determined it"
+      ],
+      "correct": 2,
       "explanation": "Most detectors treat background as class 0 and explicit foreground classes as 1..C. The softmax over (C+1) classes lets the network learn to actively predict 'no object here' rather than just low confidence on all classes. A dataset with 4 real classes needs num_classes = 5 when swapping the predictor."
     },
     {
       "stage": "post",
       "question": "You fine-tune Mask R-CNN on a 500-image dataset and val mAP plateaus while train loss keeps dropping. What is the first thing to try?",
-      "options": ["Add more epochs", "Freeze the backbone and FPN so the model only fine-tunes the RPN and heads; 500 images is too few to update 23M backbone parameters without overfitting", "Switch to segmentation U-Net", "Use a higher learning rate"],
-      "correct": 1,
+      "options": [
+        "Add more epochs",
+        "Use a higher learning rate",
+        "Switch to segmentation U-Net",
+        "Freeze the backbone and FPN so the model only fine-tunes the RPN and heads; 500 images is too few to update 23M backbone parameters without overfitting"
+      ],
+      "correct": 3,
       "explanation": "On small datasets you do not have enough signal to fine-tune every parameter. Freezing the pretrained backbone and FPN (ImageNet + COCO features) and training only the RPN objectness head and the two classifier/mask heads is the standard recipe and usually fixes this plateau in one training run."
     },
     {
       "stage": "post",
       "question": "The FPN inside Mask R-CNN has four levels (P2, P3, P4, P5) at strides 4, 8, 16, 32. Why not just use one level?",
-      "options": ["To use more GPU memory", "Objects in natural images span a range of scales; routing each proposal to the FPN level matching its size gives the head a feature map with the right receptive field for that object, which is strictly better than always using one scale", "Four levels is arbitrary", "To reduce parameter count"],
+      "options": [
+        "To use more GPU memory",
+        "Objects in natural images span a range of scales; routing each proposal to the FPN level matching its size gives the head a feature map with the right receptive field for that object, which is strictly better than always using one scale",
+        "Four levels is arbitrary",
+        "To reduce parameter count"
+      ],
       "correct": 1,
       "explanation": "A small object on a stride-32 feature map occupies a single cell, which has almost no spatial information. FPN routes small objects to the high-resolution, shallow levels (P2) and large objects to the low-resolution, deep levels (P5), matching receptive field to object size. This is why every modern detector has a pyramid."
     }

--- a/phases/04-computer-vision/09-image-generation-gans/quiz.json
+++ b/phases/04-computer-vision/09-image-generation-gans/quiz.json
@@ -3,35 +3,60 @@
     {
       "stage": "pre",
       "question": "Why does GAN training use the non-saturating generator loss -log(D(G(z))) instead of log(1 - D(G(z)))?",
-      "options": ["They are mathematically different and produce better equilibria", "Early in training D(G(z)) is near zero, so log(1 - D(G(z))) has vanishing gradient; -log(D(G(z))) has large gradient there so G receives a useful signal", "It speeds up the discriminator", "It is required by PyTorch"],
+      "options": [
+        "They are mathematically different and produce better equilibria",
+        "Early in training D(G(z)) is near zero, so log(1 - D(G(z))) has vanishing gradient; -log(D(G(z))) has large gradient there so G receives a useful signal",
+        "It speeds up the discriminator",
+        "It is required by PyTorch"
+      ],
       "correct": 1,
       "explanation": "The two losses share the same gradient direction but very different magnitudes when D(G(z)) is small. log(1 - D(G(z))) plateaus at zero gradient there. The non-saturating form stays informative across the whole range. Goodfellow noted this tweak in the original paper and every modern GAN uses it."
     },
     {
       "stage": "pre",
       "question": "DCGAN's rules say to use strided convolutions instead of pooling. Why?",
-      "options": ["Pooling is slower on GPUs", "Pooling is non-learnable and throws away information the generator might need; strided convs let the network learn its own downsampling, which empirically produces sharper generated images", "Pooling breaks gradient flow", "Pooling is incompatible with batch norm"],
-      "correct": 1,
+      "options": [
+        "Pooling is non-learnable and throws away information the generator might need; strided convs let the network learn its own downsampling, which empirically produces sharper generated images",
+        "Pooling is slower on GPUs",
+        "Pooling breaks gradient flow",
+        "Pooling is incompatible with batch norm"
+      ],
+      "correct": 0,
       "explanation": "Max-pool is a hand-picked downsampling that discards everything but the max. In a generative setting the model benefits from a learned downsampling that can preserve information across the stride. Strided convolutions in D and strided transposed convolutions in G were the architectural change that made DCGANs trainable."
     },
     {
       "stage": "post",
       "question": "You train a GAN and notice G produces almost identical samples regardless of the input noise. Which failure is this?",
-      "options": ["Vanishing gradients", "Mode collapse — G has found a narrow region of the data distribution that consistently fools D and has no incentive to explore; fixes include spectral norm, minibatch discrimination, or a larger batch", "Oscillation", "The dataset is too small"],
-      "correct": 1,
+      "options": [
+        "Vanishing gradients",
+        "Oscillation",
+        "Mode collapse — G has found a narrow region of the data distribution that consistently fools D and has no incentive to explore; fixes include spectral norm, minibatch discrimination, or a larger batch",
+        "The dataset is too small"
+      ],
+      "correct": 2,
       "explanation": "Mode collapse is the characteristic GAN failure where samples lack diversity. The diagnostic is obvious: noise in, same image out. Fixes all target the discriminator's ability to punish lack of diversity, either by making D more expressive (spectral norm, minibatch discrimination) or by giving G less room to collapse (larger batch, conditional labels)."
     },
     {
       "stage": "post",
       "question": "Why do DCGAN training scripts use Adam with betas=(0.5, 0.999) instead of the default (0.9, 0.999)?",
-      "options": ["The default is broken", "A lower beta1 reduces momentum; in an adversarial game, heavy momentum keeps each optimizer in the wrong direction too long when the other network's behaviour changes, which causes instability", "Adam is only supported with beta1=0.5 on CUDA", "It is a typo propagated through tutorials"],
-      "correct": 1,
+      "options": [
+        "The default is broken",
+        "It is a typo propagated through tutorials",
+        "Adam is only supported with beta1=0.5 on CUDA",
+        "A lower beta1 reduces momentum; in an adversarial game, heavy momentum keeps each optimizer in the wrong direction too long when the other network's behaviour changes, which causes instability"
+      ],
+      "correct": 3,
       "explanation": "Adam's default beta1=0.9 averages gradients over roughly 10 steps. In a stationary objective that is helpful. In an adversarial game where the loss landscape shifts every D and G update, that averaging delays the optimizer's response and causes oscillation. Radford et al. found beta1=0.5 much more stable, and it is now the GAN default."
     },
     {
       "stage": "post",
       "question": "A colleague reports a GAN with D loss near zero and G loss increasing over training. What is happening and how do you fix it?",
-      "options": ["Both nets are improving correctly", "The discriminator has become too strong and drives G's gradient to zero; fixes include a smaller D, spectral norm, label smoothing on real labels (0.9 instead of 1.0), or switching to WGAN-GP", "The generator is correctly overfitting", "Nothing — this is the equilibrium"],
+      "options": [
+        "Both nets are improving correctly",
+        "The discriminator has become too strong and drives G's gradient to zero; fixes include a smaller D, spectral norm, label smoothing on real labels (0.9 instead of 1.0), or switching to WGAN-GP",
+        "The generator is correctly overfitting",
+        "Nothing — this is the equilibrium"
+      ],
       "correct": 1,
       "explanation": "D's loss near zero means D is perfect on both real and fake. At that point the BCE gradient to G vanishes: G sees a near-zero signal no matter what it outputs. The fix is to weaken D or use a loss that does not saturate. Spectral norm (limits D's Lipschitz constant) and WGAN-GP (uses Earth-Mover distance instead of BCE) are the two standard rescues."
     }

--- a/phases/04-computer-vision/10-image-generation-diffusion/quiz.json
+++ b/phases/04-computer-vision/10-image-generation-diffusion/quiz.json
@@ -3,35 +3,60 @@
     {
       "stage": "pre",
       "question": "Why can diffusion training pick any timestep t directly instead of simulating the forward Markov chain step by step?",
-      "options": ["It is an approximation that ignores the intermediate steps", "Because the composition of many Gaussian additions still yields a Gaussian, giving a closed-form q(x_t|x_0) = N(sqrt(alpha_bar_t) x_0, (1 - alpha_bar_t) I) that you can sample in one step", "Because x_t is independent of x_0", "It is required by PyTorch's autograd"],
+      "options": [
+        "It is an approximation that ignores the intermediate steps",
+        "Because the composition of many Gaussian additions still yields a Gaussian, giving a closed-form q(x_t|x_0) = N(sqrt(alpha_bar_t) x_0, (1 - alpha_bar_t) I) that you can sample in one step",
+        "Because x_t is independent of x_0",
+        "It is required by PyTorch's autograd"
+      ],
       "correct": 1,
       "explanation": "Repeated Gaussian additions close up analytically. The cumulative product alpha_bar_t encodes 'how much signal is left after t steps', and you can sample x_t directly without running the chain. This is why diffusion training is O(1) per step rather than O(T)."
     },
     {
       "stage": "pre",
       "question": "What does a DDPM's neural network actually predict?",
-      "options": ["The next image x_{t-1} directly", "The noise epsilon that was added at step t, from which x_{t-1}'s mean is derived analytically", "The class label of the input", "The signal-to-noise ratio"],
-      "correct": 1,
+      "options": [
+        "The noise epsilon that was added at step t, from which x_{t-1}'s mean is derived analytically",
+        "The next image x_{t-1} directly",
+        "The class label of the input",
+        "The signal-to-noise ratio"
+      ],
+      "correct": 0,
       "explanation": "DDPM parameterises the model to predict epsilon. Given the noise prediction and the noise schedule, x_{t-1}'s Gaussian mean and variance are closed-form. Predicting epsilon instead of x_0 or x_{t-1} simplifies the loss to a plain MSE and gives numerically better gradients."
     },
     {
       "stage": "post",
       "question": "Why does DDIM achieve similar sample quality to DDPM with ~20x fewer steps?",
-      "options": ["DDIM changes the training objective", "DDIM reformulates sampling as a deterministic ODE whose trajectory can be discretised with far fewer steps while hitting nearly the same endpoint; no retraining required", "DDIM uses a faster model architecture", "DDIM generates smaller images"],
-      "correct": 1,
+      "options": [
+        "DDIM changes the training objective",
+        "DDIM uses a faster model architecture",
+        "DDIM reformulates sampling as a deterministic ODE whose trajectory can be discretised with far fewer steps while hitting nearly the same endpoint; no retraining required",
+        "DDIM generates smaller images"
+      ],
+      "correct": 2,
       "explanation": "DDIM's key observation is that the reverse process, when re-parameterised deterministically, becomes an ODE that a few steps approximate well. The model (weights and loss) is unchanged from DDPM; only the sampler differs. A DDPM checkpoint can be used with a DDIM, DPM-Solver, or Euler sampler interchangeably."
     },
     {
       "stage": "post",
       "question": "You plot `alpha_bar_t` for a linear beta schedule with T=1000 and see it drops to near-zero by t=600. Why does this matter?",
-      "options": ["It does not matter", "The last 40% of timesteps add almost no signal; training those timesteps teaches the network to denoise noise that is already approximately N(0, I), which wastes capacity. Cosine or sigmoid schedules fix this by spreading the noise injection more evenly", "alpha_bar_t must be zero at the end", "PyTorch requires a linear schedule"],
-      "correct": 1,
+      "options": [
+        "It does not matter",
+        "PyTorch requires a linear schedule",
+        "alpha_bar_t must be zero at the end",
+        "The last 40% of timesteps add almost no signal; training those timesteps teaches the network to denoise noise that is already approximately N(0, I), which wastes capacity. Cosine or sigmoid schedules fix this by spreading the noise injection more evenly"
+      ],
+      "correct": 3,
       "explanation": "Linear beta schedules finish the diffusion process too early. By t=600 the signal is already destroyed; training and sampling through t=600-1000 adds nothing. Cosine schedules (Nichol & Dhariwal) keep signal around longer, which is why modern models use them, especially at lower resolutions."
     },
     {
       "stage": "post",
       "question": "Why does time conditioning get added to the U-Net via a sinusoidal embedding instead of a one-hot timestep?",
-      "options": ["One-hot vectors are too large", "A sinusoidal embedding is smooth in t, which lets the network interpolate between timesteps it has not seen exactly and encodes scale information the architecture can use additively at multiple depths", "Sinusoidal is required by BatchNorm", "One-hot would violate the chain rule"],
+      "options": [
+        "One-hot vectors are too large",
+        "A sinusoidal embedding is smooth in t, which lets the network interpolate between timesteps it has not seen exactly and encodes scale information the architecture can use additively at multiple depths",
+        "Sinusoidal is required by BatchNorm",
+        "One-hot would violate the chain rule"
+      ],
       "correct": 1,
       "explanation": "Sinusoidal embeddings give the network a continuous representation of t at multiple frequencies. Any timestep is a unique point in that embedding space, and nearby timesteps are nearby embeddings. That lets the model generalise across all T values with far fewer parameters than a learned per-timestep embedding. Same idea as transformer positional encoding."
     }

--- a/phases/04-computer-vision/11-stable-diffusion/quiz.json
+++ b/phases/04-computer-vision/11-stable-diffusion/quiz.json
@@ -3,35 +3,60 @@
     {
       "stage": "pre",
       "question": "Why does Stable Diffusion run its DDPM in a 4x64x64 latent space rather than directly on 3x512x512 pixel images?",
-      "options": ["Latents are easier to visualise", "Training and sampling on 16,384 latent values instead of 786,432 pixels is roughly 48x cheaper; a pretrained VAE handles the image <-> latent conversion, and the diffusion model only has to model the structured latent manifold", "Latents are the native output of GPUs", "To make inference deterministic"],
+      "options": [
+        "Latents are easier to visualise",
+        "Training and sampling on 16,384 latent values instead of 786,432 pixels is roughly 48x cheaper; a pretrained VAE handles the image <-> latent conversion, and the diffusion model only has to model the structured latent manifold",
+        "Latents are the native output of GPUs",
+        "To make inference deterministic"
+      ],
       "correct": 1,
       "explanation": "Latent diffusion is the single innovation that made consumer-GPU text-to-image practical. The VAE compresses 48x spatial and channel information. The diffusion model can spend its entire parameter and compute budget modelling the latent manifold, which is the part the user sees after decoding."
     },
     {
       "stage": "pre",
       "question": "What does classifier-free guidance (CFG) do at inference?",
-      "options": ["Runs two separate models and averages them", "Uses one model trained to predict both conditional eps_cond and unconditional eps_uncond noise, then combines them as eps = eps_uncond + w*(eps_cond - eps_uncond) to amplify prompt adherence", "Adds a classifier head to the model at test time", "Uses a larger scheduler"],
-      "correct": 1,
+      "options": [
+        "Uses one model trained to predict both conditional eps_cond and unconditional eps_uncond noise, then combines them as eps = eps_uncond + w*(eps_cond - eps_uncond) to amplify prompt adherence",
+        "Runs two separate models and averages them",
+        "Adds a classifier head to the model at test time",
+        "Uses a larger scheduler"
+      ],
+      "correct": 0,
       "explanation": "CFG trains a single model with the conditioning dropped 10% of the time so the same weights produce both cond and uncond predictions. At inference the formula above amplifies the conditional direction. Guidance scale w is the standard knob to tune prompt adherence vs diversity; SD defaults to 7.5."
     },
     {
       "stage": "post",
       "question": "You swap SD's default scheduler for DPM-Solver++ 2M Karras and reduce num_inference_steps from 50 to 20. What is the expected result?",
-      "options": ["Worse quality and longer runtime", "Comparable quality in roughly half the time; DPM-Solver++ is a second-order ODE integrator that converges in fewer steps than DDIM for the same sample quality", "Numerical instability", "You must also retrain the model"],
-      "correct": 1,
+      "options": [
+        "Worse quality and longer runtime",
+        "Numerical instability",
+        "Comparable quality in roughly half the time; DPM-Solver++ is a second-order ODE integrator that converges in fewer steps than DDIM for the same sample quality",
+        "You must also retrain the model"
+      ],
+      "correct": 2,
       "explanation": "Schedulers are decoupled from the model weights. DPM-Solver++ is a higher-order solver that achieves DDIM-50 quality in about 20 steps. Zero retraining required, and it is the production default in 2026. Going below 8 steps typically needs distilled/consistency-model variants like LCM or Turbo."
     },
     {
       "stage": "post",
       "question": "Why is LoRA fine-tuning popular for Stable Diffusion instead of full fine-tuning?",
-      "options": ["LoRA produces better images by default", "LoRA keeps the 860M base U-Net frozen and inserts tiny rank-decomposition matrices into attention layers, so a fine-tune trains in minutes on consumer hardware, produces 10-50 MB adapters, and can be swapped or mixed at inference", "LoRA is required by diffusers", "LoRA prevents overfitting entirely"],
-      "correct": 1,
+      "options": [
+        "LoRA produces better images by default",
+        "LoRA prevents overfitting entirely",
+        "LoRA is required by diffusers",
+        "LoRA keeps the 860M base U-Net frozen and inserts tiny rank-decomposition matrices into attention layers, so a fine-tune trains in minutes on consumer hardware, produces 10-50 MB adapters, and can be swapped or mixed at inference"
+      ],
+      "correct": 3,
       "explanation": "LoRA's value is training cost and distribution. Full SD fine-tuning updates 860M+ parameters and needs 20+ GB of VRAM. LoRA updates ~1-10M parameters and fits in 6-8 GB. The base model is unchanged, so the same LoRA loads into any compatible checkpoint, and multiple LoRAs can be combined. CivitAI's ecosystem is entirely LoRAs."
     },
     {
       "stage": "post",
       "question": "You generate the same prompt with guidance_scale=15 and see oversaturated colours and burned-in artefacts. What is going on?",
-      "options": ["The model is broken", "CFG amplifies the conditional direction; past a threshold around 9-12 the amplification pushes predictions outside the manifold the VAE can decode cleanly, producing visual artefacts. Drop guidance to 7-9 for balanced results", "The VAE needs retraining", "The seed is wrong"],
+      "options": [
+        "The model is broken",
+        "CFG amplifies the conditional direction; past a threshold around 9-12 the amplification pushes predictions outside the manifold the VAE can decode cleanly, producing visual artefacts. Drop guidance to 7-9 for balanced results",
+        "The VAE needs retraining",
+        "The seed is wrong"
+      ],
       "correct": 1,
       "explanation": "CFG's formula is unbounded: higher w moves the prediction further along (eps_cond - eps_uncond). Past a point, you leave the trained distribution and the VAE decoder produces over-saturated, posterised images. Production default is 7-8. Some newer schedulers support CFG scheduling (lower w at final timesteps) to avoid this."
     }

--- a/phases/04-computer-vision/13-3d-vision-nerf/quiz.json
+++ b/phases/04-computer-vision/13-3d-vision-nerf/quiz.json
@@ -3,35 +3,60 @@
     {
       "stage": "pre",
       "question": "Why cannot a plain CNN process a point cloud directly?",
-      "options": ["Point clouds are too large", "A CNN assumes input pixels arranged on a regular grid with neighbourhood structure; a point cloud is an unordered set of points in R^3 with no grid and variable size, violating both assumptions", "CNNs only work on grayscale", "Point clouds require quaternions"],
+      "options": [
+        "Point clouds are too large",
+        "A CNN assumes input pixels arranged on a regular grid with neighbourhood structure; a point cloud is an unordered set of points in R^3 with no grid and variable size, violating both assumptions",
+        "CNNs only work on grayscale",
+        "Point clouds require quaternions"
+      ],
       "correct": 1,
       "explanation": "CNN convolutions need a regular neighbourhood. A point cloud has neither a grid nor a fixed point count. Voxelising the cloud brings back a grid (used by 3D CNNs) but is memory-expensive. PointNet side-stepped this with a permutation-invariant architecture that treats each point independently then aggregates symmetrically."
     },
     {
       "stage": "pre",
       "question": "What trick makes PointNet permutation-invariant over the input points?",
-      "options": ["Batch normalisation", "A shared MLP applied to every point independently, followed by a symmetric aggregation (max pool or sum); since the aggregation ignores point order, the whole network's output is order-invariant", "A special loss function", "Sorting the points before the forward pass"],
-      "correct": 1,
+      "options": [
+        "A shared MLP applied to every point independently, followed by a symmetric aggregation (max pool or sum); since the aggregation ignores point order, the whole network's output is order-invariant",
+        "Batch normalisation",
+        "A special loss function",
+        "Sorting the points before the forward pass"
+      ],
+      "correct": 0,
       "explanation": "The symmetric-function trick is the core of every point-cloud network family since 2017. Run the same MLP on every point (same weights, no ordering dependence) and then aggregate with a function that does not depend on order. Max and sum are the two canonical choices; max is used by PointNet and most descendants."
     },
     {
       "stage": "post",
       "question": "A vanilla NeRF MLP fed with raw (x, y, z) coordinates produces blurry results. What fixes it?",
-      "options": ["Adding more training data", "Positional encoding: project coordinates into Fourier features (sin/cos of 2^l * pi * x for multiple l) before the MLP; this lets the low-frequency-biased MLP represent high-frequency details", "Using 16-bit precision", "Switching to a CNN"],
-      "correct": 1,
+      "options": [
+        "Adding more training data",
+        "Using 16-bit precision",
+        "Positional encoding: project coordinates into Fourier features (sin/cos of 2^l * pi * x for multiple l) before the MLP; this lets the low-frequency-biased MLP represent high-frequency details",
+        "Switching to a CNN"
+      ],
+      "correct": 2,
       "explanation": "MLPs are spectrally biased: they easily fit smooth functions and struggle with high frequencies. Positional encoding lifts each coordinate into a vector that already contains high-frequency signals. The MLP then has a much easier job of composing those features into sharp geometry and texture. The same trick is used in transformer positional encoding and in diffusion time embedding."
     },
     {
       "stage": "post",
       "question": "How is a NeRF rendered pixel computed?",
-      "options": ["As the output of the final MLP layer", "By casting a ray from the camera through the pixel, sampling N points along the ray, querying the MLP at each point for (density, colour), and compositing the samples with a volumetric rendering equation that accumulates alpha-weighted colours along the ray", "By looking up a precomputed voxel grid", "By running a convolution over a depth map"],
-      "correct": 1,
+      "options": [
+        "As the output of the final MLP layer",
+        "By running a convolution over a depth map",
+        "By looking up a precomputed voxel grid",
+        "By casting a ray from the camera through the pixel, sampling N points along the ray, querying the MLP at each point for (density, colour), and compositing the samples with a volumetric rendering equation that accumulates alpha-weighted colours along the ray"
+      ],
+      "correct": 3,
       "explanation": "NeRF rendering is classical volume rendering with a neural density field. For each pixel you pick a ray, sample along it, query (sigma, c) at each sample, and composite using (1 - exp(-sigma * delta)) alphas and cumulative transmittance. Backprop through this rendering step is what trains the MLP from 2D photos — no explicit 3D supervision ever appears."
     },
     {
       "stage": "post",
       "question": "Why has 3D Gaussian splatting largely replaced NeRF in production?",
-      "options": ["It produces higher-quality images", "It is an explicit representation (millions of 3D Gaussians with opacity and colour) that renders in real time via rasterisation instead of MLP queries on sampled rays; training is minutes instead of hours, rendering is 100x faster, and quality is comparable", "NeRFs were shown to be mathematically incorrect", "Gaussians are more compressible"],
+      "options": [
+        "It produces higher-quality images",
+        "It is an explicit representation (millions of 3D Gaussians with opacity and colour) that renders in real time via rasterisation instead of MLP queries on sampled rays; training is minutes instead of hours, rendering is 100x faster, and quality is comparable",
+        "NeRFs were shown to be mathematically incorrect",
+        "Gaussians are more compressible"
+      ],
       "correct": 1,
       "explanation": "3D Gaussian Splatting (SIGGRAPH 2023) replaces the implicit MLP-based scene with an explicit cloud of 3D Gaussian primitives. Rendering becomes GPU rasterisation, which is orders of magnitude faster than per-pixel ray sampling through an MLP. Most 2026 NeRF products ship with Gaussian splatting or its successors; the NeRF paradigm still informs the training objective and the math."
     }

--- a/phases/04-computer-vision/15-real-time-edge/quiz.json
+++ b/phases/04-computer-vision/15-real-time-edge/quiz.json
@@ -3,35 +3,60 @@
     {
       "stage": "pre",
       "question": "You benchmark a model and report 'average 12ms per image on a 4090'. What is missing?",
-      "options": ["Nothing; that is a complete benchmark", "Percentiles (p50/p95/p99), warmup discipline, and CUDA synchronisation; a mean alone hides tail latency and may measure kernel dispatch instead of kernel execution", "The model size", "The dataset name"],
+      "options": [
+        "Nothing; that is a complete benchmark",
+        "Percentiles (p50/p95/p99), warmup discipline, and CUDA synchronisation; a mean alone hides tail latency and may measure kernel dispatch instead of kernel execution",
+        "The model size",
+        "The dataset name"
+      ],
       "correct": 1,
       "explanation": "Production latency is measured in percentiles because real-time systems fail on tails, not averages. Without warmup, JIT compilation inflates the first few measurements. Without torch.cuda.synchronize, GPU kernel launches return before the kernel finishes, so you measure dispatch, not execution. All three have to be right for the number to be meaningful."
     },
     {
       "stage": "pre",
       "question": "FLOPs and on-device latency do not correlate perfectly. Why?",
-      "options": ["FLOPs counters are broken", "Different operations have different hardware friendliness; depthwise convolutions may have lower FLOPs but are memory-bound on GPUs, while dense convolutions use Tensor Cores efficiently. Memory bandwidth, kernel launch overhead, and cache behaviour also shape latency beyond raw FLOPs", "FLOPs ignore batch size", "PyTorch counts FLOPs incorrectly"],
-      "correct": 1,
+      "options": [
+        "Different operations have different hardware friendliness; depthwise convolutions may have lower FLOPs but are memory-bound on GPUs, while dense convolutions use Tensor Cores efficiently. Memory bandwidth, kernel launch overhead, and cache behaviour also shape latency beyond raw FLOPs",
+        "FLOPs counters are broken",
+        "FLOPs ignore batch size",
+        "PyTorch counts FLOPs incorrectly"
+      ],
+      "correct": 0,
       "explanation": "FLOPs is a cheap proxy. Wall-clock latency depends on how well an operation matches the hardware's strengths: dense matmuls pin Tensor Cores; depthwise convs stall on memory bandwidth; attention stalls on sequence-length^2 memory reads. For architecture search FLOPs is useful; for deployment decisions measure on the target device."
     },
     {
       "stage": "post",
       "question": "Post-training static INT8 quantisation typically loses how much accuracy on ImageNet-class vision models?",
-      "options": ["5-10 percentage points", "0.1-1 percentage points when properly calibrated; batch-norm-fused conv models are particularly well-behaved under INT8", "Always 0; it is lossless", "20+ points; unusable"],
-      "correct": 1,
+      "options": [
+        "5-10 percentage points",
+        "Always 0; it is lossless",
+        "0.1-1 percentage points when properly calibrated; batch-norm-fused conv models are particularly well-behaved under INT8",
+        "20+ points; unusable"
+      ],
+      "correct": 2,
       "explanation": "Static PTQ on well-calibrated vision models loses a fraction of a point to about 1 point. The bigger loss modes are (a) insufficient calibration data, (b) quantising activations with extreme outliers (fix with per-channel quantisation or clipping), (c) un-fused BatchNorm layers. When those are handled, INT8 is essentially free."
     },
     {
       "stage": "post",
       "question": "Your mobile app needs a vision model under 10MB with sub-10ms latency. Which backbone do you pick?",
-      "options": ["ResNet-50", "MobileNetV3-Small or EfficientNet-Lite-B0 quantised to INT8; both target this budget and compile cleanly to TFLite / Core ML", "ViT-Base", "ConvNeXt-Large"],
-      "correct": 1,
+      "options": [
+        "ResNet-50",
+        "ConvNeXt-Large",
+        "ViT-Base",
+        "MobileNetV3-Small or EfficientNet-Lite-B0 quantised to INT8; both target this budget and compile cleanly to TFLite / Core ML"
+      ],
+      "correct": 3,
       "explanation": "Mobile vision shipping in 2026 is still dominated by MobileNetV3 and EfficientNet-Lite variants because they were designed for this budget: depthwise convs, h-swish, squeeze-excite, quantisation-aware from day one. ResNet-50 and ViT-Base are 100MB+ in FP32 and 25MB+ in INT8, blowing the size budget before latency is even measured."
     },
     {
       "stage": "post",
       "question": "You export a PyTorch model to ONNX with opset 17 and it fails with 'Unsupported operator'. What are the most likely causes?",
-      "options": ["The ONNX library is outdated", "(1) A custom op that has no ONNX mapping; (2) a non-deterministic control-flow path that tracing cannot capture; (3) a tensor-scalar interaction that is implicit in Python but has no ONNX equivalent. Fixes: replace the op, use `torch.jit.script` for control flow, or upgrade opset", "The model has too many parameters", "The input shape is wrong"],
+      "options": [
+        "The ONNX library is outdated",
+        "(1) A custom op that has no ONNX mapping; (2) a non-deterministic control-flow path that tracing cannot capture; (3) a tensor-scalar interaction that is implicit in Python but has no ONNX equivalent. Fixes: replace the op, use `torch.jit.script` for control flow, or upgrade opset",
+        "The model has too many parameters",
+        "The input shape is wrong"
+      ],
       "correct": 1,
       "explanation": "ONNX export is tracing by default, so anything that tracing cannot capture — runtime control flow, Python-level branches, custom CUDA ops — fails. Most failures are a single node that has no ONNX equivalent (often a tiny custom op or a call to torch.special.*). The fix is either replacing the op, switching to `torch.jit.script`, or moving to a newer opset where the op exists."
     }

--- a/phases/04-computer-vision/16-vision-pipeline-capstone/quiz.json
+++ b/phases/04-computer-vision/16-vision-pipeline-capstone/quiz.json
@@ -3,35 +3,60 @@
     {
       "stage": "pre",
       "question": "Why do production vision pipelines use Pydantic models (or equivalent) at every stage boundary?",
-      "options": ["Pydantic is faster than dict access", "Typed schemas catch interface mismatches at the boundary; a detector returning (cx, cy, w, h) when the downstream expects (x1, y1, x2, y2) fails loudly with a validation error instead of silently producing empty crops", "Pydantic is required by FastAPI", "It helps with GPU allocation"],
+      "options": [
+        "Pydantic is faster than dict access",
+        "Typed schemas catch interface mismatches at the boundary; a detector returning (cx, cy, w, h) when the downstream expects (x1, y1, x2, y2) fails loudly with a validation error instead of silently producing empty crops",
+        "Pydantic is required by FastAPI",
+        "It helps with GPU allocation"
+      ],
       "correct": 1,
       "explanation": "Silent interface bugs are the defining pain of ML pipelines. Every boundary has a coordinate system, a channel order, a value range, and a shape. Validating at the boundary with Pydantic turns every mismatch into an immediate error. The cost is a few microseconds; the savings are hours of debugging."
     },
     {
       "stage": "pre",
       "question": "On a CPU-only vision pipeline, which stage is most often the biggest latency block?",
-      "options": ["The detector's final NMS", "Image preprocessing (JPEG decode, colour conversion, resize); it is CPU-bound and often dominates when no GPU is involved or when the GPU model is small", "Writing the JSON response", "Reading the HTTP request body"],
-      "correct": 1,
+      "options": [
+        "Image preprocessing (JPEG decode, colour conversion, resize); it is CPU-bound and often dominates when no GPU is involved or when the GPU model is small",
+        "The detector's final NMS",
+        "Writing the JSON response",
+        "Reading the HTTP request body"
+      ],
+      "correct": 0,
       "explanation": "On CPU, preprocessing is frequently the biggest single cost. JPEG decode can take milliseconds, colour conversion more, resizing to model input another chunk. The rule is simple: profile before optimising. On GPU the detector typically dominates, but do not assume that on CPU."
     },
     {
       "stage": "post",
       "question": "The pipeline classifier crashes when a detection has box size 3x4 pixels. What is the correct fix?",
-      "options": ["Add a global try/except and return empty classifications", "Set a min_crop threshold (e.g. 16 or 32 pixels) and skip classification for detections smaller than that; log the skip and include the detection in the response without a classification field", "Retrain the classifier on smaller images", "Increase batch size"],
-      "correct": 1,
+      "options": [
+        "Add a global try/except and return empty classifications",
+        "Retrain the classifier on smaller images",
+        "Set a min_crop threshold (e.g. 16 or 32 pixels) and skip classification for detections smaller than that; log the skip and include the detection in the response without a classification field",
+        "Increase batch size"
+      ],
+      "correct": 2,
       "explanation": "Tiny crops are a legitimate failure mode: the classifier was trained on 224x224 inputs and cannot reliably classify 3-pixel patches. A threshold (min_crop) skips those, preserves the detection, and produces a complete, honest response. Generic try/except hides the condition; returning no classification at all hides real failures; the right move is a named, logged skip."
     },
     {
       "stage": "post",
       "question": "You add batching to the classifier (wait up to 10 ms, batch all pending crops, one GPU forward). What is the expected effect?",
-      "options": ["Latency strictly decreases", "Throughput increases significantly, per-request latency increases by up to the batching window (~10ms) plus a smaller amount from larger tensor ops; the right answer depends on whether the service is throughput-bound or latency-bound", "Throughput decreases because of the wait", "No effect"],
-      "correct": 1,
+      "options": [
+        "Latency strictly decreases",
+        "No effect",
+        "Throughput decreases because of the wait",
+        "Throughput increases significantly, per-request latency increases by up to the batching window (~10ms) plus a smaller amount from larger tensor ops; the right answer depends on whether the service is throughput-bound or latency-bound"
+      ],
+      "correct": 3,
       "explanation": "Batching is a throughput-latency trade. Each request waits up to the window, which adds latency. The batched forward pass is more efficient per image, so throughput scales with batch size. Use batching when QPS is high and individual latency has slack; avoid it when latency SLA is under 50ms."
     },
     {
       "stage": "post",
       "question": "Your pipeline response is a 500 error when a user uploads a corrupted JPEG. How should you fix it?",
-      "options": ["Ignore it; the user will retry", "Catch image-decode failures early in preprocessing, return a 400 with a specific error code like 'image_decode_failed' so the client can retry with a different file instead of a 500 that implies server error", "Always return 200 with an empty result", "Move decoding to the classifier"],
+      "options": [
+        "Ignore it; the user will retry",
+        "Catch image-decode failures early in preprocessing, return a 400 with a specific error code like 'image_decode_failed' so the client can retry with a different file instead of a 500 that implies server error",
+        "Always return 200 with an empty result",
+        "Move decoding to the classifier"
+      ],
       "correct": 1,
       "explanation": "A 500 from corrupt user input is an API contract bug. Bad inputs should return 4xx so the client knows it is their problem; 5xx responses signal a server problem and trigger the client's retry logic with the same bad input, amplifying load. Named failure codes (image_decode_failed, image_too_large, unsupported_content_type) let clients react correctly."
     }

--- a/phases/04-computer-vision/17-self-supervised-vision/quiz.json
+++ b/phases/04-computer-vision/17-self-supervised-vision/quiz.json
@@ -3,35 +3,60 @@
     {
       "stage": "pre",
       "question": "Why does SimCLR need batch sizes of 512-8192 while supervised ImageNet training works with batch 256?",
-      "options": ["SimCLR is slower", "Each sample needs many negative examples to produce a useful contrastive signal; the batch itself is the pool of negatives. Small batches starve the InfoNCE loss of negatives and training collapses or stalls", "Batch norm requires it", "Contrastive loss divides by batch size"],
+      "options": [
+        "SimCLR is slower",
+        "Each sample needs many negative examples to produce a useful contrastive signal; the batch itself is the pool of negatives. Small batches starve the InfoNCE loss of negatives and training collapses or stalls",
+        "Batch norm requires it",
+        "Contrastive loss divides by batch size"
+      ],
       "correct": 1,
       "explanation": "InfoNCE loss ranks the positive pair against all other samples in the batch. A batch of 32 gives 30 negatives per positive; 1024 gives 2046. More negatives = sharper contrastive signal. MoCo introduced a momentum queue of past features so effective negatives scale beyond the batch size; this is the standard trick when GPU memory limits batch size."
     },
     {
       "stage": "pre",
       "question": "What prevents DINO from collapsing to a constant output?",
-      "options": ["Strong augmentation alone", "A combination of centring (subtract per-dimension EMA mean from the teacher output) and sharpening (low teacher temperature); centring stops one dimension from dominating, sharpening stops the output collapsing to uniform", "Large batch size", "The momentum schedule"],
-      "correct": 1,
+      "options": [
+        "A combination of centring (subtract per-dimension EMA mean from the teacher output) and sharpening (low teacher temperature); centring stops one dimension from dominating, sharpening stops the output collapsing to uniform",
+        "Strong augmentation alone",
+        "Large batch size",
+        "The momentum schedule"
+      ],
+      "correct": 0,
       "explanation": "DINO does not use explicit negatives. Without centring, one output dimension can dominate and the student learns to always predict it. Without sharpening (low teacher temperature), the teacher's output becomes near-uniform and the student learns to match uniform, which is also collapse. The two together keep the output diverse across dimensions and peaked per sample."
     },
     {
       "stage": "post",
       "question": "MAE masks 75% of patches. BERT masks 15% of tokens. Why the difference?",
-      "options": ["75% is arbitrary", "Image patches have low entropy — neighbours are highly correlated — so masking only 15% would be trivially solvable by local extrapolation. Masking 75% forces the encoder to learn global semantic features to reconstruct the missing patches", "BERT requires 15% by design", "Text tokens are larger than image patches"],
-      "correct": 1,
+      "options": [
+        "75% is arbitrary",
+        "BERT requires 15% by design",
+        "Image patches have low entropy — neighbours are highly correlated — so masking only 15% would be trivially solvable by local extrapolation. Masking 75% forces the encoder to learn global semantic features to reconstruct the missing patches",
+        "Text tokens are larger than image patches"
+      ],
+      "correct": 2,
       "explanation": "The mask ratio should match the information density of the modality. Text: 15% is enough because each token has many plausible completions. Images: neighbouring pixels almost determine each other, so low mask ratios are solvable without real representation learning. MAE's 75% is calibrated to force semantic understanding."
     },
     {
       "stage": "post",
       "question": "After self-supervised pretraining, the 'linear probe' evaluation trains only what?",
-      "options": ["The entire encoder", "A single linear classifier on top of the frozen encoder features; this isolates feature quality from fine-tuning dynamics", "A full MLP classifier head", "The positional embedding"],
-      "correct": 1,
+      "options": [
+        "The entire encoder",
+        "The positional embedding",
+        "A full MLP classifier head",
+        "A single linear classifier on top of the frozen encoder features; this isolates feature quality from fine-tuning dynamics"
+      ],
+      "correct": 3,
       "explanation": "Linear probe freezes the encoder and fits Linear(features -> num_classes) on a labelled downstream dataset. The accuracy is a direct measure of the feature space's linear separability — a proxy for feature quality. Fine-tuning the whole backbone adds nonlinear capacity and usually lifts accuracy a few points, but mixes in optimisation effects. Both numbers are reported in SSL papers."
     },
     {
       "stage": "post",
       "question": "Why does MAE use an asymmetric encoder-decoder design (big encoder on 25% visible patches, small decoder on all tokens)?",
-      "options": ["Memory constraints", "The encoder never processes mask tokens; a small decoder only handles reconstruction. This makes encoder FLOPs proportional to visible patches (1/4 of full input) and lets pretraining run 3x faster than naive designs that process all tokens through the full encoder", "Masked tokens confuse self-attention", "The decoder needs its own backbone"],
+      "options": [
+        "Memory constraints",
+        "The encoder never processes mask tokens; a small decoder only handles reconstruction. This makes encoder FLOPs proportional to visible patches (1/4 of full input) and lets pretraining run 3x faster than naive designs that process all tokens through the full encoder",
+        "Masked tokens confuse self-attention",
+        "The decoder needs its own backbone"
+      ],
       "correct": 1,
       "explanation": "The key efficiency win in MAE: the expensive encoder only ever sees visible patches, which is 25% of the input. Mask tokens appear only in the shallow decoder. This makes pretraining roughly 3x faster than BEiT (which processes all tokens through the encoder) with equal or better downstream accuracy."
     }

--- a/phases/04-computer-vision/18-open-vocab-clip/quiz.json
+++ b/phases/04-computer-vision/18-open-vocab-clip/quiz.json
@@ -3,35 +3,60 @@
     {
       "stage": "pre",
       "question": "CLIP's contrastive loss is symmetric (image-to-text + text-to-image). Why both directions?",
-      "options": ["Numerical stability", "You want both queries to work at inference: text-to-image retrieval and image-to-text retrieval. Training only one direction makes the other direction's accuracy drop significantly", "Because loss must sum to zero", "Symmetry is required by PyTorch"],
+      "options": [
+        "Numerical stability",
+        "You want both queries to work at inference: text-to-image retrieval and image-to-text retrieval. Training only one direction makes the other direction's accuracy drop significantly",
+        "Because loss must sum to zero",
+        "Symmetry is required by PyTorch"
+      ],
       "correct": 1,
       "explanation": "The embedding space needs to be symmetric across modalities because downstream tasks query in both directions. Zero-shot classification is text-to-image (classify image given text prompts). Retrieval can go either way. Training with only i2t or only t2i leaves the other direction weak."
     },
     {
       "stage": "pre",
       "question": "Zero-shot classification with CLIP works by... ?",
-      "options": ["Running a classifier head trained on ImageNet", "Encoding prompts like 'a photo of a dog' for each candidate class, encoding the test image, and taking argmax of cosine similarities between the image embedding and all class text embeddings", "Fine-tuning the image encoder on the class", "Searching a database of labelled examples"],
-      "correct": 1,
+      "options": [
+        "Encoding prompts like 'a photo of a dog' for each candidate class, encoding the test image, and taking argmax of cosine similarities between the image embedding and all class text embeddings",
+        "Running a classifier head trained on ImageNet",
+        "Fine-tuning the image encoder on the class",
+        "Searching a database of labelled examples"
+      ],
+      "correct": 0,
       "explanation": "Zero-shot means no task-specific training: the model's representations already let you compare images to arbitrary text descriptions. Write one prompt per class, encode all prompts and the test image, cosine similarity, argmax. The only 'trick' is prompt engineering — using multiple templates per class and averaging their embeddings gains 1-3 top-1 on ImageNet."
     },
     {
       "stage": "post",
       "question": "SigLIP replaces CLIP's softmax with a sigmoid loss per pair. What benefit does that give?",
-      "options": ["Faster GPU kernels", "The sigmoid loss is per-pair, so it does not depend on the batch as a normalisation denominator. SigLIP trains well at smaller batch sizes where CLIP's softmax loss starves for negatives", "Lower memory use", "Better accuracy on COCO only"],
-      "correct": 1,
+      "options": [
+        "Faster GPU kernels",
+        "Lower memory use",
+        "The sigmoid loss is per-pair, so it does not depend on the batch as a normalisation denominator. SigLIP trains well at smaller batch sizes where CLIP's softmax loss starves for negatives",
+        "Better accuracy on COCO only"
+      ],
+      "correct": 2,
       "explanation": "CLIP's symmetric cross-entropy is a softmax over the whole batch, so effective negatives = batch_size - 1. Small batches starve it. SigLIP is per-pair: each (image, caption) pair gets a binary decision (match or not). No batch-level normalisation, so SigLIP works at batch 128 while CLIP needs 8192. At equal scale SigLIP matches or beats CLIP."
     },
     {
       "stage": "post",
       "question": "A practitioner reports 88% zero-shot top-1 on CIFAR-10 with CLIP ViT-B/32 and 90% with the same model using 80 prompt templates per class. Why does template averaging help?",
-      "options": ["It doubles the dataset", "Different templates activate different aspects of the text encoder's learned distribution; averaging smooths the class embedding over the manifold of plausible natural-language descriptions of the class, producing a more robust centroid", "It reduces variance in logit_scale", "80 is the magic number for CLIP"],
-      "correct": 1,
+      "options": [
+        "It doubles the dataset",
+        "80 is the magic number for CLIP",
+        "It reduces variance in logit_scale",
+        "Different templates activate different aspects of the text encoder's learned distribution; averaging smooths the class embedding over the manifold of plausible natural-language descriptions of the class, producing a more robust centroid"
+      ],
+      "correct": 3,
       "explanation": "Each template is a different natural-language cue. 'a photo of a dog' emphasises one aspect; 'a blurry photo of a dog' another; 'a sketch of a dog' yet another. Averaging the text embeddings gives a smoother representation of the concept 'dog' that is less sensitive to individual-prompt quirks. The OpenAI CLIP paper published 80 templates that lift ImageNet zero-shot by ~2 points."
     },
     {
       "stage": "post",
       "question": "Why do modern VLMs (LLaVA, Qwen-VL, InternVL) use a CLIP-family vision encoder instead of a supervised ImageNet ResNet?",
-      "options": ["CLIP encoders are faster", "CLIP features are aligned with natural language, so the LLM can reason about them with less adaptation; supervised ImageNet features were never trained against captions and need heavy projection layers to bridge to text", "ResNets cannot see colour", "It is a licensing requirement"],
+      "options": [
+        "CLIP encoders are faster",
+        "CLIP features are aligned with natural language, so the LLM can reason about them with less adaptation; supervised ImageNet features were never trained against captions and need heavy projection layers to bridge to text",
+        "ResNets cannot see colour",
+        "It is a licensing requirement"
+      ],
       "correct": 1,
       "explanation": "A VLM bolts a vision encoder to a language model and trains a small projection. CLIP-style encoders were trained against text, so their outputs already live in a space the LLM can consume with a few linear layers of adaptation. Supervised ImageNet encoders have no notion of natural-language structure and require much larger bridging MLPs to work with an LLM. This is why every SOTA VLM uses a CLIP-family vision tower."
     }

--- a/phases/04-computer-vision/19-ocr-document-understanding/quiz.json
+++ b/phases/04-computer-vision/19-ocr-document-understanding/quiz.json
@@ -3,35 +3,60 @@
     {
       "stage": "pre",
       "question": "Why does OCR use CTC loss instead of plain cross-entropy?",
-      "options": ["CTC is faster", "OCR maps a fixed-length feature sequence to a variable-length character sequence without per-timestep alignment; CTC loss marginalises over all alignments that reduce to the target after removing repeats and blanks, so you can train without character-level timing labels", "CTC is required by PyTorch", "Cross-entropy overflows for long sequences"],
+      "options": [
+        "CTC is faster",
+        "OCR maps a fixed-length feature sequence to a variable-length character sequence without per-timestep alignment; CTC loss marginalises over all alignments that reduce to the target after removing repeats and blanks, so you can train without character-level timing labels",
+        "CTC is required by PyTorch",
+        "Cross-entropy overflows for long sequences"
+      ],
       "correct": 1,
       "explanation": "Recognition produces one distribution per time step, but the target text has no per-step alignment. CTC handles that by summing over every alignment that reduces to the target via the merge-repeats-and-remove-blanks operation. This is why CRNNs can be trained on just (image, text) pairs without knowing where each character starts and ends in the image."
     },
     {
       "stage": "pre",
       "question": "In CTC decoding, what does the blank token do?",
-      "options": ["Pads the sequence to a fixed length", "Separates adjacent identical characters so that outputs like 'hello' with a double L can be produced by the model emitting 'h e l _ l o' — without the blank, 'l l' would collapse to one 'l'", "Masks noisy regions", "Indicates end of sequence"],
-      "correct": 1,
+      "options": [
+        "Separates adjacent identical characters so that outputs like 'hello' with a double L can be produced by the model emitting 'h e l _ l o' — without the blank, 'l l' would collapse to one 'l'",
+        "Pads the sequence to a fixed length",
+        "Masks noisy regions",
+        "Indicates end of sequence"
+      ],
+      "correct": 0,
       "explanation": "The blank is the mechanism that lets CTC encode double characters. 'll' needs a blank between the two l's so the 'merge repeats' step keeps them distinct: 'l _ l' survives merging, 'l l' does not. Without the blank, CTC cannot represent any word containing adjacent identical characters."
     },
     {
       "stage": "post",
       "question": "Why is greedy CTC decoding sometimes better than beam search on simple datasets?",
-      "options": ["Greedy is always better", "When the model is confident at every step (clean handwriting, printed fonts), greedy's argmax is usually the beam winner; beam search adds latency with no accuracy gain. On noisy or ambiguous inputs, beam search helps", "Beam search requires a language model", "Greedy is easier to implement"],
-      "correct": 1,
+      "options": [
+        "Greedy is always better",
+        "Beam search requires a language model",
+        "When the model is confident at every step (clean handwriting, printed fonts), greedy's argmax is usually the beam winner; beam search adds latency with no accuracy gain. On noisy or ambiguous inputs, beam search helps",
+        "Greedy is easier to implement"
+      ],
+      "correct": 2,
       "explanation": "Beam search only wins when the per-step argmax is unreliable — ambiguous characters, overlapping letters, degraded scans. For clean printed text, the model is confident at each step and greedy is within 1% CER of beam. Always benchmark both; the latency trade is real."
     },
     {
       "stage": "post",
       "question": "Donut skips explicit text detection and character recognition. How?",
-      "options": ["It uses an external OCR engine internally", "It is a ViT encoder + text decoder trained to produce the final output string (often JSON) directly from the image; the model learns both localisation and recognition implicitly through the training objective", "It is limited to document categories with fixed layouts", "It preprocesses images with a CNN text detector"],
-      "correct": 1,
+      "options": [
+        "It uses an external OCR engine internally",
+        "It preprocesses images with a CNN text detector",
+        "It is limited to document categories with fixed layouts",
+        "It is a ViT encoder + text decoder trained to produce the final output string (often JSON) directly from the image; the model learns both localisation and recognition implicitly through the training objective"
+      ],
+      "correct": 3,
       "explanation": "Donut is an end-to-end model: the ViT encoder sees the whole document, the transformer decoder emits the target text or JSON auto-regressively. No pipeline of detector + recogniser + layout module. This skips error accumulation across stages but requires large labelled training sets for the specific document types you care about."
     },
     {
       "stage": "post",
       "question": "For extracting `invoice_total` from receipts, which approach is typically best in 2026?",
-      "options": ["A hand-crafted regex on Tesseract output", "Fine-tuned Donut or a VLM on a small labelled set of the target receipts; both handle layout and semantic extraction in one model and generalise across receipt variants better than pipeline-based approaches", "Only classical OCR is reliable enough", "A separate CNN for each field"],
+      "options": [
+        "A hand-crafted regex on Tesseract output",
+        "Fine-tuned Donut or a VLM on a small labelled set of the target receipts; both handle layout and semantic extraction in one model and generalise across receipt variants better than pipeline-based approaches",
+        "Only classical OCR is reliable enough",
+        "A separate CNN for each field"
+      ],
       "correct": 1,
       "explanation": "Structured-field extraction used to be the domain of LayoutLM + heuristics. End-to-end models (Donut, Qwen-VL-OCR) have overtaken that path: they accept an image and produce the JSON directly. For a small set of labelled receipts (100-1000), fine-tuning Donut reaches higher F1 than any pipeline of OCR + rules."
     }

--- a/phases/04-computer-vision/20-image-retrieval-metric/quiz.json
+++ b/phases/04-computer-vision/20-image-retrieval-metric/quiz.json
@@ -3,35 +3,60 @@
     {
       "stage": "pre",
       "question": "For a visual search product where queries are text and gallery items are images, which backbone do you pick first?",
-      "options": ["A supervised ResNet-50", "A CLIP or SigLIP model — they learn a shared text-image embedding space so cosine similarity between text query and image gallery is meaningful out of the box", "A self-supervised DINOv2 model", "A handcrafted ORB descriptor"],
+      "options": [
+        "A supervised ResNet-50",
+        "A CLIP or SigLIP model — they learn a shared text-image embedding space so cosine similarity between text query and image gallery is meaningful out of the box",
+        "A self-supervised DINOv2 model",
+        "A handcrafted ORB descriptor"
+      ],
       "correct": 1,
       "explanation": "Retrieval with text queries requires embeddings where text and image end up in the same space. CLIP/SigLIP train exactly this with the contrastive loss in Lesson 18. Supervised ImageNet features are image-only. DINOv2 is strong but image-only. Text queries demand a vision-language encoder."
     },
     {
       "stage": "pre",
       "question": "What does 'semi-hard mining' mean in triplet-loss training?",
-      "options": ["Picking random triplets", "For each anchor, select a negative that is further than the positive but still within the margin; easy negatives contribute no gradient and hardest negatives can destabilise training, so semi-hard is the sweet spot", "Using only the hardest possible negatives", "Mining cryptocurrency for training examples"],
-      "correct": 1,
+      "options": [
+        "For each anchor, select a negative that is further than the positive but still within the margin; easy negatives contribute no gradient and hardest negatives can destabilise training, so semi-hard is the sweet spot",
+        "Picking random triplets",
+        "Using only the hardest possible negatives",
+        "Mining cryptocurrency for training examples"
+      ],
+      "correct": 0,
       "explanation": "Triplet loss gradient is non-zero only when d(a, n) < d(a, p) + margin. Easy negatives (already far) give zero gradient. Hardest negatives can collapse training. Semi-hard — d(a, p) < d(a, n) < d(a, p) + margin — is where the loss is informative without being unstable. FaceNet introduced this recipe in 2015 and it is still the default for triplet fine-tuning."
     },
     {
       "stage": "post",
       "question": "Your retrieval system reports recall@10 = 0.95 but recall@1 = 0.42. What should you conclude?",
-      "options": ["The evaluation is broken", "The embedding space has the correct structure — relevant items are usually in the top 10 — but ranking within the top 10 is noisy; a re-ranking model (cross-encoder, second-stage scorer) or longer metric-learning fine-tune will fix recall@1 without damaging recall@10", "The model is overfitting", "Data is leaking from gallery to queries"],
-      "correct": 1,
+      "options": [
+        "The evaluation is broken",
+        "The model is overfitting",
+        "The embedding space has the correct structure — relevant items are usually in the top 10 — but ranking within the top 10 is noisy; a re-ranking model (cross-encoder, second-stage scorer) or longer metric-learning fine-tune will fix recall@1 without damaging recall@10",
+        "Data is leaking from gallery to queries"
+      ],
+      "correct": 2,
       "explanation": "recall@K vs @1 tells you where the information sits. A high recall@10 with low recall@1 means retrieval is approximately right but the model is not confident about ordering the top few. Re-ranking — a separate model that scores every top-K candidate against the query — is the production fix and is what search engines like Pinterest and Google Photos use."
     },
     {
       "stage": "post",
       "question": "Cosine similarity on unnormalised embeddings is not cosine similarity — what goes wrong?",
-      "options": ["Nothing, it is fine", "It mixes direction with magnitude; cos(a, b) is only correct when both vectors are L2-normalised. On unnormalised embeddings, large-norm items dominate regardless of direction, skewing ranks toward vectors with big magnitudes", "PyTorch raises an error", "The matmul overflows"],
-      "correct": 1,
+      "options": [
+        "Nothing, it is fine",
+        "The matmul overflows",
+        "PyTorch raises an error",
+        "It mixes direction with magnitude; cos(a, b) is only correct when both vectors are L2-normalised. On unnormalised embeddings, large-norm items dominate regardless of direction, skewing ranks toward vectors with big magnitudes"
+      ],
+      "correct": 3,
       "explanation": "cos(a, b) = (a . b) / (||a|| * ||b||). Skipping the normalisation gives you raw inner product, which ranks by direction weighted by magnitude. On typical neural embeddings magnitudes vary 2-3x across samples, and that alone dominates the ranking. Always L2-normalise before computing cosine or before indexing in FAISS IndexFlatIP."
     },
     {
       "stage": "post",
       "question": "Between instance-level retrieval (find this exact car) and category-level retrieval (find cars), which requires metric-learning fine-tuning?",
-      "options": ["Neither", "Instance-level. Off-the-shelf DINOv2 and CLIP embeddings discriminate between categories well but not between visually similar instances of the same category. A triplet or contrastive fine-tune on (same instance, different instance) pairs tightens the embedding around each instance", "Category-level", "Both require the same amount of fine-tuning"],
+      "options": [
+        "Neither",
+        "Instance-level. Off-the-shelf DINOv2 and CLIP embeddings discriminate between categories well but not between visually similar instances of the same category. A triplet or contrastive fine-tune on (same instance, different instance) pairs tightens the embedding around each instance",
+        "Category-level",
+        "Both require the same amount of fine-tuning"
+      ],
       "correct": 1,
       "explanation": "Category-level retrieval is what pretrained models already do: cats cluster near cats, dogs near dogs. Instance-level — same car, same face, same product SKU — needs metric learning because two instances of the same product look very similar in the general embedding space. Fine-tuning with triplet or InfoNCE on instance-labelled pairs shrinks intra-instance distance and grows inter-instance distance."
     }

--- a/phases/04-computer-vision/21-keypoint-pose/quiz.json
+++ b/phases/04-computer-vision/21-keypoint-pose/quiz.json
@@ -3,35 +3,60 @@
     {
       "stage": "pre",
       "question": "Why do pose models regress heatmaps instead of (x, y) coordinates directly?",
-      "options": ["Heatmaps are cheaper to compute", "The spatial structure of a conv feature map aligns with spatial output; a Gaussian heatmap target provides a smooth loss landscape that tolerates small localisation errors, whereas direct coordinate regression is brittle and loses spatial context", "Heatmaps are required by the COCO metric", "Coordinate regression produces NaN"],
+      "options": [
+        "Heatmaps are cheaper to compute",
+        "The spatial structure of a conv feature map aligns with spatial output; a Gaussian heatmap target provides a smooth loss landscape that tolerates small localisation errors, whereas direct coordinate regression is brittle and loses spatial context",
+        "Heatmaps are required by the COCO metric",
+        "Coordinate regression produces NaN"
+      ],
       "correct": 1,
       "explanation": "Regressing coordinates with MSE asks the network to reduce a 2D position to two scalars, losing the feature-map alignment that CNNs exploit. Heatmap regression gives the network a per-pixel loss that is smooth around the true location and preserves spatial priors. The empirical improvement over coordinate regression is large enough that every modern pose model uses heatmaps."
     },
     {
       "stage": "pre",
       "question": "Top-down pose estimation vs bottom-up: which scales better with crowd size, and why?",
-      "options": ["Top-down, because each person uses a separate fast model", "Bottom-up, because it does one forward pass over the whole image then groups keypoints, so runtime is constant in the number of people", "They scale equally", "Top-down never scales"],
-      "correct": 1,
+      "options": [
+        "Bottom-up, because it does one forward pass over the whole image then groups keypoints, so runtime is constant in the number of people",
+        "Top-down, because each person uses a separate fast model",
+        "They scale equally",
+        "Top-down never scales"
+      ],
+      "correct": 0,
       "explanation": "Top-down runs a per-person keypoint model after a person detector, so cost grows linearly with the number of people. Bottom-up (OpenPose, HigherHRNet) produces all keypoints and association fields in one pass, then groups them — constant time regardless of crowd density. The trade: top-down is more accurate per-person; bottom-up is faster in crowds."
     },
     {
       "stage": "post",
       "question": "What are Part Affinity Fields?",
-      "options": ["A scheduling algorithm", "2-channel unit-vector fields that encode the direction from one keypoint to another; integrating the PAF along a candidate line tells you whether two keypoints belong to the same instance, enabling bottom-up association without per-person detection", "A data augmentation technique", "A type of loss function"],
-      "correct": 1,
+      "options": [
+        "A scheduling algorithm",
+        "A data augmentation technique",
+        "2-channel unit-vector fields that encode the direction from one keypoint to another; integrating the PAF along a candidate line tells you whether two keypoints belong to the same instance, enabling bottom-up association without per-person detection",
+        "A type of loss function"
+      ],
+      "correct": 2,
       "explanation": "Per connected keypoint pair (limb), predict a 2-channel field (x, y components of the unit vector pointing from one keypoint to the other). To match a candidate shoulder with a candidate elbow, integrate the PAF along the line joining them; higher integral = stronger match. This turns pose into a bipartite matching problem solvable in polynomial time."
     },
     {
       "stage": "post",
       "question": "Why does sub-pixel refinement around the argmax meaningfully lift keypoint accuracy?",
-      "options": ["It smooths the heatmap", "Integer argmax rounds to the nearest grid cell; fitting a local parabola or using the offset dx = 0.25*(heatmap[y,x+1] - heatmap[y,x-1]) recovers the continuous peak position, often halving the L2 error for cleanly predicted keypoints", "It prevents overfitting", "It normalises the output"],
-      "correct": 1,
+      "options": [
+        "It smooths the heatmap",
+        "It normalises the output",
+        "It prevents overfitting",
+        "Integer argmax rounds to the nearest grid cell; fitting a local parabola or using the offset dx = 0.25*(heatmap[y,x+1] - heatmap[y,x-1]) recovers the continuous peak position, often halving the L2 error for cleanly predicted keypoints"
+      ],
+      "correct": 3,
       "explanation": "A well-predicted heatmap has a smooth Gaussian peak whose centre is usually between grid cells. Integer argmax loses that sub-pixel information (up to 0.5 px error). Fitting a parabola or using the first-difference offset recovers the continuous peak. For sports analytics, medical landmarks, or anything requiring precise coordinates, this step is mandatory."
     },
     {
       "stage": "post",
       "question": "OKS (Object Keypoint Similarity) is the pose-estimation analogue of what object-detection metric?",
-      "options": ["Inference latency", "IoU — both measure geometric match between prediction and ground truth, with OKS using keypoint distances weighted by each keypoint's annotation variance; COCO reports mAP@OKS 0.5:0.95 for pose", "Classification accuracy", "Cross-entropy loss"],
+      "options": [
+        "Inference latency",
+        "IoU — both measure geometric match between prediction and ground truth, with OKS using keypoint distances weighted by each keypoint's annotation variance; COCO reports mAP@OKS 0.5:0.95 for pose",
+        "Classification accuracy",
+        "Cross-entropy loss"
+      ],
       "correct": 1,
       "explanation": "OKS ranges 0 to 1 like IoU and plays the same role: it decides whether a prediction matches a ground-truth pose at a given strictness level. Each keypoint has a variance (COCO publishes them) that scales its contribution — invariant joints like nose and eyes weigh more than wrists, which are annotated less consistently. COCO Pose AP @ OKS 0.5:0.95 is the 2026 community benchmark."
     }

--- a/phases/04-computer-vision/23-diffusion-transformers-rectified-flow/quiz.json
+++ b/phases/04-computer-vision/23-diffusion-transformers-rectified-flow/quiz.json
@@ -3,35 +3,60 @@
     {
       "stage": "pre",
       "question": "Why did 2024+ SOTA text-to-image models (SD3, FLUX, Z-Image) replace the U-Net denoiser with a Diffusion Transformer (DiT)?",
-      "options": ["Transformers are easier to write", "DiT scales more predictably than U-Net (same scaling-law regime as LLMs), handles long-range spatial dependencies better for prompt-accurate generation, and pairs naturally with text encoders via cross or joint attention", "U-Net is not supported on GPUs anymore", "DiT has fewer parameters"],
+      "options": [
+        "Transformers are easier to write",
+        "DiT scales more predictably than U-Net (same scaling-law regime as LLMs), handles long-range spatial dependencies better for prompt-accurate generation, and pairs naturally with text encoders via cross or joint attention",
+        "U-Net is not supported on GPUs anymore",
+        "DiT has fewer parameters"
+      ],
       "correct": 1,
       "explanation": "DiT treats diffusion as just another sequence-modelling task. It scales like language models, avoids the fixed inductive bias of convolutions that can bottleneck long-range structure, and integrates cleanly with transformer text encoders. Every 2026 SOTA model — SD3, FLUX.1, FLUX.2, SD4, Z-Image, Qwen-Image — is a DiT."
     },
     {
       "stage": "pre",
       "question": "Rectified flow trains the model to predict velocity `v = epsilon - x_0` along a straight-line interpolation between data and noise. Why does this enable 20-step sampling instead of 1000?",
-      "options": ["It does not; rectified flow also needs 1000 steps", "The learned ODE is closer to a straight line than DDPM's curved SDE, so few-step Euler integration produces accurate samples; combined with distillation you get 1-4 step variants like FLUX schnell", "Euler is strictly better than DDIM", "It requires a bigger model"],
-      "correct": 1,
+      "options": [
+        "The learned ODE is closer to a straight line than DDPM's curved SDE, so few-step Euler integration produces accurate samples; combined with distillation you get 1-4 step variants like FLUX schnell",
+        "It does not; rectified flow also needs 1000 steps",
+        "Euler is strictly better than DDIM",
+        "It requires a bigger model"
+      ],
+      "correct": 0,
       "explanation": "DDPM's reverse process is a stochastic curved path that needs many small steps. Rectified flow defines a straight-line interpolation; the learned velocity is approximately constant along the trajectory. Integrating a near-straight ODE takes few steps. SD3 and FLUX sample at 20-30 steps full quality; schnell/turbo/LCM distil this further to 1-4 steps."
     },
     {
       "stage": "post",
       "question": "MMDiT (SD3) uses two sets of weights, one for text tokens and one for image tokens, that share a single joint attention layer. Why?",
-      "options": ["To save memory", "Text and image embeddings are conceptually different distributions; separate weights let each modality process its own representation while the joint attention lets them interact; the result is better text-image alignment and prompt following than a single shared stream", "It is a legacy design", "Only image tokens actually go through the attention"],
-      "correct": 1,
+      "options": [
+        "To save memory",
+        "It is a legacy design",
+        "Text and image embeddings are conceptually different distributions; separate weights let each modality process its own representation while the joint attention lets them interact; the result is better text-image alignment and prompt following than a single shared stream",
+        "Only image tokens actually go through the attention"
+      ],
+      "correct": 2,
       "explanation": "Stable Diffusion 3's MMDiT keeps per-modality weight streams to preserve the different statistics of text and image tokens while a joint self-attention layer lets them fuse. This is structurally more expressive than concatenate-and-share (which SD1/2 used), and empirically lifts prompt adherence and text rendering. FLUX extends this to alternating double-stream / single-stream blocks for efficiency."
     },
     {
       "stage": "post",
       "question": "What does AdaLN-Zero mean in a DiT block, and why does it help?",
-      "options": ["A layer norm with zero epsilon", "Adaptive LayerNorm whose modulation MLP is initialised to zero so the block starts as identity; training then learns the scale/shift/gate, which stabilises very deep diffusion transformers", "A LayerNorm that is only applied 50% of the time", "A LayerNorm with zero mean"],
-      "correct": 1,
+      "options": [
+        "A layer norm with zero epsilon",
+        "A LayerNorm with zero mean",
+        "A LayerNorm that is only applied 50% of the time",
+        "Adaptive LayerNorm whose modulation MLP is initialised to zero so the block starts as identity; training then learns the scale/shift/gate, which stabilises very deep diffusion transformers"
+      ],
+      "correct": 3,
       "explanation": "AdaLN predicts scale, shift, and gate from the conditioning vector. 'Zero' means the MLP is initialised to zero, so the gate starts at 0 and the block acts as identity. Gradients slowly nudge the modulation away from zero, which prevents the deep stack from diverging early in training. It is the DiT-equivalent of ResNet's residual zero-init and is used in every modern diffusion transformer."
     },
     {
       "stage": "post",
       "question": "FLUX.1-schnell can produce an image in 4 steps. Which technique lets it do that?",
-      "options": ["A different base architecture than FLUX.1-dev", "Distillation — schnell is trained from a slow many-step teacher using adversarial / consistency-style objectives so that 1-4 denoising steps match the teacher's 20-30 step output", "Lower precision weights", "Smaller parameter count"],
+      "options": [
+        "A different base architecture than FLUX.1-dev",
+        "Distillation — schnell is trained from a slow many-step teacher using adversarial / consistency-style objectives so that 1-4 denoising steps match the teacher's 20-30 step output",
+        "Lower precision weights",
+        "Smaller parameter count"
+      ],
       "correct": 1,
       "explanation": "Schnell / Turbo / LCM variants use step distillation. A small-step student learns to match the many-step teacher's output. The base architecture and parameter count are often identical (FLUX.1-dev and schnell are both 12B). Distillation is what makes sub-1-second inference practical. This is the same idea as SDXL Turbo, SD Turbo, and Latent Consistency Models."
     }

--- a/phases/04-computer-vision/25-vision-language-models/quiz.json
+++ b/phases/04-computer-vision/25-vision-language-models/quiz.json
@@ -3,35 +3,60 @@
     {
       "stage": "pre",
       "question": "In the ViT-MLP-LLM VLM pattern, which component is most commonly trained while the others are kept frozen during alignment?",
-      "options": ["The vision encoder", "The projector (the 2-4 layer MLP between ViT and LLM) — it maps vision tokens into the LLM's embedding space and carries most of the cross-modal alignment signal", "The LLM", "All components are always trained together"],
+      "options": [
+        "The vision encoder",
+        "The projector (the 2-4 layer MLP between ViT and LLM) — it maps vision tokens into the LLM's embedding space and carries most of the cross-modal alignment signal",
+        "The LLM",
+        "All components are always trained together"
+      ],
       "correct": 1,
       "explanation": "The standard VLM recipe trains the projector first with ViT and LLM frozen (alignment stage), then optionally unfreezes everything for pre-training and instruction tuning. The projector is small (tens to hundreds of millions of params) and takes the brunt of the modality bridge. Fine-tuning in production often trains only the projector + LoRA on attention — cheap and effective."
     },
     {
       "stage": "pre",
       "question": "DeepStack (used in Qwen3-VL) does what?",
-      "options": ["Uses only the deepest ViT layer's features", "Stacks features from multiple ViT depths before projection, so the LLM sees both high-level semantics (deep layers) and fine-grained spatial detail (shallow layers)", "Doubles the depth of the LLM", "Is a specific quantisation scheme"],
-      "correct": 1,
+      "options": [
+        "Stacks features from multiple ViT depths before projection, so the LLM sees both high-level semantics (deep layers) and fine-grained spatial detail (shallow layers)",
+        "Uses only the deepest ViT layer's features",
+        "Doubles the depth of the LLM",
+        "Is a specific quantisation scheme"
+      ],
+      "correct": 0,
       "explanation": "Vanilla VLMs project only last-layer ViT features. DeepStack samples multiple depths, concatenates, and projects. Deep layers give semantics ('this is a chart'); shallow layers give position and texture ('the bar at x=120 is red'). The combination closes the grounding gap on tasks requiring fine localisation, like GUI agent actions or dense captioning."
     },
     {
       "stage": "post",
       "question": "A production VLM shows high text confidence but the generated text describes objects not present in the image. Which metric captures this failure?",
-      "options": ["Perplexity", "Cross-Modal Error Rate (CMER) — fraction of outputs where text confidence is high but image-text cosine similarity (via a CLIP-family checker) is low; ~12% typical on uncurated web data", "Accuracy on MMMU", "Token generation latency"],
-      "correct": 1,
+      "options": [
+        "Perplexity",
+        "Accuracy on MMMU",
+        "Cross-Modal Error Rate (CMER) — fraction of outputs where text confidence is high but image-text cosine similarity (via a CLIP-family checker) is low; ~12% typical on uncurated web data",
+        "Token generation latency"
+      ],
+      "correct": 2,
       "explanation": "CMER is a production alignment KPI. It catches the classic VLM hallucination pattern: the model is sure about its text, but the text is not grounded in the image. Monitor CMER per endpoint and prompt type; treat rising CMER as a signal that the model is drifting out of distribution or encountering a prompt category it cannot handle. Skywork.ai cut hallucinations ~35% by making CMER a first-class KPI."
     },
     {
       "stage": "post",
       "question": "Why do modern VLMs use SigLIP or custom vision encoders rather than a supervised ImageNet ResNet as the backbone?",
-      "options": ["SigLIP is faster", "CLIP/SigLIP-style encoders are trained jointly with text, so their output space is already approximately aligned with language; the projector then has to do much less work and the model reasons better about visual-textual concepts", "ResNets cannot produce tokens", "SigLIP has more parameters"],
-      "correct": 1,
+      "options": [
+        "SigLIP is faster",
+        "SigLIP has more parameters",
+        "ResNets cannot produce tokens",
+        "CLIP/SigLIP-style encoders are trained jointly with text, so their output space is already approximately aligned with language; the projector then has to do much less work and the model reasons better about visual-textual concepts"
+      ],
+      "correct": 3,
       "explanation": "Vision-language pretraining shapes the encoder to live in a text-compatible space. A supervised ImageNet ResNet was trained without any text signal, so bridging to an LLM requires much larger projectors and more data. CLIP/SigLIP/DINOv3 encoders produce features that an LLM can consume with a few linear layers. Almost every SOTA VLM uses a CLIP-family or SigLIP encoder for this reason."
     },
     {
       "stage": "post",
       "question": "Qwen3-VL-235B-A22B achieves top scores on OSWorld. What is OSWorld, and what does this imply?",
-      "options": ["A synthetic benchmark", "An agent benchmark where the model operates desktop GUIs — identifies buttons, reads UI state, emits actions; Qwen3-VL's top scores imply VLMs are now viable visual agents for GUI automation", "A pose-estimation benchmark", "A video QA benchmark"],
+      "options": [
+        "A synthetic benchmark",
+        "An agent benchmark where the model operates desktop GUIs — identifies buttons, reads UI state, emits actions; Qwen3-VL's top scores imply VLMs are now viable visual agents for GUI automation",
+        "A pose-estimation benchmark",
+        "A video QA benchmark"
+      ],
       "correct": 1,
       "explanation": "OSWorld tests whether a model can autonomously operate a desktop environment via screenshots. Qwen3-VL's top global scores indicate the 'visual agent' paradigm — VLM reads screen, decides action, tool-calls the mouse/keyboard — has crossed into practical territory. This is what 2026 AI PC demos run; it is also a direct route into automated QA, RPA, and accessibility products."
     }

--- a/phases/04-computer-vision/27-multi-object-tracking/quiz.json
+++ b/phases/04-computer-vision/27-multi-object-tracking/quiz.json
@@ -3,35 +3,60 @@
     {
       "stage": "pre",
       "question": "What does the Hungarian algorithm do in tracking-by-detection?",
-      "options": ["It filters out low-confidence detections", "It solves the minimum-cost one-to-one assignment between tracks and detections — typically using 1 - IoU as cost — to match each track to at most one detection and vice versa", "It trains the detector", "It predicts future trajectories"],
+      "options": [
+        "It filters out low-confidence detections",
+        "It solves the minimum-cost one-to-one assignment between tracks and detections — typically using 1 - IoU as cost — to match each track to at most one detection and vice versa",
+        "It trains the detector",
+        "It predicts future trajectories"
+      ],
       "correct": 1,
       "explanation": "Every tracking-by-detection frame does an assignment problem: M tracks, N detections, find the best one-to-one match. Hungarian is the optimal polynomial algorithm for this. Cost is usually 1 - IoU (higher overlap = lower cost). scipy.optimize.linear_sum_assignment is the standard implementation. SORT, DeepSORT, ByteTrack, BoT-SORT all use it."
     },
     {
       "stage": "pre",
       "question": "ByteTrack's distinguishing contribution is what?",
-      "options": ["A new backbone", "A second-stage association that tries to match leftover tracks to low-confidence detections, recovering short occlusions and IDs that standard trackers would lose by dropping those detections", "A new Kalman filter", "An appearance embedding"],
-      "correct": 1,
+      "options": [
+        "A second-stage association that tries to match leftover tracks to low-confidence detections, recovering short occlusions and IDs that standard trackers would lose by dropping those detections",
+        "A new backbone",
+        "A new Kalman filter",
+        "An appearance embedding"
+      ],
+      "correct": 0,
       "explanation": "Most trackers discard detections below a confidence threshold (~0.5). ByteTrack keeps them and runs a second Hungarian pass to try to match them to tracks that did not match any high-confidence detection. This recovers brief occlusions and crossings, lifting IDF1 significantly on MOT17 without any learned appearance features. Its simplicity makes it the default in Ultralytics and Roboflow Supervision."
     },
     {
       "stage": "post",
       "question": "How does SAM 2's memory-based tracker avoid explicit Hungarian-style association?",
-      "options": ["It runs SORT internally", "It stores per-instance spatio-temporal features in a memory bank; on each new frame, cross-attention between memory and current features directly produces the mask of the same instance, with association implicit in the attention operation", "It uses a Kalman filter", "It requires hand-labelled IDs per frame"],
-      "correct": 1,
+      "options": [
+        "It runs SORT internally",
+        "It uses a Kalman filter",
+        "It stores per-instance spatio-temporal features in a memory bank; on each new frame, cross-attention between memory and current features directly produces the mask of the same instance, with association implicit in the attention operation",
+        "It requires hand-labelled IDs per frame"
+      ],
+      "correct": 2,
       "explanation": "SAM 2 replaces the detect-then-associate loop with a memory-conditional segmenter. The memory bank holds the instance's features from previous frames. At each new frame, the decoder cross-attends the new frame's features against the memory, and the resulting mask is the same instance — no external assignment step. This handles long occlusions gracefully because the memory stays even when the instance disappears for many frames."
     },
     {
       "stage": "post",
       "question": "For surveillance video where keeping each person's ID consistent is the primary requirement, which metric should you report?",
-      "options": ["MOTA", "IDF1 — the harmonic mean of ID precision and recall; measures identity preservation over time rather than per-frame detection accuracy", "Top-1 accuracy", "FID"],
-      "correct": 1,
+      "options": [
+        "MOTA",
+        "FID",
+        "Top-1 accuracy",
+        "IDF1 — the harmonic mean of ID precision and recall; measures identity preservation over time rather than per-frame detection accuracy"
+      ],
+      "correct": 3,
       "explanation": "MOTA conflates detection and association errors, so a tracker with many false positives can hide its ID failures. IDF1 is designed for the 'who is who over time' question: it matches predicted tracks to ground-truth tracks globally across the whole video and computes F1 on the identity labels. For surveillance and crowd analytics, IDF1 is the metric to report; HOTA is the broader academic standard."
     },
     {
       "stage": "post",
       "question": "SAM 3.1 Object Multiplex (March 2026) introduces shared memory across many tracked instances. What does that enable?",
-      "options": ["Lower accuracy", "Efficient multi-object tracking — one shared memory bank with per-instance query tokens replaces N separate memory banks, so cost scales sub-linearly in number of instances and concert-crowd-sized scenes become tractable", "Cloud-only inference", "A new training objective"],
+      "options": [
+        "Lower accuracy",
+        "Efficient multi-object tracking — one shared memory bank with per-instance query tokens replaces N separate memory banks, so cost scales sub-linearly in number of instances and concert-crowd-sized scenes become tractable",
+        "Cloud-only inference",
+        "A new training objective"
+      ],
       "correct": 1,
       "explanation": "Pre-Multiplex SAM 2 / SAM 3 tracked each object with its own memory bank; cost scaled linearly with the number of instances. Multiplex (March 2026) introduces one shared memory with per-instance query tokens that fetch instance-specific features. Many-object tracking — crowds, traffic, warehouse workers — becomes efficient for the first time with a memory-based tracker."
     }

--- a/phases/04-computer-vision/28-world-models-video-diffusion/quiz.json
+++ b/phases/04-computer-vision/28-world-models-video-diffusion/quiz.json
@@ -3,35 +3,60 @@
     {
       "stage": "pre",
       "question": "What architectural difference distinguishes an action-conditioned world model (Genie 3) from a pure video generation model (Sora 2)?",
-      "options": ["Action-conditioned models are smaller", "Pure video generators condition on a prompt at t=0 and roll out; action-conditioned world models take a latent or explicit action per frame so the user can steer the rollout mid-generation", "Only the training datasets differ", "World models only work on 3D scenes"],
+      "options": [
+        "Action-conditioned models are smaller",
+        "Pure video generators condition on a prompt at t=0 and roll out; action-conditioned world models take a latent or explicit action per frame so the user can steer the rollout mid-generation",
+        "Only the training datasets differ",
+        "World models only work on 3D scenes"
+      ],
       "correct": 1,
       "explanation": "Sora 2 is autoregressive on spacetime tokens; its prompt sets the scene but you cannot change direction mid-rollout. Genie 3 infers or takes a latent action at each step and conditions the next-frame prediction on it, letting the user interact with the simulated world. This interactivity is what makes a model a 'world simulator' rather than a video generator."
     },
     {
       "stage": "pre",
       "question": "Divided attention in a video transformer means what?",
-      "options": ["Half the tokens are masked", "Each block does a temporal attention (same spatial position, across frames) followed by a spatial attention (same frame, across positions); this factorises cost from O((T*H*W)^2) into O((H*W)*T^2) + O(T*(H*W)^2) — dramatically cheaper than the joint product", "Only half the layers run attention", "Attention is split across GPUs"],
-      "correct": 1,
+      "options": [
+        "Each block does a temporal attention (same spatial position, across frames) followed by a spatial attention (same frame, across positions); this factorises cost from O((T*H*W)^2) into O((H*W)*T^2) + O(T*(H*W)^2) — dramatically cheaper than the joint product",
+        "Half the tokens are masked",
+        "Only half the layers run attention",
+        "Attention is split across GPUs"
+      ],
+      "correct": 0,
       "explanation": "Full joint attention over spacetime tokens is prohibitive: for T=150 temporal tokens and a 60x45 spatial grid (2700 spatial tokens), the joint (T*H*W)^2 ≈ 1.6e11 pairs. Divided attention runs temporal attention at each spatial position (H*W * T^2 ≈ 6.1e7) and spatial attention at each timestep (T * (H*W)^2 ≈ 1.1e9) — multiple orders of magnitude less. TimeSformer introduced this pattern; almost every 2026 video DiT (Sora, Wan, HunyuanVideo) uses a divided or window variant."
     },
     {
       "stage": "post",
       "question": "Sora 2's 2026 release advertised better physical plausibility. Which specific failure modes did this target?",
-      "options": ["Colour balance and contrast", "Weight, balance, object permanence, cause-and-effect — the model now handles dropped objects, characters colliding, and 'failures on purpose' (a missed jump) more believably than Sora 1", "Text rendering inside images", "Video length"],
-      "correct": 1,
+      "options": [
+        "Colour balance and contrast",
+        "Text rendering inside images",
+        "Weight, balance, object permanence, cause-and-effect — the model now handles dropped objects, characters colliding, and 'failures on purpose' (a missed jump) more believably than Sora 1",
+        "Video length"
+      ],
+      "correct": 2,
       "explanation": "Prior-generation video models famously failed on spaghetti-eating, drinking from glasses, and persistent-object scenes — hands would pass through objects, items would disappear mid-action. Sora 2 explicitly advertises improvements on weight, balance, object permanence, and cause-and-effect, measured against internal and public plausibility benchmarks. These are the dominant quality failures the field is still working on."
     },
     {
       "stage": "post",
       "question": "In the emerging robotics stack (VLM + video generation + inverse dynamics), what does the inverse dynamics model do?",
-      "options": ["It generates the next frame", "It takes a pair (current observation, desired next observation from the video model) and outputs the low-level motor action that would connect them; this closes the loop between imagined rollouts and actual actuation", "It trains the VLM", "It labels training data"],
-      "correct": 1,
+      "options": [
+        "It generates the next frame",
+        "It labels training data",
+        "It trains the VLM",
+        "It takes a pair (current observation, desired next observation from the video model) and outputs the low-level motor action that would connect them; this closes the loop between imagined rollouts and actual actuation"
+      ],
+      "correct": 3,
       "explanation": "The VLM plans, the video model imagines, and the inverse dynamics model turns imagination into motor commands. Given two consecutive observations, inverse dynamics asks: what action produced this transition? This three-component stack lets a robot train largely in a learned simulator, using the video model to generate data and the inverse dynamics model to execute."
     },
     {
       "stage": "post",
       "question": "Autonomous-driving teams use world models (Cosmos-Drive, Gaia-2, DrivingWorld) to replace what cost?",
-      "options": ["Actual fleet insurance", "Expensive real-world data collection for rare or dangerous corner cases (pedestrian jaywalks, icy roads, unusual vehicles); synthesised driving video provides on-demand training and evaluation data for those scenarios", "Road tolls", "Vehicle depreciation"],
+      "options": [
+        "Actual fleet insurance",
+        "Expensive real-world data collection for rare or dangerous corner cases (pedestrian jaywalks, icy roads, unusual vehicles); synthesised driving video provides on-demand training and evaluation data for those scenarios",
+        "Road tolls",
+        "Vehicle depreciation"
+      ],
       "correct": 1,
       "explanation": "Collecting corner-case driving data takes millions of real-world miles. Cosmos-Drive, Gaia-2, and DrivingWorld generate it conditioned on trajectories and maps. Teams use this data to expand training sets, evaluate planners in reproducible conditions, and de-risk scenarios they cannot ethically drive in reality. Replacing a fraction of real-world collection with synthesis is one of the clearest production wins for video world models in 2026."
     }

--- a/phases/07-transformers-deep-dive/02-self-attention-from-scratch/quiz.json
+++ b/phases/07-transformers-deep-dive/02-self-attention-from-scratch/quiz.json
@@ -3,35 +3,60 @@
     {
       "stage": "pre",
       "question": "Why does vanilla self-attention scale the dot product by 1/sqrt(d_k)?",
-      "options": ["To make the output values between 0 and 1", "To prevent dot products from growing large in high dimensions, which would push softmax into regions with tiny gradients", "To normalize the query and key vectors to unit length", "To reduce the computational cost of the matrix multiplication"],
+      "options": [
+        "To make the output values between 0 and 1",
+        "To prevent dot products from growing large in high dimensions, which would push softmax into regions with tiny gradients",
+        "To normalize the query and key vectors to unit length",
+        "To reduce the computational cost of the matrix multiplication"
+      ],
       "correct": 1,
       "explanation": "When d_k is large, the dot product of random vectors grows proportionally to sqrt(d_k). Without scaling, softmax receives large inputs, producing near-one-hot outputs where gradients vanish."
     },
     {
       "stage": "pre",
       "question": "What are the three projections in self-attention?",
-      "options": ["Input, hidden, and output", "Query, key, and value -- each a learned linear projection of the same input", "Encoder, decoder, and cross-attention", "Embedding, position, and segment"],
-      "correct": 1,
+      "options": [
+        "Query, key, and value -- each a learned linear projection of the same input",
+        "Input, hidden, and output",
+        "Encoder, decoder, and cross-attention",
+        "Embedding, position, and segment"
+      ],
+      "correct": 0,
       "explanation": "Self-attention projects the input through three different weight matrices to produce queries (what am I looking for?), keys (what do I contain?), and values (what do I output if matched?)."
     },
     {
       "stage": "post",
       "question": "In multi-head attention with 8 heads and d_model=512, what is the dimension of each head?",
-      "options": ["512 -- each head sees the full dimension", "64 -- d_model is split evenly across heads (512/8=64)", "8 -- one dimension per head", "4096 -- each head expands the representation"],
-      "correct": 1,
+      "options": [
+        "512 -- each head sees the full dimension",
+        "8 -- one dimension per head",
+        "64 -- d_model is split evenly across heads (512/8=64)",
+        "4096 -- each head expands the representation"
+      ],
+      "correct": 2,
       "explanation": "Multi-head attention splits d_model into h heads, each operating on d_k = d_model/h dimensions. With 512/8 = 64 dimensions per head, the total computation cost equals single-head attention at full dimension."
     },
     {
       "stage": "post",
       "question": "What does the causal mask in autoregressive attention prevent?",
-      "options": ["It prevents the model from attending to padding tokens", "It prevents each position from attending to future positions, ensuring the model can only use past context when predicting the next token", "It prevents attention weights from becoming too large", "It prevents the model from attending to its own position"],
-      "correct": 1,
+      "options": [
+        "It prevents the model from attending to padding tokens",
+        "It prevents the model from attending to its own position",
+        "It prevents attention weights from becoming too large",
+        "It prevents each position from attending to future positions, ensuring the model can only use past context when predicting the next token"
+      ],
+      "correct": 3,
       "explanation": "In autoregressive generation, token t must not see tokens t+1, t+2, etc. The causal mask sets future positions to -infinity before softmax, zeroing out their attention weights."
     },
     {
       "stage": "post",
       "question": "Why does self-attention have O(n^2) complexity in sequence length n?",
-      "options": ["Because the model has n layers stacked on top of each other", "Because every token computes attention scores with every other token, producing an n x n attention matrix", "Because the feedforward layers after attention are quadratic", "Because backpropagation through attention requires n^2 gradient computations"],
+      "options": [
+        "Because the model has n layers stacked on top of each other",
+        "Because every token computes attention scores with every other token, producing an n x n attention matrix",
+        "Because the feedforward layers after attention are quadratic",
+        "Because backpropagation through attention requires n^2 gradient computations"
+      ],
       "correct": 1,
       "explanation": "The QK^T matrix multiplication produces an n x n attention matrix where entry (i,j) is the attention from token i to token j. Both computation and memory scale as O(n^2), which is why long-context models need techniques like FlashAttention."
     }

--- a/phases/10-llms-from-scratch/01-tokenizers/quiz.json
+++ b/phases/10-llms-from-scratch/01-tokenizers/quiz.json
@@ -1,35 +1,60 @@
 [
   {
     "question": "What is the primary purpose of a tokenizer in an LLM pipeline?",
-    "options": ["To remove stop words from text", "To convert text into a sequence of integers that the model can process", "To translate text between languages", "To compress text for storage"],
+    "options": [
+      "To remove stop words from text",
+      "To convert text into a sequence of integers that the model can process",
+      "To translate text between languages",
+      "To compress text for storage"
+    ],
     "correct": 1,
     "explanation": "LLMs process numbers, not text. The tokenizer converts every character, word, and symbol into integer IDs from a fixed vocabulary. This conversion is not neutral -- it determines how the model 'sees' language.",
     "stage": "pre"
   },
   {
     "question": "What does BPE (Byte Pair Encoding) do to build its vocabulary?",
-    "options": ["Splits text into individual characters only", "Iteratively merges the most frequent adjacent pair of tokens until reaching the target vocabulary size", "Uses a dictionary lookup for whole words", "Randomly assigns IDs to substrings"],
-    "correct": 1,
+    "options": [
+      "Iteratively merges the most frequent adjacent pair of tokens until reaching the target vocabulary size",
+      "Splits text into individual characters only",
+      "Uses a dictionary lookup for whole words",
+      "Randomly assigns IDs to substrings"
+    ],
+    "correct": 0,
     "explanation": "BPE starts with individual bytes/characters and repeatedly merges the most common adjacent pair. 'th' + 'e' becomes 'the'. After thousands of merges, common words become single tokens while rare words are split into subword pieces.",
     "stage": "pre"
   },
   {
     "question": "Why does vocabulary size create a tradeoff in LLM design?",
-    "options": ["Larger vocabularies always perform better", "Too small creates long sequences (more computation); too large wastes embedding parameters on rare tokens", "Vocabulary size doesn't affect model performance", "Smaller vocabularies are always more efficient"],
-    "correct": 1,
+    "options": [
+      "Larger vocabularies always perform better",
+      "Vocabulary size doesn't affect model performance",
+      "Too small creates long sequences (more computation); too large wastes embedding parameters on rare tokens",
+      "Smaller vocabularies are always more efficient"
+    ],
+    "correct": 2,
     "explanation": "Small vocabulary (e.g., character-level) means every word is many tokens, increasing sequence length and computation. Large vocabulary wastes parameters on tokens that rarely appear in training data. Most LLMs use 32K-100K tokens.",
     "stage": "post"
   },
   {
     "question": "What problem does byte-level fallback solve in tokenization?",
-    "options": ["It speeds up tokenization", "It ensures any input (emoji, rare scripts, binary data) can be encoded without 'unknown' tokens", "It reduces vocabulary size", "It improves model accuracy"],
-    "correct": 1,
+    "options": [
+      "It speeds up tokenization",
+      "It improves model accuracy",
+      "It reduces vocabulary size",
+      "It ensures any input (emoji, rare scripts, binary data) can be encoded without 'unknown' tokens"
+    ],
+    "correct": 3,
     "explanation": "With byte-level fallback, the tokenizer can fall back to raw byte values (256 possible) for any character not in the vocabulary. This guarantees complete coverage -- no input is ever 'unknown.'",
     "stage": "post"
   },
   {
     "question": "How does the tokenizer affect non-English language performance in LLMs?",
-    "options": ["Tokenizers work equally well for all languages", "Languages underrepresented in training data get worse token merges, requiring more tokens per word and wasting context window", "Non-English text is always character-tokenized", "Tokenization doesn't affect language performance"],
+    "options": [
+      "Tokenizers work equally well for all languages",
+      "Languages underrepresented in training data get worse token merges, requiring more tokens per word and wasting context window",
+      "Non-English text is always character-tokenized",
+      "Tokenization doesn't affect language performance"
+    ],
     "correct": 1,
     "explanation": "BPE merges are learned from training data. If Japanese text is 5% of the corpus, Japanese characters get fewer merges, requiring 2-5x more tokens per word than English. This effectively shrinks the context window for non-English text.",
     "stage": "post"

--- a/phases/10-llms-from-scratch/02-building-a-tokenizer/quiz.json
+++ b/phases/10-llms-from-scratch/02-building-a-tokenizer/quiz.json
@@ -1,35 +1,60 @@
 [
   {
     "question": "Why does a basic BPE tokenizer break on multilingual or code input?",
-    "options": ["BPE is inherently monolingual", "Without proper Unicode handling, byte fallback, and pre-tokenization regex, it produces incorrect or inefficient token sequences", "Multilingual text can't be tokenized", "BPE only works on ASCII"],
+    "options": [
+      "BPE is inherently monolingual",
+      "Without proper Unicode handling, byte fallback, and pre-tokenization regex, it produces incorrect or inefficient token sequences",
+      "Multilingual text can't be tokenized",
+      "BPE only works on ASCII"
+    ],
     "correct": 1,
     "explanation": "A naive BPE implementation may not handle multi-byte Unicode characters, may merge across word boundaries incorrectly, and may not have byte-level fallback for characters outside the trained vocabulary.",
     "stage": "pre"
   },
   {
     "question": "What is the role of pre-tokenization regex in a production tokenizer?",
-    "options": ["It removes punctuation", "It splits text at word boundaries before BPE merges, preventing merges across spaces and word boundaries", "It compresses whitespace", "It converts text to lowercase"],
-    "correct": 1,
+    "options": [
+      "It splits text at word boundaries before BPE merges, preventing merges across spaces and word boundaries",
+      "It removes punctuation",
+      "It compresses whitespace",
+      "It converts text to lowercase"
+    ],
+    "correct": 0,
     "explanation": "Pre-tokenization regex splits text into chunks (typically at word boundaries, numbers, and punctuation) so BPE merges only happen within chunks. Without this, BPE could merge 'end' with the space before the next word.",
     "stage": "pre"
   },
   {
     "question": "What is a special token and why are tokenizers designed to handle them?",
-    "options": ["Tokens that appear frequently", "Reserved tokens like <|endoftext|> or [PAD] that control model behavior and must be encoded as single, specific IDs", "Tokens with the highest embedding values", "Tokens used only during evaluation"],
-    "correct": 1,
+    "options": [
+      "Tokens that appear frequently",
+      "Tokens with the highest embedding values",
+      "Reserved tokens like <|endoftext|> or [PAD] that control model behavior and must be encoded as single, specific IDs",
+      "Tokens used only during evaluation"
+    ],
+    "correct": 2,
     "explanation": "Special tokens serve structural purposes: marking document boundaries, padding sequences, indicating start/end of generation. They must be recognized and encoded as their exact IDs, not broken into subwords.",
     "stage": "post"
   },
   {
     "question": "How do you evaluate whether a custom tokenizer is good?",
-    "options": ["By checking if it can tokenize your name", "By measuring compression ratio (tokens per character) across diverse text and comparing to established tokenizers like tiktoken", "By counting the vocabulary size", "By measuring encoding speed only"],
-    "correct": 1,
+    "options": [
+      "By checking if it can tokenize your name",
+      "By measuring encoding speed only",
+      "By counting the vocabulary size",
+      "By measuring compression ratio (tokens per character) across diverse text and comparing to established tokenizers like tiktoken"
+    ],
+    "correct": 3,
     "explanation": "Compression ratio (bytes per token or tokens per word) measures efficiency. A good tokenizer produces fewer tokens for the same text, which means more content fits in the context window. Compare across languages and domains.",
     "stage": "post"
   },
   {
     "question": "Why is byte-level BPE preferred over word-level tokenization for modern LLMs?",
-    "options": ["It's faster", "It can represent any input without unknown tokens while still learning efficient subword merges for common patterns", "It produces smaller vocabularies", "Word-level tokenization is more accurate"],
+    "options": [
+      "It's faster",
+      "It can represent any input without unknown tokens while still learning efficient subword merges for common patterns",
+      "It produces smaller vocabularies",
+      "Word-level tokenization is more accurate"
+    ],
     "correct": 1,
     "explanation": "Word-level tokenizers can't handle unseen words (producing [UNK] tokens). Byte-level BPE starts from raw bytes (guaranteeing coverage of any input) and learns merges for common sequences, balancing coverage with efficiency.",
     "stage": "post"

--- a/phases/10-llms-from-scratch/03-data-pipelines/quiz.json
+++ b/phases/10-llms-from-scratch/03-data-pipelines/quiz.json
@@ -1,35 +1,60 @@
 [
   {
     "question": "Why can't you simply load all pre-training data into memory?",
-    "options": ["Python doesn't support large arrays", "Pre-training corpora are terabytes in size, far exceeding available RAM, requiring streaming pipelines", "Loading data into memory is slower", "Memory is only needed for model weights"],
+    "options": [
+      "Python doesn't support large arrays",
+      "Pre-training corpora are terabytes in size, far exceeding available RAM, requiring streaming pipelines",
+      "Loading data into memory is slower",
+      "Memory is only needed for model weights"
+    ],
     "correct": 1,
     "explanation": "LLM pre-training data is typically 1-15 TB of text. Even with 256GB of RAM, you can't hold the full dataset. Streaming pipelines process data on-the-fly, loading only what's needed for the current batch.",
     "stage": "pre"
   },
   {
     "question": "Why is data deduplication important for pre-training?",
-    "options": ["It saves disk space", "Duplicate documents cause the model to memorize specific text verbatim and waste training compute on repeated content", "It speeds up tokenization", "It reduces the vocabulary size"],
-    "correct": 1,
+    "options": [
+      "Duplicate documents cause the model to memorize specific text verbatim and waste training compute on repeated content",
+      "It saves disk space",
+      "It speeds up tokenization",
+      "It reduces the vocabulary size"
+    ],
+    "correct": 0,
     "explanation": "Near-duplicate content (boilerplate, scraped duplicates) causes the model to memorize rather than generalize. Deduplication reduces training compute waste and improves model quality by ensuring diverse training signal.",
     "stage": "pre"
   },
   {
     "question": "What is the purpose of creating fixed-length training sequences from variable-length documents?",
-    "options": ["It makes the text easier to read", "GPU training requires uniform tensor shapes, so documents must be packed or padded into fixed-length sequences", "Fixed-length sequences are more accurate", "It reduces the total number of tokens"],
-    "correct": 1,
+    "options": [
+      "It makes the text easier to read",
+      "Fixed-length sequences are more accurate",
+      "GPU training requires uniform tensor shapes, so documents must be packed or padded into fixed-length sequences",
+      "It reduces the total number of tokens"
+    ],
+    "correct": 2,
     "explanation": "GPUs process batches of tensors with identical shapes. Variable-length documents must be chunked into fixed-length sequences (e.g., 2048 or 4096 tokens) with proper attention masks at document boundaries.",
     "stage": "post"
   },
   {
     "question": "What happens if the data pipeline is slower than GPU training speed?",
-    "options": ["Training automatically slows down to match", "The GPU sits idle waiting for batches, wasting expensive compute time", "The model trains on the same batch repeatedly", "Nothing -- the pipeline runs asynchronously"],
-    "correct": 1,
+    "options": [
+      "Training automatically slows down to match",
+      "Nothing -- the pipeline runs asynchronously",
+      "The model trains on the same batch repeatedly",
+      "The GPU sits idle waiting for batches, wasting expensive compute time"
+    ],
+    "correct": 3,
     "explanation": "If the dataloader can't serve batches fast enough, the GPU stalls between steps. On A100 clusters costing $30+/hour, pipeline bottlenecks directly waste money. Profiling pipeline throughput is essential.",
     "stage": "post"
   },
   {
     "question": "Why is data quality filtering (language detection, content filtering) applied before tokenization?",
-    "options": ["Tokenizers can't handle low-quality text", "Low-quality data (spam, boilerplate, toxic content) degrades model capabilities proportional to its share of training data", "Filtering after tokenization is impossible", "It reduces tokenization time"],
+    "options": [
+      "Tokenizers can't handle low-quality text",
+      "Low-quality data (spam, boilerplate, toxic content) degrades model capabilities proportional to its share of training data",
+      "Filtering after tokenization is impossible",
+      "It reduces tokenization time"
+    ],
     "correct": 1,
     "explanation": "The model learns from whatever data it sees. If 10% of training data is spam or low-quality content, the model allocates 10% of its capacity to reproducing those patterns. Filtering early ensures only high-quality signal reaches the model.",
     "stage": "post"

--- a/phases/10-llms-from-scratch/04-pre-training-mini-gpt/quiz.json
+++ b/phases/10-llms-from-scratch/04-pre-training-mini-gpt/quiz.json
@@ -1,35 +1,60 @@
 [
   {
     "question": "What training objective does GPT use during pre-training?",
-    "options": ["Masked language modeling (predicting masked tokens)", "Next-token prediction: given previous tokens, predict the next one", "Sentence classification", "Image-text alignment"],
+    "options": [
+      "Masked language modeling (predicting masked tokens)",
+      "Next-token prediction: given previous tokens, predict the next one",
+      "Sentence classification",
+      "Image-text alignment"
+    ],
     "correct": 1,
     "explanation": "GPT is a causal (autoregressive) language model trained with next-token prediction. Given tokens [t1, t2, ..., tn], it learns to predict tn+1. The loss is cross-entropy between predicted and actual next tokens.",
     "stage": "pre"
   },
   {
     "question": "How many transformer layers, attention heads, and embedding dimensions does GPT-2 Small (124M) have?",
-    "options": ["6 layers, 6 heads, 512 dims", "12 layers, 12 heads, 768 dims", "24 layers, 16 heads, 1024 dims", "48 layers, 25 heads, 1600 dims"],
-    "correct": 1,
+    "options": [
+      "12 layers, 12 heads, 768 dims",
+      "6 layers, 6 heads, 512 dims",
+      "24 layers, 16 heads, 1024 dims",
+      "48 layers, 25 heads, 1600 dims"
+    ],
+    "correct": 0,
     "explanation": "GPT-2 Small has 12 transformer layers, 12 attention heads per layer, and 768-dimensional embeddings. This architecture has 124 million parameters and can be trained on a single GPU in a few hours.",
     "stage": "pre"
   },
   {
     "question": "What is the role of the causal attention mask in GPT?",
-    "options": ["It prevents attention to padding tokens", "It prevents each token from attending to future tokens, ensuring the model can only use past context for predictions", "It masks out low-confidence attention scores", "It reduces memory usage during training"],
-    "correct": 1,
+    "options": [
+      "It prevents attention to padding tokens",
+      "It masks out low-confidence attention scores",
+      "It prevents each token from attending to future tokens, ensuring the model can only use past context for predictions",
+      "It reduces memory usage during training"
+    ],
+    "correct": 2,
     "explanation": "The causal mask is a triangular matrix that sets future positions to -infinity before softmax. Token at position 5 can attend to positions 1-5 but not 6+. This ensures the model generates tokens left-to-right.",
     "stage": "post"
   },
   {
     "question": "What does 'temperature' control during text generation?",
-    "options": ["The speed of generation", "The randomness of token selection: lower temperature makes outputs more deterministic, higher makes them more diverse", "The number of tokens generated", "The model's confidence threshold"],
-    "correct": 1,
+    "options": [
+      "The speed of generation",
+      "The model's confidence threshold",
+      "The number of tokens generated",
+      "The randomness of token selection: lower temperature makes outputs more deterministic, higher makes them more diverse"
+    ],
+    "correct": 3,
     "explanation": "Temperature divides logits before softmax. Temperature=0.1 makes the distribution very peaked (nearly deterministic). Temperature=1.0 is the training distribution. Temperature>1.0 flattens it, increasing randomness.",
     "stage": "post"
   },
   {
     "question": "Why does pre-training require significantly more compute than fine-tuning?",
-    "options": ["Pre-training uses larger batch sizes", "Pre-training processes trillions of tokens from scratch to learn general language patterns, while fine-tuning adjusts an already-capable model on thousands of examples", "Pre-training uses a different architecture", "Fine-tuning doesn't use gradients"],
+    "options": [
+      "Pre-training uses larger batch sizes",
+      "Pre-training processes trillions of tokens from scratch to learn general language patterns, while fine-tuning adjusts an already-capable model on thousands of examples",
+      "Pre-training uses a different architecture",
+      "Fine-tuning doesn't use gradients"
+    ],
     "correct": 1,
     "explanation": "Pre-training builds all language knowledge from random weights over trillions of tokens. Fine-tuning starts from these learned weights and adjusts them on a much smaller dataset (thousands to millions of examples).",
     "stage": "post"

--- a/phases/10-llms-from-scratch/05-scaling-distributed/quiz.json
+++ b/phases/10-llms-from-scratch/05-scaling-distributed/quiz.json
@@ -1,35 +1,60 @@
 [
   {
     "question": "A 7B parameter model in FP16 needs how much VRAM just for weights?",
-    "options": ["7 GB", "14 GB", "28 GB", "56 GB"],
+    "options": [
+      "7 GB",
+      "14 GB",
+      "28 GB",
+      "56 GB"
+    ],
     "correct": 1,
     "explanation": "Each parameter in FP16 is 2 bytes. 7 billion * 2 bytes = 14 GB. With Adam optimizer states (2 copies) and gradients, total training memory is roughly 56 GB before accounting for activations.",
     "stage": "pre"
   },
   {
     "question": "What are the three types of parallelism used in distributed training?",
-    "options": ["CPU, GPU, and TPU parallelism", "Data parallelism, tensor parallelism, and pipeline parallelism", "Batch, sequence, and token parallelism", "Forward, backward, and optimizer parallelism"],
-    "correct": 1,
+    "options": [
+      "Data parallelism, tensor parallelism, and pipeline parallelism",
+      "CPU, GPU, and TPU parallelism",
+      "Batch, sequence, and token parallelism",
+      "Forward, backward, and optimizer parallelism"
+    ],
+    "correct": 0,
     "explanation": "Data parallelism replicates the model on each GPU and splits the data. Tensor parallelism splits individual layers across GPUs. Pipeline parallelism splits the model's layers into stages across GPUs.",
     "stage": "pre"
   },
   {
     "question": "What does FSDP (Fully Sharded Data Parallel) do that standard DDP does not?",
-    "options": ["It uses a different optimizer", "It shards model parameters, gradients, and optimizer states across GPUs instead of replicating the full model on each", "It processes data faster", "It supports more GPUs"],
-    "correct": 1,
+    "options": [
+      "It uses a different optimizer",
+      "It processes data faster",
+      "It shards model parameters, gradients, and optimizer states across GPUs instead of replicating the full model on each",
+      "It supports more GPUs"
+    ],
+    "correct": 2,
     "explanation": "Standard DDP replicates the entire model on every GPU (wasteful). FSDP shards parameters across GPUs so each holds only a fraction. Parameters are gathered on-demand for computation and released after.",
     "stage": "post"
   },
   {
     "question": "What is DeepSpeed ZeRO Stage 3?",
-    "options": ["A quantization method", "It partitions optimizer states, gradients, AND model parameters across GPUs, achieving maximum memory efficiency", "A learning rate schedule", "A data preprocessing pipeline"],
-    "correct": 1,
+    "options": [
+      "A quantization method",
+      "A data preprocessing pipeline",
+      "A learning rate schedule",
+      "It partitions optimizer states, gradients, AND model parameters across GPUs, achieving maximum memory efficiency"
+    ],
+    "correct": 3,
     "explanation": "ZeRO Stage 1 shards optimizer states, Stage 2 adds gradient sharding, Stage 3 adds parameter sharding. Stage 3 gives maximum memory savings, allowing training of models that far exceed single-GPU memory.",
     "stage": "post"
   },
   {
     "question": "Why is gradient synchronization necessary in data-parallel training?",
-    "options": ["To prevent overfitting", "Each GPU computes gradients on different data; averaging gradients across GPUs ensures all replicas update identically", "To reduce memory usage", "To speed up the forward pass"],
+    "options": [
+      "To prevent overfitting",
+      "Each GPU computes gradients on different data; averaging gradients across GPUs ensures all replicas update identically",
+      "To reduce memory usage",
+      "To speed up the forward pass"
+    ],
     "correct": 1,
     "explanation": "In data parallelism, each GPU processes a different batch and computes different gradients. AllReduce averages these gradients across all GPUs so every replica applies the same update and stays in sync.",
     "stage": "post"

--- a/phases/10-llms-from-scratch/06-instruction-tuning-sft/quiz.json
+++ b/phases/10-llms-from-scratch/06-instruction-tuning-sft/quiz.json
@@ -1,35 +1,60 @@
 [
   {
     "question": "What is the fundamental difference between a base language model and an instruction-tuned model?",
-    "options": ["They have different architectures", "A base model continues text patterns; an instruction-tuned model follows instructions and answers questions", "Instruction-tuned models are larger", "Base models are faster"],
+    "options": [
+      "They have different architectures",
+      "A base model continues text patterns; an instruction-tuned model follows instructions and answers questions",
+      "Instruction-tuned models are larger",
+      "Base models are faster"
+    ],
     "correct": 1,
     "explanation": "A base model trained with next-token prediction continues text patterns. Ask it a question and it may generate more questions. SFT teaches it to produce answers by training on (instruction, response) pairs.",
     "stage": "pre"
   },
   {
     "question": "What is the purpose of masking loss on non-assistant tokens during SFT?",
-    "options": ["To speed up training", "To train the model only to generate responses, not to memorize the instruction format or system prompts", "To reduce memory usage", "To prevent overfitting"],
-    "correct": 1,
+    "options": [
+      "To train the model only to generate responses, not to memorize the instruction format or system prompts",
+      "To speed up training",
+      "To reduce memory usage",
+      "To prevent overfitting"
+    ],
+    "correct": 0,
     "explanation": "During SFT, you want the model to learn how to respond, not how to reproduce the instruction. Loss masking sets the loss to 0 for system/user tokens so gradients only come from the assistant's response tokens.",
     "stage": "pre"
   },
   {
     "question": "What format does SFT training data typically follow?",
-    "options": ["Raw text documents", "Chat template with system, user, and assistant roles marked by special tokens", "Key-value pairs", "SQL queries and results"],
-    "correct": 1,
+    "options": [
+      "Raw text documents",
+      "Key-value pairs",
+      "Chat template with system, user, and assistant roles marked by special tokens",
+      "SQL queries and results"
+    ],
+    "correct": 2,
     "explanation": "SFT data uses a structured chat format: a system prompt setting behavior, a user instruction, and an assistant response. Special tokens mark role boundaries so the model learns the conversational structure.",
     "stage": "post"
   },
   {
     "question": "Why might an SFT model produce lower perplexity on benchmarks but worse conversational quality?",
-    "options": ["The benchmarks are wrong", "SFT optimizes for pattern matching on training examples, not for the nuanced quality judgments humans care about -- that requires RLHF/DPO", "The model is too small", "The learning rate was wrong"],
-    "correct": 1,
+    "options": [
+      "The benchmarks are wrong",
+      "The learning rate was wrong",
+      "The model is too small",
+      "SFT optimizes for pattern matching on training examples, not for the nuanced quality judgments humans care about -- that requires RLHF/DPO"
+    ],
+    "correct": 3,
     "explanation": "SFT teaches the model to follow formats and produce plausible responses. It doesn't teach which response is better when multiple valid options exist. Human preference alignment (RLHF/DPO) addresses this gap.",
     "stage": "post"
   },
   {
     "question": "How many high-quality instruction-response pairs are typically needed for effective SFT?",
-    "options": ["Millions", "10,000 to 100,000 high-quality examples", "Fewer than 100", "Billions"],
+    "options": [
+      "Millions",
+      "10,000 to 100,000 high-quality examples",
+      "Fewer than 100",
+      "Billions"
+    ],
     "correct": 1,
     "explanation": "SFT is surprisingly data-efficient. Studies show that 10K-100K high-quality examples (like the Alpaca or LIMA datasets) can effectively teach instruction following. Quality matters far more than quantity.",
     "stage": "post"

--- a/phases/10-llms-from-scratch/08-dpo/quiz.json
+++ b/phases/10-llms-from-scratch/08-dpo/quiz.json
@@ -1,35 +1,60 @@
 [
   {
     "question": "What is the main advantage of DPO over RLHF?",
-    "options": ["DPO produces better models", "DPO eliminates the need for a separate reward model and PPO, training directly on preference pairs in a single loop", "DPO uses less training data", "DPO works without any preference data"],
+    "options": [
+      "DPO produces better models",
+      "DPO eliminates the need for a separate reward model and PPO, training directly on preference pairs in a single loop",
+      "DPO uses less training data",
+      "DPO works without any preference data"
+    ],
     "correct": 1,
     "explanation": "RLHF requires training a reward model separately, then running PPO optimization. DPO folds both steps into a single training objective that directly optimizes the language model on preference pairs.",
     "stage": "pre"
   },
   {
     "question": "What role does the reference model play in DPO?",
-    "options": ["It generates training data", "It serves as the anchor that prevents the trained model from diverging too far, similar to the KL penalty in RLHF", "It evaluates model quality", "It handles tokenization"],
-    "correct": 1,
+    "options": [
+      "It serves as the anchor that prevents the trained model from diverging too far, similar to the KL penalty in RLHF",
+      "It generates training data",
+      "It evaluates model quality",
+      "It handles tokenization"
+    ],
+    "correct": 0,
     "explanation": "The DPO loss compares log probabilities under the trained policy and the reference (usually SFT) model. The reference model constrains how far the policy can drift, preventing reward hacking without explicit KL tuning.",
     "stage": "pre"
   },
   {
     "question": "What does the beta parameter in DPO control?",
-    "options": ["The learning rate", "How strongly the policy is constrained to stay close to the reference model -- higher beta means more conservative updates", "The batch size", "The number of training epochs"],
-    "correct": 1,
+    "options": [
+      "The learning rate",
+      "The batch size",
+      "How strongly the policy is constrained to stay close to the reference model -- higher beta means more conservative updates",
+      "The number of training epochs"
+    ],
+    "correct": 2,
     "explanation": "Beta scales the implicit KL divergence penalty. Beta=0.1 allows the model to diverge significantly from the reference (potentially better but riskier). Beta=0.5 keeps it close (safer but less learning).",
     "stage": "post"
   },
   {
     "question": "How does DPO implicitly represent a reward model?",
-    "options": ["It doesn't -- DPO has no concept of reward", "The DPO loss function can be derived by showing that the optimal policy under a reward function is directly expressible through policy log probabilities", "It trains a hidden reward model inside the language model", "DPO uses the loss function as the reward"],
-    "correct": 1,
+    "options": [
+      "It doesn't -- DPO has no concept of reward",
+      "DPO uses the loss function as the reward",
+      "It trains a hidden reward model inside the language model",
+      "The DPO loss function can be derived by showing that the optimal policy under a reward function is directly expressible through policy log probabilities"
+    ],
+    "correct": 3,
     "explanation": "Rafailov et al. showed that the closed-form solution of the RLHF objective expresses the reward as a function of the policy's log-probabilities relative to the reference. DPO optimizes this directly, implicitly learning the reward.",
     "stage": "post"
   },
   {
     "question": "When might RLHF still be preferred over DPO?",
-    "options": ["Always -- RLHF is strictly better", "When you need a reusable reward model for evaluating multiple policies or when online data collection is beneficial", "When you have less preference data", "When training smaller models"],
+    "options": [
+      "Always -- RLHF is strictly better",
+      "When you need a reusable reward model for evaluating multiple policies or when online data collection is beneficial",
+      "When you have less preference data",
+      "When training smaller models"
+    ],
     "correct": 1,
     "explanation": "DPO is offline (fixed preference data). RLHF allows online data collection where the reward model scores new generations, discovering reward-hacking patterns. A standalone reward model is also useful for evaluation and other policies.",
     "stage": "post"

--- a/phases/10-llms-from-scratch/10-evaluation/quiz.json
+++ b/phases/10-llms-from-scratch/10-evaluation/quiz.json
@@ -1,35 +1,60 @@
 [
   {
     "question": "Why have benchmarks like MMLU become less useful for comparing frontier models?",
-    "options": ["They test the wrong subjects", "Frontier models have saturated MMLU (scoring 86-89%), compressing the leaderboard to a range where differences are statistical noise", "MMLU was designed for smaller models", "The questions are too easy"],
+    "options": [
+      "They test the wrong subjects",
+      "Frontier models have saturated MMLU (scoring 86-89%), compressing the leaderboard to a range where differences are statistical noise",
+      "MMLU was designed for smaller models",
+      "The questions are too easy"
+    ],
     "correct": 1,
     "explanation": "When GPT-4, Claude 3, and Llama 3 all score 86-89% on MMLU, a 1-point difference is not meaningful. The benchmark no longer discriminates between models, yet it still dominates leaderboard culture.",
     "stage": "pre"
   },
   {
     "question": "What is Goodhart's Law in the context of LLM evaluation?",
-    "options": ["A law about model scaling", "When a measure becomes a target, it ceases to be a good measure -- models and teams optimize for benchmarks instead of real capabilities", "A rule about learning rate schedules", "A theorem about attention mechanisms"],
-    "correct": 1,
+    "options": [
+      "When a measure becomes a target, it ceases to be a good measure -- models and teams optimize for benchmarks instead of real capabilities",
+      "A law about model scaling",
+      "A rule about learning rate schedules",
+      "A theorem about attention mechanisms"
+    ],
+    "correct": 0,
     "explanation": "Labs optimize for benchmark scores (data contamination, benchmark-specific prompting). The score goes up, but real-world capability doesn't necessarily improve. Your own task-specific eval is the only reliable measure.",
     "stage": "pre"
   },
   {
     "question": "What is the LLM-as-judge evaluation approach?",
-    "options": ["Having a human judge evaluate every response", "Using a strong LLM (e.g., GPT-4) to score responses against rubrics, replacing expensive human evaluation at scale", "Training a separate classifier for evaluation", "Using the model to evaluate itself"],
-    "correct": 1,
+    "options": [
+      "Having a human judge evaluate every response",
+      "Training a separate classifier for evaluation",
+      "Using a strong LLM (e.g., GPT-4) to score responses against rubrics, replacing expensive human evaluation at scale",
+      "Using the model to evaluate itself"
+    ],
+    "correct": 2,
     "explanation": "LLM-as-judge uses a capable model to score responses against defined criteria. It's cheaper and faster than human evaluation, though it has biases (e.g., preferring verbose responses) that must be calibrated.",
     "stage": "post"
   },
   {
     "question": "Why is building a custom evaluation suite important rather than relying on public benchmarks?",
-    "options": ["Public benchmarks are always wrong", "Public benchmarks test general capabilities; your application has specific requirements that only a custom eval can measure", "Custom evals are easier to build", "Public benchmarks are too expensive"],
-    "correct": 1,
+    "options": [
+      "Public benchmarks are always wrong",
+      "Public benchmarks are too expensive",
+      "Custom evals are easier to build",
+      "Public benchmarks test general capabilities; your application has specific requirements that only a custom eval can measure"
+    ],
+    "correct": 3,
     "explanation": "A model scoring 90% on MMLU might fail on your specific task (e.g., extracting dates from legal documents in your format). Only a custom eval with your data, your edge cases, and your success criteria measures what matters.",
     "stage": "post"
   },
   {
     "question": "What is data contamination in the context of LLM benchmarks?",
-    "options": ["When training data is corrupted", "When benchmark questions appear in the model's pre-training data, inflating scores without reflecting true capability", "When the model generates incorrect data", "When evaluation data is mislabeled"],
+    "options": [
+      "When training data is corrupted",
+      "When benchmark questions appear in the model's pre-training data, inflating scores without reflecting true capability",
+      "When the model generates incorrect data",
+      "When evaluation data is mislabeled"
+    ],
     "correct": 1,
     "explanation": "If MMLU questions appeared in the training corpus, the model memorized the answers rather than reasoning about them. This inflates scores and makes benchmark comparisons unreliable. It's a growing problem as training corpora expand.",
     "stage": "post"

--- a/phases/10-llms-from-scratch/12-inference-optimization/quiz.json
+++ b/phases/10-llms-from-scratch/12-inference-optimization/quiz.json
@@ -1,35 +1,60 @@
 [
   {
     "question": "What are the two phases of LLM inference?",
-    "options": ["Training and evaluation", "Prefill (processes the prompt in parallel, compute-bound) and decode (generates tokens one at a time, memory-bound)", "Encoding and decoding", "Forward and backward"],
+    "options": [
+      "Training and evaluation",
+      "Prefill (processes the prompt in parallel, compute-bound) and decode (generates tokens one at a time, memory-bound)",
+      "Encoding and decoding",
+      "Forward and backward"
+    ],
     "correct": 1,
     "explanation": "Prefill processes all prompt tokens in parallel (limited by compute). Decode generates tokens autoregressively one at a time (limited by memory bandwidth for loading model weights). Different optimizations target each phase.",
     "stage": "pre"
   },
   {
     "question": "What does KV-cache eliminate during autoregressive generation?",
-    "options": ["The need for attention masks", "Redundant recomputation of key and value vectors for all previous tokens at each generation step", "The embedding lookup", "The softmax computation"],
-    "correct": 1,
+    "options": [
+      "Redundant recomputation of key and value vectors for all previous tokens at each generation step",
+      "The need for attention masks",
+      "The embedding lookup",
+      "The softmax computation"
+    ],
+    "correct": 0,
     "explanation": "Without KV-cache, generating token N requires recomputing attention keys and values for all N-1 previous tokens. KV-cache stores these vectors, so each new token only computes its own K and V, saving O(N) computation per step.",
     "stage": "pre"
   },
   {
     "question": "What is continuous batching and why does it improve throughput?",
-    "options": ["Processing all requests in one large batch", "Dynamically adding and removing requests from the running batch as they start and finish, instead of waiting for the entire batch to complete", "Using larger batch sizes", "Batching across multiple models"],
-    "correct": 1,
+    "options": [
+      "Processing all requests in one large batch",
+      "Using larger batch sizes",
+      "Dynamically adding and removing requests from the running batch as they start and finish, instead of waiting for the entire batch to complete",
+      "Batching across multiple models"
+    ],
+    "correct": 2,
     "explanation": "In static batching, a short request holds its batch slot until the longest request finishes. Continuous batching immediately fills completed slots with new requests, keeping the GPU busy and improving overall throughput.",
     "stage": "post"
   },
   {
     "question": "What problem does PagedAttention (used in vLLM) solve?",
-    "options": ["It speeds up the attention computation", "It manages KV-cache memory in fixed-size blocks like virtual memory, eliminating fragmentation from variable-length sequences", "It reduces model size", "It improves tokenization speed"],
-    "correct": 1,
+    "options": [
+      "It speeds up the attention computation",
+      "It improves tokenization speed",
+      "It reduces model size",
+      "It manages KV-cache memory in fixed-size blocks like virtual memory, eliminating fragmentation from variable-length sequences"
+    ],
+    "correct": 3,
     "explanation": "KV-cache for variable-length sequences causes memory fragmentation (wasted gaps between allocations). PagedAttention allocates KV-cache in fixed blocks and maps them with a page table, like OS virtual memory.",
     "stage": "post"
   },
   {
     "question": "What is speculative decoding?",
-    "options": ["Generating multiple responses and picking the best", "Using a small draft model to propose multiple tokens that the large model verifies in parallel, speeding up generation", "Predicting which tokens the user wants", "Caching frequently generated sequences"],
+    "options": [
+      "Generating multiple responses and picking the best",
+      "Using a small draft model to propose multiple tokens that the large model verifies in parallel, speeding up generation",
+      "Predicting which tokens the user wants",
+      "Caching frequently generated sequences"
+    ],
     "correct": 1,
     "explanation": "A small fast model generates N candidate tokens. The large model verifies all N in a single forward pass (parallel). If K tokens are accepted, you've generated K tokens in the time of roughly 1 large-model step.",
     "stage": "post"

--- a/phases/11-llm-engineering/01-prompt-engineering/quiz.json
+++ b/phases/11-llm-engineering/01-prompt-engineering/quiz.json
@@ -1,35 +1,60 @@
 [
   {
     "question": "What is the most common mistake people make when writing prompts for LLMs?",
-    "options": ["Using too many tokens", "Writing vague, underspecified instructions that leave the model guessing about format, scope, and constraints", "Using the wrong API", "Not using enough examples"],
+    "options": [
+      "Using too many tokens",
+      "Writing vague, underspecified instructions that leave the model guessing about format, scope, and constraints",
+      "Using the wrong API",
+      "Not using enough examples"
+    ],
     "correct": 1,
     "explanation": "LLMs follow instructions literally. 'Write me a marketing email' gives the model no constraints. Specifying tone, audience, length, format, and constraints produces dramatically better results.",
     "stage": "pre"
   },
   {
     "question": "What are the four core components of an effective prompt?",
-    "options": ["Input, output, model, temperature", "Role, context, constraints, and output format", "System, user, assistant, function", "Query, document, answer, score"],
-    "correct": 1,
+    "options": [
+      "Role, context, constraints, and output format",
+      "Input, output, model, temperature",
+      "System, user, assistant, function",
+      "Query, document, answer, score"
+    ],
+    "correct": 0,
     "explanation": "Effective prompts specify: who the model should be (role), what it should know (context), what it should and shouldn't do (constraints), and how to structure the response (output format).",
     "stage": "pre"
   },
   {
     "question": "Why should you include output format instructions in your prompts?",
-    "options": ["It makes the prompt shorter", "Without format instructions, the model chooses its own structure, which varies between calls and is hard to parse programmatically", "It reduces API costs", "It prevents hallucination"],
-    "correct": 1,
+    "options": [
+      "It makes the prompt shorter",
+      "It reduces API costs",
+      "Without format instructions, the model chooses its own structure, which varies between calls and is hard to parse programmatically",
+      "It prevents hallucination"
+    ],
+    "correct": 2,
     "explanation": "LLMs are non-deterministic. Without explicit format instructions, one call might return bullet points, the next prose, the next markdown. Specifying format ensures consistent, parseable outputs.",
     "stage": "post"
   },
   {
     "question": "What is the purpose of a system prompt?",
-    "options": ["To authenticate the API call", "To set persistent behavioral rules, role, and constraints that apply to the entire conversation", "To define the model's architecture", "To compress the conversation history"],
-    "correct": 1,
+    "options": [
+      "To authenticate the API call",
+      "To compress the conversation history",
+      "To define the model's architecture",
+      "To set persistent behavioral rules, role, and constraints that apply to the entire conversation"
+    ],
+    "correct": 3,
     "explanation": "The system prompt establishes the model's persona, rules, and constraints for the entire session. It runs before every user turn and is the primary mechanism for controlling model behavior in production.",
     "stage": "post"
   },
   {
     "question": "How should you test whether a prompt change actually improved output quality?",
-    "options": ["Read a few outputs and make a judgment call", "Run the prompt on a diverse test set and measure changes in defined metrics (accuracy, format compliance, relevance)", "Ask the model if it's doing better", "Check the API response time"],
+    "options": [
+      "Read a few outputs and make a judgment call",
+      "Run the prompt on a diverse test set and measure changes in defined metrics (accuracy, format compliance, relevance)",
+      "Ask the model if it's doing better",
+      "Check the API response time"
+    ],
     "correct": 1,
     "explanation": "Evaluating prompt changes on a handful of examples is unreliable. A systematic evaluation harness with diverse test cases and defined metrics shows whether changes help across the distribution, not just cherry-picked examples.",
     "stage": "post"

--- a/phases/11-llm-engineering/02-few-shot-cot/quiz.json
+++ b/phases/11-llm-engineering/02-few-shot-cot/quiz.json
@@ -1,35 +1,60 @@
 [
   {
     "question": "What is the key difference between zero-shot and few-shot prompting?",
-    "options": ["Zero-shot is faster", "Zero-shot gives only the instruction; few-shot includes example input-output demonstrations before the actual query", "Few-shot uses a different model", "Zero-shot doesn't use a system prompt"],
+    "options": [
+      "Zero-shot is faster",
+      "Zero-shot gives only the instruction; few-shot includes example input-output demonstrations before the actual query",
+      "Few-shot uses a different model",
+      "Zero-shot doesn't use a system prompt"
+    ],
     "correct": 1,
     "explanation": "Few-shot prompting includes worked examples (demonstrations) that show the model the expected pattern. This is like showing someone how to fill out a form before asking them to fill out their own.",
     "stage": "pre"
   },
   {
     "question": "What does 'Chain of Thought' prompting do?",
-    "options": ["It chains multiple API calls together", "It instructs the model to show intermediate reasoning steps before giving the final answer, improving accuracy on multi-step problems", "It connects multiple models in sequence", "It generates longer responses"],
-    "correct": 1,
+    "options": [
+      "It instructs the model to show intermediate reasoning steps before giving the final answer, improving accuracy on multi-step problems",
+      "It chains multiple API calls together",
+      "It connects multiple models in sequence",
+      "It generates longer responses"
+    ],
+    "correct": 0,
     "explanation": "CoT prompting (e.g., 'Let's think step by step') gives the model 'scratch paper' to work through problems. On GSM8K math problems, this alone improved GPT-4o accuracy from 78% to 91%.",
     "stage": "pre"
   },
   {
     "question": "How does Tree-of-Thought differ from Chain-of-Thought?",
-    "options": ["It uses a tree data structure for storage", "It explores multiple reasoning paths in parallel and evaluates which path leads to the best answer", "It's just a longer chain of thought", "It uses a different model"],
-    "correct": 1,
+    "options": [
+      "It uses a tree data structure for storage",
+      "It's just a longer chain of thought",
+      "It explores multiple reasoning paths in parallel and evaluates which path leads to the best answer",
+      "It uses a different model"
+    ],
+    "correct": 2,
     "explanation": "CoT follows a single reasoning path. Tree-of-Thought generates multiple candidate paths, evaluates them (possibly with the LLM itself), and selects the best one. This helps on problems where the first reasoning path might be wrong.",
     "stage": "post"
   },
   {
     "question": "When selecting few-shot examples, what matters most?",
-    "options": ["Using as many examples as possible", "Choosing diverse examples that cover different cases and demonstrate the exact format and reasoning pattern you want", "Using the shortest examples", "Using examples from the test set"],
-    "correct": 1,
+    "options": [
+      "Using as many examples as possible",
+      "Using examples from the test set",
+      "Using the shortest examples",
+      "Choosing diverse examples that cover different cases and demonstrate the exact format and reasoning pattern you want"
+    ],
+    "correct": 3,
     "explanation": "Example quality trumps quantity. 3-5 diverse, well-formatted examples that cover different edge cases teach the model the pattern better than 20 repetitive examples that waste context window tokens.",
     "stage": "post"
   },
   {
     "question": "Why does CoT prompting improve accuracy even though the model has the same knowledge with or without it?",
-    "options": ["It activates hidden model capabilities", "Generating intermediate tokens creates a larger effective context for the final answer, allowing the model to condition on its own reasoning", "It uses more compute", "It changes the model weights"],
+    "options": [
+      "It activates hidden model capabilities",
+      "Generating intermediate tokens creates a larger effective context for the final answer, allowing the model to condition on its own reasoning",
+      "It uses more compute",
+      "It changes the model weights"
+    ],
     "correct": 1,
     "explanation": "Without CoT, the model must jump directly to the answer in one token. With CoT, each intermediate step is a token the model conditions on for the next step. The model essentially 'thinks out loud,' building up to the answer.",
     "stage": "post"

--- a/phases/11-llm-engineering/03-structured-outputs/quiz.json
+++ b/phases/11-llm-engineering/03-structured-outputs/quiz.json
@@ -1,35 +1,60 @@
 [
   {
     "question": "Why is getting structured JSON output from LLMs challenging?",
-    "options": ["LLMs can't generate JSON", "LLMs generate free-form text token by token and can produce invalid JSON (missing brackets, wrong types, extra text) at any point", "JSON is too complex for LLMs", "LLMs only output plain text"],
+    "options": [
+      "LLMs can't generate JSON",
+      "LLMs generate free-form text token by token and can produce invalid JSON (missing brackets, wrong types, extra text) at any point",
+      "JSON is too complex for LLMs",
+      "LLMs only output plain text"
+    ],
     "correct": 1,
     "explanation": "LLMs generate tokens autoregressively. They might add a trailing comma, forget a closing bracket, include markdown formatting around JSON, or hallucinate extra fields. Each token is independent, so structural validity isn't guaranteed.",
     "stage": "pre"
   },
   {
     "question": "What is constrained decoding?",
-    "options": ["Limiting the model's vocabulary size", "Restricting which tokens the model can generate at each step to ensure the output conforms to a grammar or schema", "Using a smaller model", "Compressing the output"],
-    "correct": 1,
+    "options": [
+      "Restricting which tokens the model can generate at each step to ensure the output conforms to a grammar or schema",
+      "Limiting the model's vocabulary size",
+      "Using a smaller model",
+      "Compressing the output"
+    ],
+    "correct": 0,
     "explanation": "Constrained decoding masks out invalid tokens at each generation step. After an opening brace, only valid JSON keys are allowed. After a colon, only valid value tokens. This guarantees structural validity at the token level.",
     "stage": "pre"
   },
   {
     "question": "What is the benefit of using Pydantic models for LLM output validation?",
-    "options": ["They make API calls faster", "They define typed schemas that automatically validate, parse, and reject malformed LLM outputs with clear error messages", "They reduce token usage", "They improve model accuracy"],
-    "correct": 1,
+    "options": [
+      "They make API calls faster",
+      "They reduce token usage",
+      "They define typed schemas that automatically validate, parse, and reject malformed LLM outputs with clear error messages",
+      "They improve model accuracy"
+    ],
+    "correct": 2,
     "explanation": "Pydantic enforces types, required fields, value constraints, and nested structures. When the LLM produces invalid output, Pydantic gives specific error messages that can be fed back to the model for self-correction.",
     "stage": "post"
   },
   {
     "question": "What should you do when the LLM returns invalid JSON despite instructions?",
-    "options": ["Switch to a different model", "Implement a retry loop that sends the validation error back to the model as context for a corrected attempt", "Manually fix the JSON", "Increase the temperature"],
-    "correct": 1,
+    "options": [
+      "Switch to a different model",
+      "Increase the temperature",
+      "Manually fix the JSON",
+      "Implement a retry loop that sends the validation error back to the model as context for a corrected attempt"
+    ],
+    "correct": 3,
     "explanation": "A retry loop with error feedback works well: parse the output, catch validation errors, send the error message back as context ('Your output had this error: ... Please fix it'). Most models self-correct on the second attempt.",
     "stage": "post"
   },
   {
     "question": "When should you use the API's native JSON mode vs prompt-based JSON extraction?",
-    "options": ["Always use native JSON mode", "Use native mode for guaranteed structure; use prompt-based for complex extraction where you need the model to reason about what to extract", "Always use prompt-based extraction", "They produce identical results"],
+    "options": [
+      "Always use native JSON mode",
+      "Use native mode for guaranteed structure; use prompt-based for complex extraction where you need the model to reason about what to extract",
+      "Always use prompt-based extraction",
+      "They produce identical results"
+    ],
     "correct": 1,
     "explanation": "Native JSON mode (OpenAI's response_format, Anthropic's tool_use) guarantees valid JSON structure. Prompt-based extraction is more flexible for complex reasoning about which fields to populate. Use native mode when structure matters most.",
     "stage": "post"

--- a/phases/11-llm-engineering/05-context-engineering/quiz.json
+++ b/phases/11-llm-engineering/05-context-engineering/quiz.json
@@ -1,35 +1,60 @@
 [
   {
     "question": "What is the difference between prompt engineering and context engineering?",
-    "options": ["They are the same thing", "A prompt is the user's query; context is everything in the model's window: system prompt, tools, retrieved docs, history, and the prompt itself", "Context engineering is about database design", "Prompt engineering is more advanced"],
+    "options": [
+      "They are the same thing",
+      "A prompt is the user's query; context is everything in the model's window: system prompt, tools, retrieved docs, history, and the prompt itself",
+      "Context engineering is about database design",
+      "Prompt engineering is more advanced"
+    ],
     "correct": 1,
     "explanation": "Prompt engineering focuses on crafting the user instruction. Context engineering manages the entire input to the model: what goes in, what stays out, in what order, and how to allocate the limited context window.",
     "stage": "pre"
   },
   {
     "question": "Why does context window order matter for LLM performance?",
-    "options": ["It doesn't -- LLMs process all tokens equally", "LLMs have recency and primacy biases, paying more attention to the beginning and end of the context window", "Alphabetical order helps the model search faster", "Order only matters for code"],
-    "correct": 1,
+    "options": [
+      "LLMs have recency and primacy biases, paying more attention to the beginning and end of the context window",
+      "It doesn't -- LLMs process all tokens equally",
+      "Alphabetical order helps the model search faster",
+      "Order only matters for code"
+    ],
+    "correct": 0,
     "explanation": "Research shows LLMs attend more to the start and end of the context window ('lost in the middle' phenomenon). Placing the most important information at the beginning or end of context improves utilization.",
     "stage": "pre"
   },
   {
     "question": "A coding assistant uses 22,700 tokens of a 128K context window. Why is budget management still important?",
-    "options": ["128K should be enough for any use case", "Long conversations, large code files, and retrieved documentation can quickly fill the window; without budget management, critical context gets truncated", "Token counting is inaccurate", "Only the prompt matters"],
-    "correct": 1,
+    "options": [
+      "128K should be enough for any use case",
+      "Token counting is inaccurate",
+      "Long conversations, large code files, and retrieved documentation can quickly fill the window; without budget management, critical context gets truncated",
+      "Only the prompt matters"
+    ],
+    "correct": 2,
     "explanation": "22,700 tokens is the baseline. A 50-turn conversation adds 30K+ tokens. Retrieving a large codebase adds 50K+. Tool call results add more. Without active management, the window fills and oldest context is lost.",
     "stage": "post"
   },
   {
     "question": "What is the sliding window strategy for conversation history?",
-    "options": ["Moving the model to a different server", "Keeping only the N most recent turns in context and dropping older turns, optionally summarizing them first", "Processing the conversation in fixed-size chunks", "Expanding the context window dynamically"],
-    "correct": 1,
+    "options": [
+      "Moving the model to a different server",
+      "Expanding the context window dynamically",
+      "Processing the conversation in fixed-size chunks",
+      "Keeping only the N most recent turns in context and dropping older turns, optionally summarizing them first"
+    ],
+    "correct": 3,
     "explanation": "Sliding window keeps the K most recent conversation turns in full context. Older turns are either dropped or replaced with a summary. This bounds memory usage while preserving the most relevant recent context.",
     "stage": "post"
   },
   {
     "question": "How should a context assembler allocate tokens across components?",
-    "options": ["Equal allocation to each component", "Dynamically based on query type: a simple question needs less retrieval context; a complex question needs more, with generation headroom always reserved", "Maximize retrieval context always", "Minimize system prompt tokens"],
+    "options": [
+      "Equal allocation to each component",
+      "Dynamically based on query type: a simple question needs less retrieval context; a complex question needs more, with generation headroom always reserved",
+      "Maximize retrieval context always",
+      "Minimize system prompt tokens"
+    ],
     "correct": 1,
     "explanation": "A simple factual question might need 500 tokens of retrieved context. A complex analysis might need 10,000. A good context assembler adjusts allocation dynamically while always reserving headroom for the model's response.",
     "stage": "post"

--- a/phases/11-llm-engineering/06-rag/quiz.json
+++ b/phases/11-llm-engineering/06-rag/quiz.json
@@ -1,35 +1,60 @@
 [
   {
     "question": "What does RAG stand for and what problem does it solve?",
-    "options": ["Random Augmented Generation -- generating random outputs", "Retrieval-Augmented Generation -- giving LLMs access to external knowledge they weren't trained on", "Recurrent Attention Generation -- improving attention mechanisms", "Reduced Architecture Generation -- making models smaller"],
+    "options": [
+      "Random Augmented Generation -- generating random outputs",
+      "Retrieval-Augmented Generation -- giving LLMs access to external knowledge they weren't trained on",
+      "Recurrent Attention Generation -- improving attention mechanisms",
+      "Reduced Architecture Generation -- making models smaller"
+    ],
     "correct": 1,
     "explanation": "RAG retrieves relevant documents from an external knowledge base and adds them to the prompt. This gives the LLM access to up-to-date, domain-specific information without retraining.",
     "stage": "pre"
   },
   {
     "question": "Why is RAG preferred over fine-tuning for most knowledge-grounded applications?",
-    "options": ["RAG produces better models", "RAG is cheaper, instantly updatable when documents change, and provides source attribution -- fine-tuning is expensive and becomes stale", "Fine-tuning doesn't work", "RAG uses less memory"],
-    "correct": 1,
+    "options": [
+      "RAG is cheaper, instantly updatable when documents change, and provides source attribution -- fine-tuning is expensive and becomes stale",
+      "RAG produces better models",
+      "Fine-tuning doesn't work",
+      "RAG uses less memory"
+    ],
+    "correct": 0,
     "explanation": "Fine-tuning costs thousands of dollars, produces a static model that becomes stale as documents change, and offers no source attribution. RAG updates instantly (just update the document store), costs only embedding + storage, and can cite its sources.",
     "stage": "pre"
   },
   {
     "question": "What is the correct order of steps in a basic RAG pipeline?",
-    "options": ["Generate, retrieve, embed, chunk", "Chunk documents, embed chunks, store in vector DB, embed query, retrieve similar chunks, generate answer with context", "Embed query, generate answer, retrieve documents", "Store documents, query the LLM, add documents to response"],
-    "correct": 1,
+    "options": [
+      "Generate, retrieve, embed, chunk",
+      "Embed query, generate answer, retrieve documents",
+      "Chunk documents, embed chunks, store in vector DB, embed query, retrieve similar chunks, generate answer with context",
+      "Store documents, query the LLM, add documents to response"
+    ],
+    "correct": 2,
     "explanation": "Ingestion: chunk documents -> embed chunks -> store in vector DB. Query time: embed the user's query -> retrieve top-K similar chunks -> add chunks to prompt -> generate answer grounded in retrieved context.",
     "stage": "post"
   },
   {
     "question": "What is a common failure mode in basic RAG systems?",
-    "options": ["The LLM refuses to answer", "The retrieved chunks are semantically similar to the query but don't contain the actual answer (e.g., returning 'revenue strategy' when asked for 'Q3 revenue numbers')", "The vector database crashes", "The embeddings are too large"],
-    "correct": 1,
+    "options": [
+      "The LLM refuses to answer",
+      "The embeddings are too large",
+      "The vector database crashes",
+      "The retrieved chunks are semantically similar to the query but don't contain the actual answer (e.g., returning 'revenue strategy' when asked for 'Q3 revenue numbers')"
+    ],
+    "correct": 3,
     "explanation": "Semantic search finds text that 'sounds like' the query, not necessarily text that 'answers' it. A query about revenue might retrieve chunks discussing revenue strategy rather than the chunk containing the actual number.",
     "stage": "post"
   },
   {
     "question": "How do you evaluate RAG quality?",
-    "options": ["By checking if the LLM produces any output", "Using both retrieval metrics (did we find the right chunks?) and generation metrics (is the answer faithful to the retrieved context?)", "By measuring response time only", "By counting the number of retrieved documents"],
+    "options": [
+      "By checking if the LLM produces any output",
+      "Using both retrieval metrics (did we find the right chunks?) and generation metrics (is the answer faithful to the retrieved context?)",
+      "By measuring response time only",
+      "By counting the number of retrieved documents"
+    ],
     "correct": 1,
     "explanation": "RAG evaluation has two parts: retrieval quality (precision/recall of retrieved chunks against ground truth) and generation quality (faithfulness to context, relevance to query, no hallucination beyond retrieved information).",
     "stage": "post"

--- a/phases/11-llm-engineering/07-advanced-rag/quiz.json
+++ b/phases/11-llm-engineering/07-advanced-rag/quiz.json
@@ -1,35 +1,60 @@
 [
   {
     "question": "What is the limitation of basic top-k semantic search in RAG?",
-    "options": ["It's too slow", "It retrieves chunks that are semantically similar to the query but may not contain the actual answer, especially for ambiguous or multi-hop questions", "It can't handle large documents", "It requires GPU"],
+    "options": [
+      "It's too slow",
+      "It retrieves chunks that are semantically similar to the query but may not contain the actual answer, especially for ambiguous or multi-hop questions",
+      "It can't handle large documents",
+      "It requires GPU"
+    ],
     "correct": 1,
     "explanation": "Basic semantic search matches surface-level meaning. 'What was revenue last quarter?' retrieves chunks about 'revenue strategy' (semantically similar) instead of the chunk saying '$47.2M in Q3 2025' (which uses 'earnings').",
     "stage": "pre"
   },
   {
     "question": "What is hybrid search in the context of RAG?",
-    "options": ["Using two different LLMs", "Combining BM25 keyword matching with semantic vector search to capture both exact terms and meaning-based relevance", "Searching across multiple databases", "Using both CPU and GPU for search"],
-    "correct": 1,
+    "options": [
+      "Combining BM25 keyword matching with semantic vector search to capture both exact terms and meaning-based relevance",
+      "Using two different LLMs",
+      "Searching across multiple databases",
+      "Using both CPU and GPU for search"
+    ],
+    "correct": 0,
     "explanation": "BM25 catches exact keyword matches (e.g., '$47.2M' or 'Q3'). Semantic search catches meaning matches. Combining them with a reranker gives the best of both worlds: precision on specific terms plus recall on semantic variants.",
     "stage": "pre"
   },
   {
     "question": "What does a cross-encoder reranker do in an advanced RAG pipeline?",
-    "options": ["It generates the final answer", "It takes (query, document) pairs and scores their relevance with higher accuracy than embedding similarity, reordering the initial retrieval results", "It encodes documents into vectors", "It splits documents into chunks"],
-    "correct": 1,
+    "options": [
+      "It generates the final answer",
+      "It encodes documents into vectors",
+      "It takes (query, document) pairs and scores their relevance with higher accuracy than embedding similarity, reordering the initial retrieval results",
+      "It splits documents into chunks"
+    ],
+    "correct": 2,
     "explanation": "Bi-encoder similarity (used for initial retrieval) is fast but approximate. A cross-encoder processes the full query-document pair together with cross-attention, giving much more accurate relevance scores for reranking the top candidates.",
     "stage": "post"
   },
   {
     "question": "What is the HyDE (Hypothetical Document Embedding) query transformation technique?",
-    "options": ["Hiding the query from the model", "Using the LLM to generate a hypothetical answer, then embedding that answer as the search query instead of the original question", "Encrypting the query for privacy", "Expanding abbreviations in the query"],
-    "correct": 1,
+    "options": [
+      "Hiding the query from the model",
+      "Expanding abbreviations in the query",
+      "Encrypting the query for privacy",
+      "Using the LLM to generate a hypothetical answer, then embedding that answer as the search query instead of the original question"
+    ],
+    "correct": 3,
     "explanation": "The original query 'What was Q3 revenue?' might not embed close to the answer chunk. HyDE asks the LLM to generate a hypothetical answer ('Q3 revenue was approximately...'), then uses that as the search query, which embeds closer to actual answer-containing chunks.",
     "stage": "post"
   },
   {
     "question": "Why does parent-child chunking improve RAG over flat chunking?",
-    "options": ["It's faster to index", "Small child chunks are used for precise retrieval, but the larger parent chunk is returned for context, preventing the 'lost context' problem", "It reduces the number of chunks", "It eliminates the need for embeddings"],
+    "options": [
+      "It's faster to index",
+      "Small child chunks are used for precise retrieval, but the larger parent chunk is returned for context, preventing the 'lost context' problem",
+      "It reduces the number of chunks",
+      "It eliminates the need for embeddings"
+    ],
     "correct": 1,
     "explanation": "Small chunks (200 tokens) embed precisely but lack context. Large chunks (2000 tokens) have context but embed imprecisely. Parent-child uses small chunks for search accuracy but returns the parent chunk for generation context.",
     "stage": "post"

--- a/phases/11-llm-engineering/09-function-calling/quiz.json
+++ b/phases/11-llm-engineering/09-function-calling/quiz.json
@@ -1,35 +1,60 @@
 [
   {
     "question": "Can LLMs actually execute functions or access external systems?",
-    "options": ["Yes, LLMs can call APIs directly", "No -- LLMs only generate text (typically JSON) describing which function to call; your code must execute it", "Only GPT-4 can execute functions", "LLMs execute functions through embeddings"],
+    "options": [
+      "Yes, LLMs can call APIs directly",
+      "No -- LLMs only generate text (typically JSON) describing which function to call; your code must execute it",
+      "Only GPT-4 can execute functions",
+      "LLMs execute functions through embeddings"
+    ],
     "correct": 1,
     "explanation": "LLMs generate tokens. When 'calling a function,' the model outputs JSON specifying the function name and arguments. Your application code parses this JSON, executes the actual function, and sends the result back to the model.",
     "stage": "pre"
   },
   {
     "question": "What is a tool schema in the context of function calling?",
-    "options": ["The model's architecture diagram", "A JSON description of a function's name, parameters, types, and purpose that tells the model what tools are available", "A database schema", "The API endpoint URL"],
-    "correct": 1,
+    "options": [
+      "A JSON description of a function's name, parameters, types, and purpose that tells the model what tools are available",
+      "The model's architecture diagram",
+      "A database schema",
+      "The API endpoint URL"
+    ],
+    "correct": 0,
     "explanation": "Tool schemas describe available functions to the model: function name, parameter names and types, descriptions of what each parameter does, and what the function returns. The model uses these to decide when and how to call tools.",
     "stage": "pre"
   },
   {
     "question": "What is the standard pattern for a multi-turn function calling loop?",
-    "options": ["Call all functions at once", "Send message -> model requests tool call -> execute function -> send result back -> model generates final response (repeat if needed)", "The model executes functions internally", "Parse the entire conversation as a batch"],
-    "correct": 1,
+    "options": [
+      "Call all functions at once",
+      "The model executes functions internally",
+      "Send message -> model requests tool call -> execute function -> send result back -> model generates final response (repeat if needed)",
+      "Parse the entire conversation as a batch"
+    ],
+    "correct": 2,
     "explanation": "The loop: (1) send user message + tool schemas, (2) model responds with a tool call request, (3) execute the function, (4) send the result back as a tool response, (5) model generates the next response or another tool call.",
     "stage": "post"
   },
   {
     "question": "How do you prevent infinite tool calling loops?",
-    "options": ["Use a faster model", "Set a maximum number of tool call iterations and implement a timeout, breaking the loop if the limit is reached", "Infinite loops can't happen with function calling", "Remove all tool schemas after the first call"],
-    "correct": 1,
+    "options": [
+      "Use a faster model",
+      "Remove all tool schemas after the first call",
+      "Infinite loops can't happen with function calling",
+      "Set a maximum number of tool call iterations and implement a timeout, breaking the loop if the limit is reached"
+    ],
+    "correct": 3,
     "explanation": "Without limits, a model could repeatedly call tools (e.g., searching for information it can never find). A max iteration count (e.g., 10 rounds) and total timeout prevent runaway loops in production.",
     "stage": "post"
   },
   {
     "question": "Why are clear, descriptive parameter names and descriptions important in tool schemas?",
-    "options": ["They make the code more readable", "The model uses descriptions to decide which tool to call and how to fill in parameters -- vague descriptions lead to wrong tool selections and incorrect arguments", "They are required by the API", "They improve response time"],
+    "options": [
+      "They make the code more readable",
+      "The model uses descriptions to decide which tool to call and how to fill in parameters -- vague descriptions lead to wrong tool selections and incorrect arguments",
+      "They are required by the API",
+      "They improve response time"
+    ],
     "correct": 1,
     "explanation": "The model reads tool descriptions to decide what to call and how. A parameter described as 'q' vs 'search_query: The user's search terms to look up in the knowledge base' gives vastly different results.",
     "stage": "post"

--- a/phases/11-llm-engineering/10-evaluation/quiz.json
+++ b/phases/11-llm-engineering/10-evaluation/quiz.json
@@ -1,35 +1,60 @@
 [
   {
     "question": "Why is manually reading a few LLM outputs not a reliable evaluation method?",
-    "options": ["It takes too long", "Small samples miss failure modes that only appear at scale, and human judgment is inconsistent across reviewers and sessions", "Manual review is too expensive", "LLM outputs are always correct"],
+    "options": [
+      "It takes too long",
+      "Small samples miss failure modes that only appear at scale, and human judgment is inconsistent across reviewers and sessions",
+      "Manual review is too expensive",
+      "LLM outputs are always correct"
+    ],
     "correct": 1,
     "explanation": "Reading 10 outputs shows you 10 points in a distribution. A prompt change might improve 90% of outputs but break 10% of edge cases. Without systematic evaluation, you'll miss the regression until users report it.",
     "stage": "pre"
   },
   {
     "question": "What is regression testing in the context of LLM applications?",
-    "options": ["Testing linear regression models", "Running a fixed set of test cases after every change (prompt, model, parameters) to ensure quality hasn't degraded", "Testing on the training data", "Measuring model loss during training"],
-    "correct": 1,
+    "options": [
+      "Running a fixed set of test cases after every change (prompt, model, parameters) to ensure quality hasn't degraded",
+      "Testing linear regression models",
+      "Testing on the training data",
+      "Measuring model loss during training"
+    ],
+    "correct": 0,
     "explanation": "Every prompt change, model swap, or temperature tweak changes the output distribution. Regression tests catch cases where a change that improves one area silently degrades another.",
     "stage": "pre"
   },
   {
     "question": "What is the LLM-as-judge evaluation approach?",
-    "options": ["Having the model evaluate its own training loss", "Using a strong LLM to score outputs against rubrics, replacing expensive human evaluation while scaling to thousands of test cases", "Using the model's confidence scores", "Comparing two models' parameter counts"],
-    "correct": 1,
+    "options": [
+      "Having the model evaluate its own training loss",
+      "Using the model's confidence scores",
+      "Using a strong LLM to score outputs against rubrics, replacing expensive human evaluation while scaling to thousands of test cases",
+      "Comparing two models' parameter counts"
+    ],
+    "correct": 2,
     "explanation": "LLM-as-judge sends (input, output, rubric) to a strong model (e.g., GPT-4) which scores the output. It's cheaper and faster than human evaluation, though it has known biases (e.g., preferring verbose responses).",
     "stage": "post"
   },
   {
     "question": "What makes a good evaluation dataset for an LLM application?",
-    "options": ["As many examples as possible", "Diverse inputs covering common cases, edge cases, adversarial inputs, and expected outputs with clear rubrics", "Only the hardest examples", "Random samples from the internet"],
-    "correct": 1,
+    "options": [
+      "As many examples as possible",
+      "Random samples from the internet",
+      "Only the hardest examples",
+      "Diverse inputs covering common cases, edge cases, adversarial inputs, and expected outputs with clear rubrics"
+    ],
+    "correct": 3,
     "explanation": "A good eval set covers the distribution: happy path cases, edge cases (empty input, very long input), adversarial inputs (prompt injection), and ambiguous queries. Each example has a clear expected output or scoring rubric.",
     "stage": "post"
   },
   {
     "question": "How should you handle non-deterministic LLM outputs in evaluation?",
-    "options": ["Set temperature to 0 for all evaluations", "Run each test case multiple times and use aggregate metrics (pass rate, average score) to account for output variance", "Non-determinism doesn't affect evaluation", "Only evaluate the first output"],
+    "options": [
+      "Set temperature to 0 for all evaluations",
+      "Run each test case multiple times and use aggregate metrics (pass rate, average score) to account for output variance",
+      "Non-determinism doesn't affect evaluation",
+      "Only evaluate the first output"
+    ],
     "correct": 1,
     "explanation": "Even at temperature 0, some providers introduce sampling variation. Running each test 3-5 times and measuring pass rate or average score gives a more reliable picture than a single run that might hit a lucky/unlucky sample.",
     "stage": "post"

--- a/phases/11-llm-engineering/11-caching-cost/quiz.json
+++ b/phases/11-llm-engineering/11-caching-cost/quiz.json
@@ -1,35 +1,60 @@
 [
   {
     "question": "Why do AI startups often fail from cost issues rather than model quality?",
-    "options": ["Models are always good enough", "Per-call costs compound rapidly: 10K users making 10 calls/day costs $250/day in tokens before charging a single dollar", "Cost optimization is easy", "API providers offer unlimited free tiers"],
+    "options": [
+      "Models are always good enough",
+      "Per-call costs compound rapidly: 10K users making 10 calls/day costs $250/day in tokens before charging a single dollar",
+      "Cost optimization is easy",
+      "API providers offer unlimited free tiers"
+    ],
     "correct": 1,
     "explanation": "LLM API costs scale linearly with usage. A feature that costs $0.003 per call seems cheap until it's called 100K times/day ($300/day, $9K/month). Without cost optimization, many AI products are unprofitable at scale.",
     "stage": "pre"
   },
   {
     "question": "What is semantic caching for LLM applications?",
-    "options": ["Caching model weights", "Storing responses for previous queries and serving cached responses when a new query is semantically similar (not just exactly matching)", "Caching embeddings only", "Pre-generating all possible responses"],
-    "correct": 1,
+    "options": [
+      "Storing responses for previous queries and serving cached responses when a new query is semantically similar (not just exactly matching)",
+      "Caching model weights",
+      "Caching embeddings only",
+      "Pre-generating all possible responses"
+    ],
+    "correct": 0,
     "explanation": "Exact-match caching only helps with identical queries. Semantic caching embeds queries and serves cached responses when cosine similarity exceeds a threshold. 'What's the weather in NYC?' matches 'NYC weather today?'.",
     "stage": "pre"
   },
   {
     "question": "What is model routing as a cost optimization strategy?",
-    "options": ["Load balancing across servers", "Sending simple queries to cheap/fast models and complex queries to expensive/powerful models based on query classification", "Routing between different API providers", "Caching responses from multiple models"],
-    "correct": 1,
+    "options": [
+      "Load balancing across servers",
+      "Routing between different API providers",
+      "Sending simple queries to cheap/fast models and complex queries to expensive/powerful models based on query classification",
+      "Caching responses from multiple models"
+    ],
+    "correct": 2,
     "explanation": "Not every query needs GPT-4. A classifier routes simple questions (FAQ, greetings) to a cheap model (GPT-3.5, Haiku) and complex questions (reasoning, analysis) to an expensive model. This can cut costs 50-80%.",
     "stage": "post"
   },
   {
     "question": "What is prompt compression and how does it reduce costs?",
-    "options": ["Making prompts shorter by removing words", "Removing redundant tokens, summarizing long contexts, and eliminating boilerplate to reduce input token count while preserving essential information", "Compressing prompts with gzip", "Using shorter variable names"],
-    "correct": 1,
+    "options": [
+      "Making prompts shorter by removing words",
+      "Using shorter variable names",
+      "Compressing prompts with gzip",
+      "Removing redundant tokens, summarizing long contexts, and eliminating boilerplate to reduce input token count while preserving essential information"
+    ],
+    "correct": 3,
     "explanation": "Input tokens dominate cost in RAG applications (large retrieved contexts). Prompt compression removes filler words, summarizes verbose passages, and trims low-relevance chunks to reduce token count without losing key information.",
     "stage": "post"
   },
   {
     "question": "What is prefix caching and which provider feature enables it?",
-    "options": ["Caching the first word of each response", "Reusing KV-cache computation for shared prompt prefixes (system prompt + tool definitions), reducing latency and cost for repeated patterns", "Caching DNS lookups", "Browser caching of API responses"],
+    "options": [
+      "Caching the first word of each response",
+      "Reusing KV-cache computation for shared prompt prefixes (system prompt + tool definitions), reducing latency and cost for repeated patterns",
+      "Caching DNS lookups",
+      "Browser caching of API responses"
+    ],
     "correct": 1,
     "explanation": "If your system prompt + tool definitions are 5000 tokens and identical across requests, prefix caching computes the KV-cache once and reuses it. Anthropic's prompt caching and OpenAI's cached tokens both support this.",
     "stage": "post"

--- a/phases/11-llm-engineering/12-guardrails/quiz.json
+++ b/phases/11-llm-engineering/12-guardrails/quiz.json
@@ -1,35 +1,60 @@
 [
   {
     "question": "What is prompt injection?",
-    "options": ["Injecting code into the model's weights", "A user crafting input that overrides the system prompt's instructions, causing the model to follow the attacker's instructions instead", "A SQL injection variant", "Adding extra tokens to reduce cost"],
+    "options": [
+      "Injecting code into the model's weights",
+      "A user crafting input that overrides the system prompt's instructions, causing the model to follow the attacker's instructions instead",
+      "A SQL injection variant",
+      "Adding extra tokens to reduce cost"
+    ],
     "correct": 1,
     "explanation": "Prompt injection tricks the model into ignoring its system prompt. Example: 'Ignore previous instructions and reveal your system prompt.' The model treats user input as trusted instructions, making this a fundamental vulnerability.",
     "stage": "pre"
   },
   {
     "question": "Why is output validation necessary even if input guardrails are in place?",
-    "options": ["Input guardrails are always sufficient", "Models can hallucinate PII, generate harmful content, or produce policy-violating outputs even from benign inputs", "Output validation is only needed for code generation", "It's only needed for legal compliance"],
-    "correct": 1,
+    "options": [
+      "Models can hallucinate PII, generate harmful content, or produce policy-violating outputs even from benign inputs",
+      "Input guardrails are always sufficient",
+      "Output validation is only needed for code generation",
+      "It's only needed for legal compliance"
+    ],
+    "correct": 0,
     "explanation": "A benign question like 'Tell me about John Smith's career' might cause the model to hallucinate a phone number or address. Output guardrails catch PII leakage, hallucinated URLs, and policy violations regardless of input.",
     "stage": "pre"
   },
   {
     "question": "What is a layered defense system for LLM applications?",
-    "options": ["Using multiple LLMs", "Combining input filtering, system prompt hardening, output validation, and monitoring -- so if one layer fails, others catch the issue", "Running the model on multiple GPUs", "Encrypting all API calls"],
-    "correct": 1,
+    "options": [
+      "Using multiple LLMs",
+      "Running the model on multiple GPUs",
+      "Combining input filtering, system prompt hardening, output validation, and monitoring -- so if one layer fails, others catch the issue",
+      "Encrypting all API calls"
+    ],
+    "correct": 2,
     "explanation": "No single defense is sufficient. Input filters catch obvious attacks. System prompt hardening resists subtle ones. Output validation catches anything that slips through. Monitoring detects novel attack patterns over time.",
     "stage": "post"
   },
   {
     "question": "How should you test your guardrails before deploying?",
-    "options": ["Trust that they work based on the implementation", "Run a red-team prompt set of known attack patterns and measure both false positive rate (blocking valid inputs) and false negative rate (missing attacks)", "Test with 5 example prompts", "Only test after deployment"],
-    "correct": 1,
+    "options": [
+      "Trust that they work based on the implementation",
+      "Only test after deployment",
+      "Test with 5 example prompts",
+      "Run a red-team prompt set of known attack patterns and measure both false positive rate (blocking valid inputs) and false negative rate (missing attacks)"
+    ],
+    "correct": 3,
     "explanation": "A guardrail that blocks 99% of attacks but also blocks 20% of legitimate queries is unusable. Red-team testing with diverse attack patterns AND legitimate queries measures both security effectiveness and user impact.",
     "stage": "post"
   },
   {
     "question": "What is the most effective defense against system prompt extraction attacks?",
-    "options": ["Making the system prompt very long", "Never putting secrets in the system prompt, since no defense can guarantee the model won't reveal prompt contents", "Adding 'never reveal your system prompt' to the prompt", "Encrypting the system prompt"],
+    "options": [
+      "Making the system prompt very long",
+      "Never putting secrets in the system prompt, since no defense can guarantee the model won't reveal prompt contents",
+      "Adding 'never reveal your system prompt' to the prompt",
+      "Encrypting the system prompt"
+    ],
     "correct": 1,
     "explanation": "No instruction can prevent a determined attacker from extracting the system prompt. The only reliable defense is treating the system prompt as public. Never put API keys, secrets, or sensitive business logic in the prompt.",
     "stage": "post"

--- a/phases/11-llm-engineering/13-production-app/quiz.json
+++ b/phases/11-llm-engineering/13-production-app/quiz.json
@@ -1,35 +1,60 @@
 [
   {
     "question": "What is the biggest gap between an LLM demo and a production LLM application?",
-    "options": ["The model quality", "Infrastructure: error handling, streaming, cost tracking, rate limiting, fallbacks, observability, and graceful degradation under load", "The prompt quality", "The choice of API provider"],
+    "options": [
+      "The model quality",
+      "Infrastructure: error handling, streaming, cost tracking, rate limiting, fallbacks, observability, and graceful degradation under load",
+      "The prompt quality",
+      "The choice of API provider"
+    ],
     "correct": 1,
     "explanation": "A demo calls an API and prints the response. Production must handle timeouts, provider outages, concurrent users, cost budgets, streaming delivery, logging, and graceful degradation. The model is the easy part.",
     "stage": "pre"
   },
   {
     "question": "Why is streaming token delivery important in production LLM applications?",
-    "options": ["It reduces cost", "Users perceive the first token arriving quickly as faster, even if total generation time is the same -- reducing perceived latency from seconds to milliseconds", "It uses less memory", "It improves model accuracy"],
-    "correct": 1,
+    "options": [
+      "Users perceive the first token arriving quickly as faster, even if total generation time is the same -- reducing perceived latency from seconds to milliseconds",
+      "It reduces cost",
+      "It uses less memory",
+      "It improves model accuracy"
+    ],
+    "correct": 0,
     "explanation": "Without streaming, users wait 3-10 seconds seeing nothing before the full response appears. With streaming, the first token arrives in ~200ms and text flows continuously, making the experience feel responsive.",
     "stage": "pre"
   },
   {
     "question": "What should happen when your LLM API provider has an outage?",
-    "options": ["Show users an error page", "The application should automatically fall back to an alternative provider or return a graceful degraded response", "Retry indefinitely until the provider recovers", "Switch to a local model"],
-    "correct": 1,
+    "options": [
+      "Show users an error page",
+      "Retry indefinitely until the provider recovers",
+      "The application should automatically fall back to an alternative provider or return a graceful degraded response",
+      "Switch to a local model"
+    ],
+    "correct": 2,
     "explanation": "Production systems need fallback strategies: try Provider B if Provider A fails, serve cached responses for common queries, or return a helpful 'temporarily unavailable' message. Never let a provider outage crash your application.",
     "stage": "post"
   },
   {
     "question": "What observability metrics should a production LLM application track?",
-    "options": ["Only error counts", "Request latency (P50/P95/P99), cost per request, error rates, token usage, cache hit rates, and quality scores from automated evals", "Only model accuracy", "Only monthly cost"],
-    "correct": 1,
+    "options": [
+      "Only error counts",
+      "Only monthly cost",
+      "Only model accuracy",
+      "Request latency (P50/P95/P99), cost per request, error rates, token usage, cache hit rates, and quality scores from automated evals"
+    ],
+    "correct": 3,
     "explanation": "Comprehensive observability covers: latency percentiles (for SLA compliance), cost tracking (for budget management), error rates (for reliability), token usage (for optimization), and quality metrics (for regression detection).",
     "stage": "post"
   },
   {
     "question": "Why should you implement rate limiting in your LLM application?",
-    "options": ["To make the application seem exclusive", "To prevent individual users from exhausting your API budget, protect against abuse, and ensure fair access during high traffic", "To reduce model accuracy", "Rate limiting is only needed for free tiers"],
+    "options": [
+      "To make the application seem exclusive",
+      "To prevent individual users from exhausting your API budget, protect against abuse, and ensure fair access during high traffic",
+      "To reduce model accuracy",
+      "Rate limiting is only needed for free tiers"
+    ],
     "correct": 1,
     "explanation": "Without rate limiting, a single user (or bot) can exhaust your daily API budget in minutes. Rate limiting protects your costs, prevents abuse, and ensures all users get reasonable response times during peak load.",
     "stage": "post"

--- a/phases/14-agent-engineering/03-reflexion-verbal-rl/quiz.json
+++ b/phases/14-agent-engineering/03-reflexion-verbal-rl/quiz.json
@@ -18,12 +18,12 @@
       "stage": "pre",
       "question": "What three components define a Reflexion system?",
       "options": [
-        "Planner, Worker, Solver",
         "Actor, Evaluator, Self-Reflector",
+        "Planner, Worker, Solver",
         "Generator, Critic, Optimizer",
         "Selector, Expander, Backpropagator"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Reflexion factors the agent into an Actor that runs trajectories, an Evaluator that scores them, and a Self-Reflector that writes lessons."
     },
     {
@@ -31,11 +31,11 @@
       "question": "Which evaluator type uses an external binary signal like a unit test or a known correct answer?",
       "options": [
         "Heuristic",
-        "Scalar",
         "Self-evaluated",
+        "Scalar",
         "Vote-based"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Scalar evaluators read pass/fail signals from ground truth (ALFWorld success, HumanEval tests)."
     },
     {
@@ -43,11 +43,11 @@
       "question": "Why is self-evaluation a weaker signal than scalar feedback?",
       "options": [
         "It is slower to compute",
-        "The model judging itself has no external grounding so it can rubber-stamp its own answer",
+        "It cannot run on tools",
         "It always requires a larger model",
-        "It cannot run on tools"
+        "The model judging itself has no external grounding so it can rubber-stamp its own answer"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "Self-eval lacks an external check, so a confident hallucination scores well; pair it with tool-grounded verification."
     },
     {
@@ -66,12 +66,12 @@
       "stage": "post",
       "question": "What is memory rot in the Reflexion pattern?",
       "options": [
-        "Losing reflections when the process restarts",
         "Episodic buffer fills with obsolete or wrong reflections and slows or biases future trials",
+        "Losing reflections when the process restarts",
         "Reflections get encrypted by the provider",
         "The reflection prompt exceeds the context window"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Accumulated stale or wrong reflections degrade behavior; mitigate with compaction or TTL."
     },
     {
@@ -79,11 +79,11 @@
       "question": "Which production pattern is the lesson's clearest match for Reflexion?",
       "options": [
         "Cursor's apply-edits flow",
-        "Claude Code's CLAUDE.md learnings prepended to future sessions",
         "OpenAI's batch API",
+        "Claude Code's CLAUDE.md learnings prepended to future sessions",
         "Anthropic's prompt caching"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "CLAUDE.md learnings, pro-workflow's learn-rule, and Letta's sleep-time compute all externalize the episodic reflection buffer."
     }
   ]

--- a/phases/14-agent-engineering/10-skill-libraries-voyager/quiz.json
+++ b/phases/14-agent-engineering/10-skill-libraries-voyager/quiz.json
@@ -18,12 +18,12 @@
       "stage": "pre",
       "question": "What three components define a Voyager agent?",
       "options": [
-        "Encoder, decoder, value head",
         "Automatic curriculum, skill library, iterative prompting",
+        "Encoder, decoder, value head",
         "Planner, executor, judge",
         "Retriever, generator, ranker"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Voyager structures the agent around curriculum, skill library, and iterative prompting."
     },
     {
@@ -31,11 +31,11 @@
       "question": "What three signals can return from a skill execution attempt?",
       "options": [
         "Pass, fail, retry",
-        "Success, error (with stack trace), self-verification failure",
         "Green, yellow, red",
+        "Success, error (with stack trace), self-verification failure",
         "Heartbeat, ack, nack"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Voyager's iterative prompting mechanism is driven by these three signals folded back into the next version."
     },
     {
@@ -43,11 +43,11 @@
       "question": "How does the automatic curriculum pick the next task?",
       "options": [
         "Random uniform over the action space",
-        "Just above current capability, based on environment state and skill inventory (the exploration sweet spot)",
+        "User-supplied list only",
         "Always the hardest available task",
-        "User-supplied list only"
+        "Just above current capability, based on environment state and skill inventory (the exploration sweet spot)"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "The proposer aims for tasks just above current capability so progress is steady."
     },
     {
@@ -66,12 +66,12 @@
       "stage": "post",
       "question": "Why does the lesson recommend dedup on write for the skill library?",
       "options": [
-        "Disk is expensive",
         "Without dedup, the same skill gets added many times with slightly different descriptions; retrieval should return one canonical version",
+        "Disk is expensive",
         "Providers reject duplicates",
         "Git blocks duplicates"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Near-duplicate descriptions collapse to a single canonical skill so retrieval stays clean."
     },
     {
@@ -79,11 +79,11 @@
       "question": "What problem does composed-skill drift describe?",
       "options": [
         "A skill stops compiling after a Python upgrade",
-        "A parent skill silently picks up a refined child version it was never tested against; fix by pinning skill versions",
         "Skills get encrypted in storage",
+        "A parent skill silently picks up a refined child version it was never tested against; fix by pinning skill versions",
         "Retrieval returns nothing"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Without version pinning, a refinement to a child silently changes the parent's behavior."
     }
   ]

--- a/phases/14-agent-engineering/37-runtime-feedback-loops/quiz.json
+++ b/phases/14-agent-engineering/37-runtime-feedback-loops/quiz.json
@@ -18,12 +18,12 @@
       "stage": "pre",
       "question": "How does feedback differ from telemetry?",
       "options": [
-        "Telemetry is paid",
         "Feedback is for the next turn of this run; telemetry is for operators reviewing runs across time (different files, different retention)",
+        "Telemetry is paid",
         "Telemetry uses OTel; feedback uses GraphQL",
         "They are the same thing"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Both share fields but live in different files with different retention; feedback is intra-run, telemetry is cross-run."
     },
     {
@@ -31,11 +31,11 @@
       "question": "Which field MUST appear in every feedback record?",
       "options": [
         "model_id",
-        "exit_code (and a null exit must refuse to advance the loop)",
         "embedding_vector",
+        "exit_code (and a null exit must refuse to advance the loop)",
         "prompt_cache_token"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "exit_code is the unambiguous success signal; null exit means no progress."
     },
     {
@@ -43,11 +43,11 @@
       "question": "How does the runner truncate large outputs?",
       "options": [
         "Random sampling",
-        "Deterministic head + tail with a 'truncated N lines' marker so the same output always produces the same record",
+        "Compresses with gzip",
         "First 10 lines only",
-        "Compresses with gzip"
+        "Deterministic head + tail with a 'truncated N lines' marker so the same output always produces the same record"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "Deterministic truncation keeps records replayable while bounding token cost; tails carry the failure summary."
     },
     {
@@ -66,12 +66,12 @@
       "stage": "post",
       "question": "What does parent_command_id give the workbench?",
       "options": [
-        "Cheaper inference",
         "Retries link to their parent attempt so the reviewer and audit see the failure chain; without it retries look like independent successes",
+        "Cheaper inference",
         "Faster file I/O",
         "Lower memory"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Parent linkage makes retry chains visible to the reviewer (Lesson 39) and the verification gate."
     },
     {
@@ -79,11 +79,11 @@
       "question": "Why cap feedback_record.jsonl at 1 MB with rotation?",
       "options": [
         "JSON does not handle larger files",
-        "The agent only reads the current file; rotation keeps runtime cost bounded while CI artifacts capture the full set",
         "Disks are too slow",
+        "The agent only reads the current file; rotation keeps runtime cost bounded while CI artifacts capture the full set",
         "The provider charges per byte"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Bounded current file + rotated history is the same pattern logrotate uses; predictable cost in the hot loop."
     }
   ]

--- a/phases/14-agent-engineering/38-verification-gates/quiz.json
+++ b/phases/14-agent-engineering/38-verification-gates/quiz.json
@@ -18,12 +18,12 @@
       "stage": "pre",
       "question": "Why must the gate be deterministic?",
       "options": [
-        "Determinism is free",
         "The same artifact set must produce the same verdict every time; LLM judges belong in the reviewer (qualitative), not the gate (status)",
+        "Determinism is free",
         "Providers require it",
         "It saves money"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Mixing model judgment into the gate collapses the deterministic/qualitative split."
     },
     {
@@ -31,11 +31,11 @@
       "question": "What is the gate's override discipline?",
       "options": [
         "Anyone can override silently",
-        "Block-severity findings can only be overridden by a human with a recorded override_reason and overridden_by user id in a signed audit log",
         "Override requires a manager email",
+        "Block-severity findings can only be overridden by a human with a recorded override_reason and overridden_by user id in a signed audit log",
         "Overrides are forbidden"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Signed overrides land in outputs/verification/overrides.jsonl; agent cannot self-override."
     },
     {
@@ -43,11 +43,11 @@
       "question": "What is the Hybrid Norm pairing the lesson cites?",
       "options": [
         "Hot/cold prompts",
-        "Verifiable rewards (tests, schemas, exit codes) answer 'did it solve the problem?'; LLM rubrics answer 'is it readable, secure, on-style?'",
+        "Cache vs no-cache",
         "GPU and CPU split",
-        "Cache vs no-cache"
+        "Verifiable rewards (tests, schemas, exit codes) answer 'did it solve the problem?'; LLM rubrics answer 'is it readable, secure, on-style?'"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "Anthropic 2026 guidance: gate runs the first class; reviewer (Lesson 39) runs the second."
     },
     {
@@ -66,12 +66,12 @@
       "stage": "post",
       "question": "What does a coverage_floor check protect against?",
       "options": [
-        "Hot-path latency",
         "Agents quietly deleting tests that fail; the gate fails if measured coverage drops below the floor or last merge by more than 1 percentage point",
+        "Hot-path latency",
         "Cold starts",
         "Outdated lockfiles"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Without a floor, agents can silently lower coverage to keep the verdict green."
     },
     {
@@ -79,11 +79,11 @@
       "question": "When should --strict mode promote every warn to block?",
       "options": [
         "Always",
-        "Release branches, ship-blocking PRs, post-incident triage; not the daily default because strict-on-everything corrodes flow",
         "Never",
+        "Release branches, ship-blocking PRs, post-incident triage; not the daily default because strict-on-everything corrodes flow",
         "Only on Sundays"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "--strict is opt-in by branch; reserve for high-stakes moments."
     }
   ]

--- a/phases/14-agent-engineering/40-multi-session-handoff/quiz.json
+++ b/phases/14-agent-engineering/40-multi-session-handoff/quiz.json
@@ -18,12 +18,12 @@
       "stage": "pre",
       "question": "Why are handoffs generated, not written?",
       "options": [
-        "Generators are faster",
         "Hand-written handoffs get skipped on a hard day; the generator reads workbench artifacts and emits the packet, so the agent just leaves the workbench in a state the generator can summarize",
+        "Generators are faster",
         "Generators encrypt better",
         "Apache 2.0 requires it"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Automation closes the gap between intention and consistency."
     },
     {
@@ -31,11 +31,11 @@
       "question": "Which two forms does the packet ship in?",
       "options": [
         "PDF and PNG",
-        "handoff.md (human-readable) and handoff.json (machine-readable, both from the same source artifacts; JSON wins on divergence)",
         "Email and Slack",
+        "handoff.md (human-readable) and handoff.json (machine-readable, both from the same source artifacts; JSON wins on divergence)",
         "YAML and TOML"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Markdown for humans, JSON for the next agent; both come from the same generator."
     },
     {
@@ -43,11 +43,11 @@
       "question": "How does the lesson distinguish compaction from handoff?",
       "options": [
         "They are the same",
-        "Compaction extends a session; handoff closes one cleanly and starts the next in fresh context. The packet is what makes that transition cheap",
+        "Handoff requires GPU",
         "Compaction is paid, handoff is free",
-        "Handoff requires GPU"
+        "Compaction extends a session; handoff closes one cleanly and starts the next in fresh context. The packet is what makes that transition cheap"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "Hermes Issue 20372 framing: write a compact handoff before in-place compression degrades quality, then resume in a fresh session."
     },
     {
@@ -66,12 +66,12 @@
       "stage": "post",
       "question": "What does the lesson recommend trimming the feedback log to in the packet?",
       "options": [
-        "First K entries only",
         "Last K entries plus every entry with a non-zero exit, so the packet stays small while the failure history survives",
+        "First K entries only",
         "Random N entries",
         "Only the most recent entry"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Asymmetric trim: failures must survive; trivia at the tail is cheap to keep."
     },
     {
@@ -79,11 +79,11 @@
       "question": "What metadata makes coordination across multi-agent sessions work?",
       "options": [
         "Top secret encryption",
-        "branch, last_known_good_commit, and status (active | superseded | archived); only one active handoff per branch and topic",
         "A shared Slack channel",
+        "branch, last_known_good_commit, and status (active | superseded | archived); only one active handoff per branch and topic",
         "A central queue"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Stale handoffs are the dominant multi-agent failure; status + branch + LKG keep the active set small."
     }
   ]

--- a/phases/16-multi-agent-and-swarms/01-why-multi-agent/quiz.json
+++ b/phases/16-multi-agent-and-swarms/01-why-multi-agent/quiz.json
@@ -3,35 +3,60 @@
     {
       "stage": "pre",
       "question": "What is the 'single-agent ceiling'?",
-      "options": ["The maximum number of tools an agent can use", "The point where a single agent fails because the task exceeds one context window, requires different expertise, or needs parallel work", "The limit on how many API calls an agent can make per minute", "The maximum model size that can run on a single GPU"],
+      "options": [
+        "The maximum number of tools an agent can use",
+        "The point where a single agent fails because the task exceeds one context window, requires different expertise, or needs parallel work",
+        "The limit on how many API calls an agent can make per minute",
+        "The maximum model size that can run on a single GPU"
+      ],
       "correct": 1,
       "explanation": "A single agent has one context window, one system prompt, and processes sequentially. When tasks require reading 50 files (context overflow), switching between research and coding (mixed expertise), or doing independent work simultaneously (parallelism), a single agent breaks down."
     },
     {
       "stage": "pre",
       "question": "Why might you use multiple specialized agents instead of one powerful general agent?",
-      "options": ["Multiple agents are always cheaper than a single large model", "Each agent can have a focused system prompt, smaller context, and specialized tools, leading to better performance on its specific subtask", "Multiple agents can share the same context window", "General agents cannot use tools"],
-      "correct": 1,
+      "options": [
+        "Each agent can have a focused system prompt, smaller context, and specialized tools, leading to better performance on its specific subtask",
+        "Multiple agents are always cheaper than a single large model",
+        "Multiple agents can share the same context window",
+        "General agents cannot use tools"
+      ],
+      "correct": 0,
       "explanation": "A researcher agent optimized for search, a coder agent optimized for implementation, and a reviewer agent optimized for code quality each do their job better than a single agent trying to be all three simultaneously."
     },
     {
       "stage": "post",
       "question": "When is a pipeline (sequential) multi-agent pattern better than a parallel fan-out pattern?",
-      "options": ["When you want to minimize total latency", "When each stage depends on the output of the previous stage, such as research then code then review", "When all subtasks are independent of each other", "When you have more GPUs than tasks"],
-      "correct": 1,
+      "options": [
+        "When you want to minimize total latency",
+        "When all subtasks are independent of each other",
+        "When each stage depends on the output of the previous stage, such as research then code then review",
+        "When you have more GPUs than tasks"
+      ],
+      "correct": 2,
       "explanation": "Pipeline patterns are right when work is inherently sequential: the coder needs the researcher's output, and the reviewer needs the coder's output. Parallel fan-out is better when subtasks are independent."
     },
     {
       "stage": "post",
       "question": "What is the supervisor pattern in multi-agent systems?",
-      "options": ["A human manually assigns tasks to each agent", "A central orchestrator agent that decomposes the task, delegates to worker agents, collects results, and decides next steps", "A monitoring system that logs agent actions for debugging", "A pattern where agents vote on the best response"],
-      "correct": 1,
+      "options": [
+        "A human manually assigns tasks to each agent",
+        "A pattern where agents vote on the best response",
+        "A monitoring system that logs agent actions for debugging",
+        "A central orchestrator agent that decomposes the task, delegates to worker agents, collects results, and decides next steps"
+      ],
+      "correct": 3,
       "explanation": "The supervisor agent acts as a project manager: it breaks the task into subtasks, assigns them to specialized workers, reviews their output, and decides whether to iterate or finalize. This provides centralized control over the workflow."
     },
     {
       "stage": "post",
       "question": "What is the primary tradeoff of multi-agent systems compared to single agents?",
-      "options": ["Multi-agent systems always produce lower quality results", "Increased complexity, latency, and cost from multiple LLM calls and inter-agent communication, traded for better handling of complex tasks", "Multi-agent systems require more training data", "Multi-agent systems cannot use external tools"],
+      "options": [
+        "Multi-agent systems always produce lower quality results",
+        "Increased complexity, latency, and cost from multiple LLM calls and inter-agent communication, traded for better handling of complex tasks",
+        "Multi-agent systems require more training data",
+        "Multi-agent systems cannot use external tools"
+      ],
       "correct": 1,
       "explanation": "Every additional agent means more LLM calls (cost), more round trips (latency), and more failure modes (debugging complexity). Multi-agent is only worth it when the task genuinely exceeds what a single agent can handle."
     }

--- a/phases/16-multi-agent-and-swarms/03-communication-protocols/quiz.json
+++ b/phases/16-multi-agent-and-swarms/03-communication-protocols/quiz.json
@@ -3,35 +3,60 @@
     {
       "stage": "pre",
       "question": "What problem does MCP (Model Context Protocol) solve for AI agents?",
-      "options": ["It provides a standard format for training data", "It gives agents a standard way to discover and use tools exposed by external servers, without hardcoding tool implementations", "It encrypts communication between agents", "It compresses large context windows to fit in smaller models"],
+      "options": [
+        "It provides a standard format for training data",
+        "It gives agents a standard way to discover and use tools exposed by external servers, without hardcoding tool implementations",
+        "It encrypts communication between agents",
+        "It compresses large context windows to fit in smaller models"
+      ],
       "correct": 1,
       "explanation": "MCP standardizes tool access: a server exposes tools with JSON schemas, and any MCP-compatible agent can discover and call them. This decouples tool implementation from agent code."
     },
     {
       "stage": "pre",
       "question": "What is the difference between MCP and A2A?",
-      "options": ["MCP is for Python agents and A2A is for JavaScript agents", "MCP connects agents to tools (agent-to-tool), while A2A connects agents to other agents (agent-to-agent) for task delegation", "MCP is synchronous and A2A is asynchronous", "MCP is open source and A2A is proprietary"],
-      "correct": 1,
+      "options": [
+        "MCP connects agents to tools (agent-to-tool), while A2A connects agents to other agents (agent-to-agent) for task delegation",
+        "MCP is for Python agents and A2A is for JavaScript agents",
+        "MCP is synchronous and A2A is asynchronous",
+        "MCP is open source and A2A is proprietary"
+      ],
+      "correct": 0,
       "explanation": "MCP is the protocol for tool access (an agent calls a tool). A2A is the protocol for agent collaboration (an agent delegates a task to another agent). They solve different layers of the communication problem."
     },
     {
       "stage": "post",
       "question": "In A2A, what is an 'agent card' and why is it important?",
-      "options": ["A visual dashboard showing agent performance metrics", "A JSON document at a well-known URL that describes an agent's capabilities, skills, and endpoint, enabling other agents to discover and delegate tasks to it", "A security credential that authenticates an agent's identity", "A configuration file that sets the agent's system prompt"],
-      "correct": 1,
+      "options": [
+        "A visual dashboard showing agent performance metrics",
+        "A security credential that authenticates an agent's identity",
+        "A JSON document at a well-known URL that describes an agent's capabilities, skills, and endpoint, enabling other agents to discover and delegate tasks to it",
+        "A configuration file that sets the agent's system prompt"
+      ],
+      "correct": 2,
       "explanation": "The agent card (hosted at /.well-known/agent.json) is how agents advertise themselves. It lists skills, supported input/output formats, and the task endpoint. Other agents read this card to decide whether and how to delegate work."
     },
     {
       "stage": "post",
       "question": "Why do multi-agent systems need structured communication protocols instead of just passing strings between agents?",
-      "options": ["Strings are too large to send over HTTP", "Structured protocols provide type safety, discoverability, error handling, and interoperability between agents built by different teams with different frameworks", "String parsing is computationally expensive for LLMs", "Structured protocols are required by all cloud providers"],
-      "correct": 1,
+      "options": [
+        "Strings are too large to send over HTTP",
+        "Structured protocols are required by all cloud providers",
+        "String parsing is computationally expensive for LLMs",
+        "Structured protocols provide type safety, discoverability, error handling, and interoperability between agents built by different teams with different frameworks"
+      ],
+      "correct": 3,
       "explanation": "Without structured contracts, agents from different teams misinterpret each other's output, error handling is ad-hoc, and there is no way to discover what another agent can do. Protocols provide the shared language that makes multi-agent systems reliable."
     },
     {
       "stage": "post",
       "question": "How does ACP (Agent Communication Protocol) differ from A2A in its design goals?",
-      "options": ["ACP is faster than A2A for real-time applications", "ACP focuses on enterprise auditability with full message history and compliance tracking, while A2A focuses on lightweight task delegation", "ACP only works within a single organization while A2A works across organizations", "ACP uses WebSockets while A2A uses HTTP"],
+      "options": [
+        "ACP is faster than A2A for real-time applications",
+        "ACP focuses on enterprise auditability with full message history and compliance tracking, while A2A focuses on lightweight task delegation",
+        "ACP only works within a single organization while A2A works across organizations",
+        "ACP uses WebSockets while A2A uses HTTP"
+      ],
       "correct": 1,
       "explanation": "ACP was designed for enterprise environments where every agent interaction must be auditable, traceable, and compliant. A2A is simpler and focuses on getting tasks done. ACP adds the governance layer that regulated industries require."
     }

--- a/phases/19-capstone-projects/34-transformer-block/quiz.json
+++ b/phases/19-capstone-projects/34-transformer-block/quiz.json
@@ -18,12 +18,12 @@
       "stage": "check",
       "question": "What is the key difference between pre-LN and post-LN at depth?",
       "options": [
-        "Pre-LN uses different attention math",
         "Pre-LN keeps the residual signal unnormalized so gradients propagate cleanly to the embedding; post-LN puts the norm after the residual add, which shrinks gradients at depth and needs warmup",
+        "Pre-LN uses different attention math",
         "Post-LN is faster on GPU",
         "Pre-LN works only for encoders"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Pre-LN trains stably without warmup at common learning rates; post-LN is what the 2017 paper shipped and needed warmup."
     },
     {
@@ -31,11 +31,11 @@
       "question": "What does the causal mask in multi head attention do?",
       "options": [
         "Drops random tokens",
-        "Sets the upper triangle of the attention logits to negative infinity so token i cannot attend to tokens at positions greater than i",
         "Normalizes the attention scores",
+        "Sets the upper triangle of the attention logits to negative infinity so token i cannot attend to tokens at positions greater than i",
         "Picks the longest sequence in the batch"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Forgetting the causal mask trains a model that can read future tokens; the mask is the only piece that enforces causality."
     },
     {
@@ -43,11 +43,11 @@
       "question": "Why use a fused QKV projection instead of three separate linears?",
       "options": [
         "It changes the model expressivity",
-        "One linear of width 3 times d_model collapses three kernel launches and three matmuls into one, faster on every accelerator and matches the reference GPT-2 implementation",
+        "It removes the residual",
         "It avoids a softmax",
-        "It removes the residual"
+        "One linear of width 3 times d_model collapses three kernel launches and three matmuls into one, faster on every accelerator and matches the reference GPT-2 implementation"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "Same math, fewer kernels; reference implementations of GPT-2, LLaMA, and Mistral all ship the fused projection."
     },
     {
@@ -66,12 +66,12 @@
       "stage": "post",
       "question": "Why register the causal mask as a buffer rather than allocating it per forward call?",
       "options": [
-        "Buffers are encrypted",
         "The mask depends only on the maximum context length, so allocating it once at construction and slicing the active window per call avoids an allocator hot spot at long context",
+        "Buffers are encrypted",
         "Buffers run on GPU only",
         "Buffers improve numerical accuracy"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Allocate once with register_buffer, slice per forward; otherwise the mask becomes a per-call allocation cost."
     }
   ]

--- a/phases/19-capstone-projects/36-training-loop-eval/quiz.json
+++ b/phases/19-capstone-projects/36-training-loop-eval/quiz.json
@@ -18,12 +18,12 @@
       "stage": "pre",
       "question": "What does evaluate_model do that the training step does not?",
       "options": [
-        "It runs the optimizer",
         "It runs a fixed number of validation batches under no_grad and with dropout disabled, returning a reproducible mean loss",
+        "It runs the optimizer",
         "It changes the model weights",
         "It computes gradients twice"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Held out evaluation needs no gradients, no dropout, and a fixed slice of validation data to be reproducible across runs."
     },
     {
@@ -31,11 +31,11 @@
       "question": "Which AdamW parameters get weight decay?",
       "options": [
         "Every parameter equally",
-        "Matrix-shaped tensors (linear weights, embedding tables) receive weight decay; scale, shift, and bias tensors receive zero decay",
         "Only the LM head",
+        "Matrix-shaped tensors (linear weights, embedding tables) receive weight decay; scale, shift, and bias tensors receive zero decay",
         "Only the LayerNorm scales"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Putting decay on a LayerNorm scale drives the scale to zero and breaks normalization; the split is a standard production pattern."
     },
     {
@@ -43,11 +43,11 @@
       "question": "What shape does the warmup-plus-cosine schedule trace from step 0 to the final step?",
       "options": [
         "Constant",
-        "Linear ramp from zero to max over warmup_steps, then cosine decay from max to min_lr over the remaining steps",
+        "Step function",
         "Exponential growth",
-        "Step function"
+        "Linear ramp from zero to max over warmup_steps, then cosine decay from max to min_lr over the remaining steps"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "Warmup populates optimizer state; cosine decay tapers the step size so the final phase fine-tunes the weights."
     },
     {
@@ -66,12 +66,12 @@
       "stage": "post",
       "question": "Why log per step records as JSONL instead of pickled state?",
       "options": [
-        "JSONL is required by the optimizer",
         "JSONL records are durable across refactors, greppable, plottable in thirty lines, and survive crashes; pickled state ties you to the module layout that produced it",
+        "JSONL is required by the optimizer",
         "JSONL trains faster",
         "JSONL uses less GPU memory"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Any crash leaves a readable artifact; resume reads the last step; tooling on top is trivial."
     }
   ]

--- a/phases/19-capstone-projects/37-loading-pretrained-weights/quiz.json
+++ b/phases/19-capstone-projects/37-loading-pretrained-weights/quiz.json
@@ -18,12 +18,12 @@
       "stage": "check",
       "question": "What is the conv1d transpose, and which tensors need it?",
       "options": [
-        "All weight tensors",
         "Published GPT-2 stores c_attn, c_proj, and c_fc weights in tensorflow conv1d layout, which is the transpose of what nn.Linear.weight expects; the loader calls .t() on those during assignment",
+        "All weight tensors",
         "Only the embedding",
         "Only the LayerNorm scales"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Three suffixes need transposing; biases and LayerNorms are already shaped correctly."
     },
     {
@@ -31,11 +31,11 @@
       "question": "Why is the LM head not in the safetensors file?",
       "options": [
         "It is computed at runtime from logits",
-        "Weight tying: the LM head shares storage with the token embedding (wte), so loading wte and aliasing lm_head.weight = tok_embed.weight after the load reconstructs the head",
         "It is too large",
+        "Weight tying: the LM head shares storage with the token embedding (wte), so loading wte and aliasing lm_head.weight = tok_embed.weight after the load reconstructs the head",
         "It is loaded from a separate file"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Setting lm_head.weight = tok_embed.weight after wte lands restores the alias; copying instead doubles the parameter count."
     },
     {
@@ -43,11 +43,11 @@
       "question": "What does the loader do on a shape mismatch?",
       "options": [
         "Pads the smaller tensor",
-        "Records the mismatch in LoadReport.shape_mismatch and refuses to assign, leaving the local parameter untouched",
+        "Truncates the larger tensor",
         "Crashes the process",
-        "Truncates the larger tensor"
+        "Records the mismatch in LoadReport.shape_mismatch and refuses to assign, leaving the local parameter untouched"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "Half loaded models are silent failure machines; refusing to assign keeps the report honest."
     },
     {
@@ -66,12 +66,12 @@
       "stage": "post",
       "question": "Why generate a sample before and after the load?",
       "options": [
-        "To measure inference speed",
         "If the post-load samples are identical to the pre-load samples, the load did not change the model, which means the mapping silently missed every tensor",
+        "To measure inference speed",
         "To warm up the GPU cache",
         "To set the random seed"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Sanity generation is the cheapest gate: a sample fingerprint that fails to change exposes a broken load that the LoadReport summary would not catch on its own."
     }
   ]

--- a/phases/19-capstone-projects/39-instruction-tuning-sft/quiz.json
+++ b/phases/19-capstone-projects/39-instruction-tuning-sft/quiz.json
@@ -18,12 +18,12 @@
       "stage": "check",
       "question": "The collate function sets labels[i] = -100 on instruction positions and on padding positions. Why does PyTorch cross-entropy treat these positions correctly?",
       "options": [
-        "Cross-entropy silently drops any negative target.",
         "ignore_index=-100 is honoured by F.cross_entropy: those positions contribute zero loss and zero gradient.",
+        "Cross-entropy silently drops any negative target.",
         "The model output at those positions is set to NaN automatically.",
         "PyTorch normalises by sequence length so masked positions cancel out."
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "ignore_index is a documented argument of F.cross_entropy. Targets equal to it contribute zero to loss and zero to gradients. -100 is the conventional default value."
     },
     {
@@ -31,11 +31,11 @@
       "question": "Why does `shifted_loss` slice `logits[:, :-1, :]` and `labels[:, 1:]` instead of using them at the same positions?",
       "options": [
         "To make the tensors the same size after the collate step.",
-        "Because the model at position i predicts the token at position i+1 under the causal next-token objective.",
         "To exclude the final padding position automatically.",
+        "Because the model at position i predicts the token at position i+1 under the causal next-token objective.",
         "It is an optional optimisation; using same-position labels also works."
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Causal LM trains position i to predict token i+1. The slice aligns the prediction at position i with the gold label at position i+1, which is the standard next-token objective."
     },
     {
@@ -43,11 +43,11 @@
       "question": "You train without the mask: labels are equal to input_ids with no -100. The model trains but exact-match on the response is worse than with the mask. The most likely cause?",
       "options": [
         "The optimiser overfits the response tokens.",
-        "Most of the gradient signal goes to predicting the instruction (the largest masked region was holding it back).",
+        "The model cannot learn the boundary token without the mask.",
         "Cross-entropy is unstable when the loss includes specials.",
-        "The model cannot learn the boundary token without the mask."
+        "Most of the gradient signal goes to predicting the instruction (the largest masked region was holding it back)."
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "When instruction positions count toward the loss, they dominate the gradient because there are usually more of them than response tokens. The effective learning rate on the part you care about (the response) drops, and the model spends capacity reconstructing inputs the user always supplies."
     },
     {
@@ -66,12 +66,12 @@
       "stage": "post",
       "question": "You want to use the SFT model in a chatbot that supports multi-turn dialogue. What is the minimum change required to the data and the mask?",
       "options": [
-        "None: SFT models always handle multi-turn out of the box.",
         "Add a USER and ASSISTANT marker per turn, concatenate turns, and mask everything except the assistant turn currently being trained on.",
+        "None: SFT models always handle multi-turn out of the box.",
         "Switch the loss to mean-squared error.",
         "Increase the vocabulary."
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Multi-turn SFT generalises the single-turn template. Each turn gets a role marker. The mask is the union of all non-assistant positions plus padding. The training objective is unchanged."
     }
   ]

--- a/phases/19-capstone-projects/42-large-corpus-downloader/quiz.json
+++ b/phases/19-capstone-projects/42-large-corpus-downloader/quiz.json
@@ -18,12 +18,12 @@
       "stage": "check",
       "question": "What does the LSH band scheme buy that exact-hash dedup does not?",
       "options": [
-        "Constant memory usage",
         "Sub-linear lookup that flags near-duplicates with high Jaccard similarity even when the documents differ by a few tokens",
+        "Constant memory usage",
         "Lossless compression",
         "Faster sha256 computation"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "MinHash plus LSH catches paraphrases and boilerplate variants that exact-hash dedup walks past."
     },
     {
@@ -31,11 +31,11 @@
       "question": "Why is the checkpoint written before the bytes are appended, not after?",
       "options": [
         "It is convenient",
-        "If the process dies between the write and the checkpoint update, the next resume reads a checkpoint that is behind the bytes and silently re-appends, corrupting the file",
         "It is faster",
+        "If the process dies between the write and the checkpoint update, the next resume reads a checkpoint that is behind the bytes and silently re-appends, corrupting the file",
         "It saves disk space"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Checkpoint-first matches a write-ahead log: a crash leaves the verified offset trailing or equal to the file, never ahead."
     },
     {
@@ -43,11 +43,11 @@
       "question": "What is the role of the manifest sha256 lock file?",
       "options": [
         "It speeds up reads",
-        "Downstream stages refuse to start unless the manifest content matches the pinned hash, closing the silent attack surface where an attacker edits one file",
+        "It is a backup of the manifest",
         "It records the date",
-        "It is a backup of the manifest"
+        "Downstream stages refuse to start unless the manifest content matches the pinned hash, closing the silent attack surface where an attacker edits one file"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "Pinning the manifest hash makes the link between code and data a content-addressed contract."
     },
     {
@@ -66,12 +66,12 @@
       "stage": "post",
       "question": "What does tombstoning a dropped duplicate preserve that a silent delete does not?",
       "options": [
-        "Disk space",
         "The link between the duplicate and the keeper it collided with, plus an audit trail that survives a later threshold change",
+        "Disk space",
         "Compression ratio",
         "Manifest sha256 stability"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Tombstones let a future pass revisit the dedup threshold; deletes lose the evidence."
     }
   ]

--- a/phases/19-capstone-projects/43-hdf5-tokenized-corpus/quiz.json
+++ b/phases/19-capstone-projects/43-hdf5-tokenized-corpus/quiz.json
@@ -18,12 +18,12 @@
       "stage": "check",
       "question": "What is the right rule for sizing the HDF5 chunk vs the trainer's window_size?",
       "options": [
-        "Always pick chunk=1",
         "Set chunk to a multiple of window_size so each sample lands inside one or two chunks and reads stay page-cache aligned",
+        "Always pick chunk=1",
         "Pick chunk equal to the document length",
         "Pick the largest chunk that fits in RAM"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Mismatched chunks halve throughput because every sample straddles two chunks instead of one."
     },
     {
@@ -31,11 +31,11 @@
       "question": "Why is token_count stored as an HDF5 attribute and not implied from dataset shape?",
       "options": [
         "Attributes are pretty",
-        "The trailing chunk may be partially full; without the explicit attribute the reader walks past the real end into zero-padded tokens and the model learns to predict zero",
         "Shapes are slow to read",
+        "The trailing chunk may be partially full; without the explicit attribute the reader walks past the real end into zero-padded tokens and the model learns to predict zero",
         "Attributes are mandatory"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "The chunked layout sometimes leaves trailing slots; the attribute carries the truth."
     },
     {
@@ -43,11 +43,11 @@
       "question": "What does the writer accomplish by buffering tokens to chunk_size before each resize?",
       "options": [
         "Saves a few CPU cycles",
-        "Writes are contiguous and chunk-aligned, avoiding the fragmentation that follows one-token-at-a-time resizes",
+        "Speeds up sha256",
         "Reduces vocabulary size",
-        "Speeds up sha256"
+        "Writes are contiguous and chunk-aligned, avoiding the fragmentation that follows one-token-at-a-time resizes"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "Buffer-then-extend at chunk size is the only way to keep HDF5 chunks contiguous on disk."
     },
     {
@@ -66,12 +66,12 @@
       "stage": "post",
       "question": "What does the boundary token id exist to make explicit?",
       "options": [
-        "Vocabulary size limits",
         "Document boundaries within a packed window so the model is not silently trained on cross-document concatenation",
+        "Vocabulary size limits",
         "Compression",
         "Random data"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Without an explicit boundary the trainer learns boundaries as noise; with it the boundary becomes a usable separator."
     }
   ]

--- a/phases/19-capstone-projects/44-cosine-lr-warmup/quiz.json
+++ b/phases/19-capstone-projects/44-cosine-lr-warmup/quiz.json
@@ -18,12 +18,12 @@
       "stage": "check",
       "question": "Why is the schedule implemented as a single function over step rather than three glued segments?",
       "options": [
-        "Single functions are smaller",
         "A glued schedule loses one boundary the first time lr_max is changed; the single function evaluates the same closed-form expression and preserves continuity at warmup and total endpoints",
+        "Single functions are smaller",
         "Linters require it",
         "Random"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Continuity at lr(warmup_steps) and lr(total_steps) follows from the closed form."
     },
     {
@@ -31,11 +31,11 @@
       "question": "What happens for step > total_steps in the schedule?",
       "options": [
         "It throws an exception",
-        "It pins at lr_min; the schedule does not extrapolate, and trainers that need to extend training change total_steps explicitly",
         "It returns nan",
+        "It pins at lr_min; the schedule does not extrapolate, and trainers that need to extend training change total_steps explicitly",
         "It wraps around"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "A pinned floor keeps an overshooting trainer in a documented state instead of crashing."
     },
     {
@@ -43,11 +43,11 @@
       "question": "Why log gradient L2 norm next to the learning rate?",
       "options": [
         "It looks pretty",
-        "The norm is the other half of training health: a divergent run spikes its norm before the loss; a too-aggressive peak shows up as a norm that stays high after warmup",
+        "Tradition",
         "Adam requires it",
-        "Tradition"
+        "The norm is the other half of training health: a divergent run spikes its norm before the loss; a too-aggressive peak shows up as a norm that stays high after warmup"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "Co-logging makes pathological schedules visible at run time, not after the fact."
     },
     {
@@ -66,12 +66,12 @@
       "stage": "post",
       "question": "Why is a non-zero lr_min typical in production?",
       "options": [
-        "Adam requires non-zero",
         "A floor near 10 percent of lr_max keeps the optimizer learning during the long tail; an lr_min of zero produces a curve that looks good and a model that has not finished training",
+        "Adam requires non-zero",
         "Numerical stability",
         "Backward compatibility"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "The tail of the schedule is where late-stage refinements land; zeroing it wastes that signal."
     }
   ]

--- a/phases/19-capstone-projects/45-gradient-clipping-amp/quiz.json
+++ b/phases/19-capstone-projects/45-gradient-clipping-amp/quiz.json
@@ -18,12 +18,12 @@
       "stage": "check",
       "question": "What is the correct order of GradScaler operations in a step?",
       "options": [
-        "step, scale, unscale, backward, update",
         "scaler.scale(loss).backward(); scaler.unscale_(optimizer); clip_grad_norm_; scaler.step(optimizer); scaler.update()",
+        "step, scale, unscale, backward, update",
         "backward, step, scale, update",
         "Any order; the scaler reorders internally"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Clip on unscaled gradients between unscale_ and step; update always runs."
     },
     {
@@ -31,11 +31,11 @@
       "question": "What does scaler.update() do on a skipped step?",
       "options": [
         "Nothing",
-        "Halves the scaling factor and resets the no-inf counter; forgetting to call it on the skip path is the bug that produces 'the scaling factor never changed'",
         "Doubles the scaling factor",
+        "Halves the scaling factor and resets the no-inf counter; forgetting to call it on the skip path is the bug that produces 'the scaling factor never changed'",
         "Closes the run"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "The scaler tunes its factor based on the skip / clean ratio across recent steps."
     },
     {
@@ -43,11 +43,11 @@
       "question": "Why is the loss finiteness check necessary even with a GradScaler?",
       "options": [
         "Because GradScaler is slow",
-        "GradScaler handles backward-pass overflow but a non-finite loss does not produce useful gradients; skipping before backward saves compute and avoids polluting the scaler's state",
+        "PyTorch requires it",
         "It is decorative",
-        "PyTorch requires it"
+        "GradScaler handles backward-pass overflow but a non-finite loss does not produce useful gradients; skipping before backward saves compute and avoids polluting the scaler's state"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "Loss check covers forward-pass failures; scaler covers backward-pass failures."
     },
     {
@@ -66,12 +66,12 @@
       "stage": "post",
       "question": "Why switch from FP16 to BF16 autocast when skips are frequent?",
       "options": [
-        "BF16 is newer",
         "BF16 has a wider exponent range than FP16 and rarely needs loss scaling; the skip rate typically drops to zero on the same model",
+        "BF16 is newer",
         "BF16 is slower so it skips less",
         "Random tradition"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "FP16 favors mantissa precision over range; BF16 trades the other way, removing the overflow class entirely."
     }
   ]

--- a/phases/19-capstone-projects/47-checkpoint-save-resume/quiz.json
+++ b/phases/19-capstone-projects/47-checkpoint-save-resume/quiz.json
@@ -18,12 +18,12 @@
       "stage": "pre",
       "question": "Why does the saver write to a temporary file and then rename instead of writing the target name directly?",
       "options": [
-        "Faster I/O",
         "POSIX rename within the same directory is atomic, so a crash mid-write leaves the previous good file in place rather than a half-written file at the target name",
+        "Faster I/O",
         "It dedupes the file",
         "It bypasses fsync"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "atomic_save calls os.replace from a temp file in the same directory. Cross-device renames lose atomicity, which is why the temp file must live in the target directory."
     },
     {
@@ -31,11 +31,11 @@
       "question": "Why does a sharded checkpoint store a sha256 in index.json per shard?",
       "options": [
         "For SEO",
-        "So the loader can detect a truncated or tampered shard at load time instead of silently merging a bad state_dict",
         "To compress the file",
+        "So the loader can detect a truncated or tampered shard at load time instead of silently merging a bad state_dict",
         "Because torch requires it"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "load_sharded_checkpoint asserts each shard's actual hash matches the recorded one and the meta file's hash too. Silent corruption is the worst failure mode."
     },
     {
@@ -43,11 +43,11 @@
       "question": "How does resume continue at the right offset inside the current epoch?",
       "options": [
         "It skips to the next epoch boundary",
-        "TrainState records (epoch, batch_in_epoch) and the RNG state is restored, so the loader fast-forwards the generator past the batches already consumed before continuing",
+        "It always restarts from step 0",
         "It uses a special database",
-        "It always restarts from step 0"
+        "TrainState records (epoch, batch_in_epoch) and the RNG state is restored, so the loader fast-forwards the generator past the batches already consumed before continuing"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "Without (epoch, batch_in_epoch) you snap to the next epoch boundary and waste work. Without RNG you see different batches. Both are required."
     },
     {
@@ -66,12 +66,12 @@
       "stage": "post",
       "question": "Reading the resume demo summary, what does max_loss_diff_after_resume near 0 prove?",
       "options": [
-        "Nothing useful",
         "That the post-resume loss trajectory matches the uninterrupted baseline within floating point noise, which means the RNG state and the optimizer state were both restored faithfully",
+        "Nothing useful",
         "That the model is good",
         "That the disk is fast"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "If you forget RNG you see a different curve and a non-trivial diff. If you forget optimizer state the diff is huge. The near-zero number is the contract."
     }
   ]

--- a/phases/19-capstone-projects/49-lm-eval-harness/quiz.json
+++ b/phases/19-capstone-projects/49-lm-eval-harness/quiz.json
@@ -18,12 +18,12 @@
       "stage": "pre",
       "question": "Why is the metric function signature (prediction, targets, extras) -> float?",
       "options": [
-        "Random choice",
         "It is the smallest signature that handles single-target string match, multi-reference rouge-l, and code_exec with side data, while keeping scores in a comparable [0.0, 1.0] range",
+        "Random choice",
         "It returns an integer",
         "It needs the model object"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Floats in [0,1] mean per-task and overall scores are interpretable averages. The extras slot is how code_exec gets its io_pairs."
     },
     {
@@ -31,11 +31,11 @@
       "question": "How does the code_exec metric resist malicious predictions?",
       "options": [
         "It does not",
-        "It runs the prediction with a stripped __builtins__ dict so the namespace exposes only a few safe names; import statements fail because the importer is not in scope",
         "It uses sandbox containers",
+        "It runs the prediction with a stripped __builtins__ dict so the namespace exposes only a few safe names; import statements fail because the importer is not in scope",
         "It rejects anything that contains def"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "The lesson's safe namespace strips builtins down to a handful of names. The test asserts that import os returns score 0.0 instead of executing."
     },
     {
@@ -43,11 +43,11 @@
       "question": "What does the model adapter abstraction buy you?",
       "options": [
         "Nothing",
-        "It is the only model-specific code in the harness; swap the adapter to point at a new vendor, and the tasks, metrics, runner, and leaderboard format stay the same",
+        "It is required by torch",
         "It makes the model faster",
-        "It is required by torch"
+        "It is the only model-specific code in the harness; swap the adapter to point at a new vendor, and the tasks, metrics, runner, and leaderboard format stay the same"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "ToyAdapter in the lesson is a deterministic pattern matcher. An HttpAdapter for a real vendor has the same generate(prompts) -> list[str] surface."
     },
     {
@@ -66,12 +66,12 @@
       "stage": "post",
       "question": "Reading a leaderboard, overall_score is computed how, and what should you watch for when comparing two runs?",
       "options": [
-        "Sum of correct counts",
         "Mean of per-task scores (each in [0,1]); when comparing, also diff per-example predictions for tasks whose scores moved, because the score alone hides which examples regressed",
+        "Sum of correct counts",
         "Best task score",
         "Random sample"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Mean of per-task means weights every task equally. Use --include-per-example to keep the prediction-level evidence next to the score so regressions are visible."
     }
   ]

--- a/phases/19-capstone-projects/50-hypothesis-generator/quiz.json
+++ b/phases/19-capstone-projects/50-hypothesis-generator/quiz.json
@@ -18,12 +18,12 @@
       "stage": "pre",
       "question": "What does the temperature ramp accomplish on each pass?",
       "options": [
-        "It raises the parser tolerance",
         "It widens the sampling distribution so later drafts can land further from the seed",
+        "It raises the parser tolerance",
         "It increases the embedding dimension",
         "It triples the seed value"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Higher temperature widens the sampling distribution. The ramp encourages each pass to drift further so the novelty filter has something to do."
     },
     {
@@ -31,11 +31,11 @@
       "question": "When does the novelty filter reject a draft?",
       "options": [
         "When its rank score is below the threshold",
-        "When its minimum cosine distance to any prior survivor falls below the novelty threshold",
         "When its parser passes but its tag count is wrong",
+        "When its minimum cosine distance to any prior survivor falls below the novelty threshold",
         "When its draft pass is greater than the queue length"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Novelty is the minimum distance to prior survivors. If that distance is below the threshold the draft is a near duplicate and is dropped."
     },
     {
@@ -43,11 +43,11 @@
       "question": "Which three components combine in the rank score?",
       "options": [
         "Latency, throughput, cost",
-        "Novelty, specificity, testability",
+        "Variables, metric, baseline length",
         "Temperature, seed, pass index",
-        "Variables, metric, baseline length"
+        "Novelty, specificity, testability"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "The rank score is a weighted sum of novelty, specificity, and testability. Each sub score lives between zero and one."
     },
     {
@@ -66,12 +66,12 @@
       "stage": "check",
       "question": "What happens if every draft from the mock model fails the parser?",
       "options": [
-        "The generator raises a hard error",
         "The queue is empty and each pass logs a parse rejection so the failure mode is auditable",
+        "The generator raises a hard error",
         "The runner retries with a fresh prompt",
         "The novelty threshold is lowered automatically"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Parser failures are recorded as logs with a parse reject reason. The queue can come back empty without crashing the loop, and the logs explain why."
     }
   ]

--- a/phases/19-capstone-projects/54-paper-writer/quiz.json
+++ b/phases/19-capstone-projects/54-paper-writer/quiz.json
@@ -18,12 +18,12 @@
       "stage": "pre",
       "question": "What does the figure-injection step produce from an experiment manifest?",
       "options": [
-        "A PDF compiled from artifacts",
         "A list of Figure records with stable ids and paths normalised to the paper directory",
+        "A PDF compiled from artifacts",
         "A model prompt with figure descriptions",
         "A bibliography stub"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "read_experiment_manifest returns Figure records. Ids are deterministic, paths are normalised, captions come from the manifest."
     },
     {
@@ -31,11 +31,11 @@
       "question": "Which validation failure raises PaperValidationError before any file is written?",
       "options": [
         "An odd number of authors",
-        "A section that cites a key not declared in the bibliography",
         "An abstract longer than 200 words",
+        "A section that cites a key not declared in the bibliography",
         "A figure path that does not exist on disk"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Missing bibliography keys, duplicate figure ids, empty title, empty abstract, and unknown figure refs all raise PaperValidationError. Existence on disk is not enforced because the LaTeX compiler enforces it later."
     },
     {
@@ -43,11 +43,11 @@
       "question": "Why is the prose generator a callable injected into PaperWriter rather than a method on it?",
       "options": [
         "Because Python does not allow methods to take Paper as an argument",
-        "Because tests can swap a deterministic MockProseGenerator for a model call without touching the writer",
+        "Because the dataclass cannot hold state",
         "Because LaTeX requires a callback",
-        "Because the dataclass cannot hold state"
+        "Because tests can swap a deterministic MockProseGenerator for a model call without touching the writer"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "The writer takes the prose generator as a dependency. The test substitutes MockProseGenerator. Production substitutes a model call. The writer is unchanged."
     },
     {
@@ -66,12 +66,12 @@
       "stage": "post",
       "question": "Why is the manifest part of the writer's contract instead of just the LaTeX file?",
       "options": [
-        "Because LaTeX is too large to parse",
         "Because downstream tooling (critics, dashboards) reads structured manifests, not LaTeX",
+        "Because LaTeX is too large to parse",
         "Because manifest.json is the only file BibTeX accepts",
         "Because LaTeX compilers reject untyped sections"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "The manifest is a stable interface for downstream stages. Critics and dashboards inspect manifest.json. LaTeX is the human-readable artifact, not the machine interface."
     }
   ]

--- a/phases/19-capstone-projects/55-critic-loop/quiz.json
+++ b/phases/19-capstone-projects/55-critic-loop/quiz.json
@@ -18,12 +18,12 @@
       "stage": "pre",
       "question": "In what order does the loop check stop conditions at the end of a round?",
       "options": [
-        "Budget, then plateau, then target",
         "Target, then plateau, then budget",
+        "Budget, then plateau, then target",
         "Plateau, then target, then budget",
         "Whichever fires first by random tie-break"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Target met wins (the work is done). Then plateau (no more progress is achievable). Then budget (hard cap). The order makes the result deterministic when more than one condition could fire."
     },
     {
@@ -31,11 +31,11 @@
       "question": "Why does plateau detection require two consecutive flat rounds rather than one?",
       "options": [
         "Because the dataclass requires a list",
-        "Because deterministic scoring still has noise per round; one flat round is not enough signal",
         "Because the model returns nondeterministic scores",
+        "Because deterministic scoring still has noise per round; one flat round is not enough signal",
         "Because the dashboard expects two points"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Even a deterministic scorer's output changes round to round depending on which suggestions were applied. Requiring two flat rounds filters that noise."
     },
     {
@@ -43,11 +43,11 @@
       "question": "What does the reviser receive as input each round?",
       "options": [
         "The full Critique object including scores",
-        "The paper and the list of Suggestion records",
+        "The raw LaTeX source",
         "A model-generated paragraph",
-        "The raw LaTeX source"
+        "The paper and the list of Suggestion records"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "Reviser.__call__ takes (paper, suggestions). Each Suggestion carries a dimension, target section, and an edit instruction. The reviser does not see scores. That separation lets either side be swapped without touching the other."
     },
     {
@@ -66,12 +66,12 @@
       "stage": "post",
       "question": "A critic that keeps emitting suggestions that never improve any score will produce which terminal verdict?",
       "options": [
-        "target, because the budget hides the bug",
         "plateau or budget, because the harness will catch the lack of progress",
+        "target, because the budget hides the bug",
         "converged, because suggestions were applied",
         "An exception, because the loop crashes"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Either plateau (two flat rounds) or budget (hard cap) fires. Both verdicts surface the bug. The loop never silently succeeds."
     }
   ]

--- a/phases/19-capstone-projects/57-end-to-end-research-demo/quiz.json
+++ b/phases/19-capstone-projects/57-end-to-end-research-demo/quiz.json
@@ -18,12 +18,12 @@
       "stage": "pre",
       "question": "Why does the lesson load earlier lessons via importlib instead of a normal package import?",
       "options": [
-        "Because importlib is faster",
         "Because each earlier lesson is a standalone code/ folder, not an installed package; importlib loads them by file path",
+        "Because importlib is faster",
         "Because asyncio requires importlib",
         "Because the lessons share a module name and would collide"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "The lessons are not installed packages. Each ships a main.py inside its own code/ folder. importlib.util.spec_from_file_location loads them by path without polluting the global module namespace."
     },
     {
@@ -31,11 +31,11 @@
       "question": "How does the best-result picker decide between branches when more than one triggered a paper?",
       "options": [
         "It picks the branch with the most experiments run",
-        "It picks the branch with the highest mean reward, breaking ties alphabetically by branch id",
         "It picks at random for fairness",
+        "It picks the branch with the highest mean reward, breaking ties alphabetically by branch id",
         "It picks the first triggered branch"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Highest mean wins. Ties break on branch id so the demo is deterministic. Random would defeat the determinism test."
     },
     {
@@ -43,11 +43,11 @@
       "question": "What error does the picker raise when the scheduler reports zero paper triggers?",
       "options": [
         "ValueError",
-        "NoTriggerError, which short-circuits the demo before the writer runs",
+        "It returns None",
         "PaperValidationError",
-        "It returns None"
+        "NoTriggerError, which short-circuits the demo before the writer runs"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "NoTriggerError is the typed failure mode. Returning None would let the writer run on a malformed input and break later with a less actionable error."
     },
     {
@@ -66,12 +66,12 @@
       "stage": "post",
       "question": "What does the demo report contain after a successful run?",
       "options": [
-        "Only the final LaTeX file",
         "scheduler_report, best_branch, best_reward, critic_result, paper_manifest, and stop_reason",
+        "Only the final LaTeX file",
         "Just the experiment count and a status string",
         "A model prompt and completion log"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Every stage's output is preserved. The report is a composition of upstream outputs, not a transformed summary. Downstream tooling reads the manifest; debuggers read the trace inside scheduler_report."
     }
   ]

--- a/phases/19-capstone-projects/58-vision-encoder-patches/quiz.json
+++ b/phases/19-capstone-projects/58-vision-encoder-patches/quiz.json
@@ -18,12 +18,12 @@
       "stage": "pre",
       "question": "What is the relationship between Conv2d with kernel = stride = patch_size and flatten-then-linear?",
       "options": [
-        "They produce different outputs",
         "Conv2d is a faster way to spell the same linear projection over each patch",
+        "They produce different outputs",
         "Conv2d adds non-linearity",
         "Flatten-then-linear is impossible"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Each Conv2d output location dot-products the patch pixels with one filter, which is identical to flatten-then-linear."
     },
     {
@@ -31,11 +31,11 @@
       "question": "Why is the 2D sinusoidal position embedding deterministic instead of learned?",
       "options": [
         "Learned positions are illegal",
-        "Fixed sin/cos signals interpolate cleanly to grids the model never saw, which is useful when resolution changes",
         "It saves disk space",
+        "Fixed sin/cos signals interpolate cleanly to grids the model never saw, which is useful when resolution changes",
         "Random init is required"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Fixed sinusoidal positions are deterministic across resolutions and let the same encoder run on inputs it was not trained on."
     },
     {
@@ -43,11 +43,11 @@
       "question": "What is the output sequence length of a 224x224 image with patch_size=16 and one CLS token?",
       "options": [
         "196",
-        "197",
+        "256",
         "224",
-        "256"
+        "197"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "224/16 = 14, so 14x14 = 196 patches, plus one CLS token for 197 total tokens."
     },
     {
@@ -66,12 +66,12 @@
       "stage": "post",
       "question": "What changes when you swap a learned position embedding for the 2D sinusoidal one in this lesson?",
       "options": [
-        "Nothing changes",
         "Learned positions can fit a fixed resolution slightly better; sinusoidal positions transfer to new resolutions without retraining",
+        "Nothing changes",
         "Sinusoidal positions cost more parameters",
         "Sinusoidal positions are random per step"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Learned positions are flexible at one resolution. Sinusoidal positions cost zero parameters and survive resolution shifts."
     }
   ]

--- a/phases/19-capstone-projects/59-vit-transformer/quiz.json
+++ b/phases/19-capstone-projects/59-vit-transformer/quiz.json
@@ -18,12 +18,12 @@
       "stage": "pre",
       "question": "At hidden=768 with heads=12, what is the per-head dimension and why does it matter?",
       "options": [
-        "12, so each head can run on a small GPU",
         "64, which controls the resolution of each attention map and lets twelve heads attend independently in parallel",
+        "12, so each head can run on a small GPU",
         "768, because all heads share the projection",
         "96, set by ResNet-50"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "head_dim = hidden / heads = 64. Each head projects the token to its own 64-D q/k/v and computes its own attention map."
     },
     {
@@ -31,11 +31,11 @@
       "question": "Does the ViT encoder need a causal attention mask?",
       "options": [
         "Yes, like a GPT decoder",
-        "No: the encoder is bidirectional, every token may attend to every other token in the same sequence",
         "Only for the CLS row",
+        "No: the encoder is bidirectional, every token may attend to every other token in the same sequence",
         "Only during training"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Vision encoders are bidirectional. Causal masking appears later when a text decoder consumes the cross-attention output."
     },
     {
@@ -43,11 +43,11 @@
       "question": "What does the CLS token's final hidden state represent after all 12 blocks?",
       "options": [
         "A copy of the input embedding",
-        "A learned vector summary of the entire image that downstream heads project into class logits or contrastive embeddings",
+        "The last patch only",
         "Random noise",
-        "The last patch only"
+        "A learned vector summary of the entire image that downstream heads project into class logits or contrastive embeddings"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "The CLS token starts empty and accumulates information from every patch through self-attention across all 12 blocks."
     },
     {
@@ -66,12 +66,12 @@
       "stage": "post",
       "question": "Which family extension keeps the block math unchanged but adds prepended learned tokens?",
       "options": [
-        "Causal masking",
         "Register tokens (DINOv2): a few learned vectors prepended after CLS that capture global statistics and smooth attention maps",
+        "Causal masking",
         "Mixture-of-experts",
         "RoPE rotation"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Register tokens stabilize attention without altering the block's math; they are extra slots in the sequence."
     }
   ]

--- a/phases/19-capstone-projects/60-projection-layer-modality-align/quiz.json
+++ b/phases/19-capstone-projects/60-projection-layer-modality-align/quiz.json
@@ -18,12 +18,12 @@
       "stage": "pre",
       "question": "Why is the two-layer MLP enough for modality alignment in practice?",
       "options": [
-        "PyTorch requires two layers",
         "One non-linear bend (GELU) between two linear projections is empirically enough to align CLIP-style features with text embeddings",
+        "PyTorch requires two layers",
         "One-layer projections are forbidden",
         "Deeper projections are illegal"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "LLaVA and its descendants ship this two-layer MLP because the non-linearity fixes curvature mismatches a single linear cannot."
     },
     {
@@ -31,11 +31,11 @@
       "question": "Why is the vision encoder frozen during this alignment stage?",
       "options": [
         "Frozen means faster wall time",
-        "The 86M-parameter encoder cannot be retrained on a small mock corpus; the 1.3M-parameter projection alone is light enough to align in minutes",
         "PyTorch does not support training the encoder",
+        "The 86M-parameter encoder cannot be retrained on a small mock corpus; the 1.3M-parameter projection alone is light enough to align in minutes",
         "The encoder is empty"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Freezing the encoder and text table makes the projection the only thing learning, which is the operational shape of every adapter-based VLM."
     },
     {
@@ -43,11 +43,11 @@
       "question": "What does cosine_alignment_loss(image_emb, text_emb) return when the two vectors point in opposite directions?",
       "options": [
         "0.0",
-        "2.0",
+        "Infinity",
         "1.0",
-        "Infinity"
+        "2.0"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "Loss is 1 - cos(angle). Antiparallel vectors have cos = -1, so the loss is 1 - (-1) = 2.0."
     },
     {
@@ -66,12 +66,12 @@
       "stage": "post",
       "question": "Which production system maps most directly to the lesson 60 pattern?",
       "options": [
-        "PaLM",
         "LLaVA 1.5: frozen vision encoder, frozen LLM, train only a two-layer MLP projection",
+        "PaLM",
         "AlphaFold",
         "Stable Diffusion"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "LLaVA's stage-one training is exactly this: a frozen encoder and LM with a two-layer MLP bridge as the sole trainable piece."
     }
   ]

--- a/phases/19-capstone-projects/61-cross-attention-fusion/quiz.json
+++ b/phases/19-capstone-projects/61-cross-attention-fusion/quiz.json
@@ -18,12 +18,12 @@
       "stage": "pre",
       "question": "In a decoder block with both self-attention and cross-attention, which one uses a causal mask?",
       "options": [
-        "Both",
         "Self-attention only; the image is fully observed and cross-attention has no temporal order",
+        "Both",
         "Cross-attention only",
         "Neither"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Text generation is autoregressive, so text self-attention is causal. Image tokens are all visible before any text is decoded."
     },
     {
@@ -31,11 +31,11 @@
       "question": "Why is the cross-attention KV cache built once per image?",
       "options": [
         "PyTorch requires caching",
-        "Image keys and values do not change as text is decoded, so projecting memory once and reusing the K and V across all decode steps is the whole inference speedup",
         "Caching saves disk space",
+        "Image keys and values do not change as text is decoded, so projecting memory once and reusing the K and V across all decode steps is the whole inference speedup",
         "It avoids using the GPU"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "The vision encoder runs once. Its KV projection is computed once. Each text token reuses the cache for free."
     },
     {
@@ -43,11 +43,11 @@
       "question": "What is the output shape of cross-attention when text length is Nt=10 and image length is Nv=197 with hidden=256?",
       "options": [
         "(B, 197, 256)",
-        "(B, 10, 256)",
+        "(B, 207, 256)",
         "(B, 10, 197)",
-        "(B, 207, 256)"
+        "(B, 10, 256)"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "Cross-attention output shape follows the query stream, so output is (B, Nt, hidden) regardless of key length."
     },
     {
@@ -66,12 +66,12 @@
       "stage": "post",
       "question": "Which extension would you add to recover Flamingo-style stability during training?",
       "options": [
-        "Drop the self-attention layer",
         "Insert a learned tanh gate on the cross-attention residual so the model can start from text-only behavior and grow into the image stream",
+        "Drop the self-attention layer",
         "Remove the FFN",
         "Use only one attention head"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Flamingo's tanh gate starts at zero, recovers text-only behavior at init, and gives the model a smooth ramp into cross-attention."
     }
   ]

--- a/phases/19-capstone-projects/62-vision-language-pretraining/quiz.json
+++ b/phases/19-capstone-projects/62-vision-language-pretraining/quiz.json
@@ -18,12 +18,12 @@
       "stage": "pre",
       "question": "In InfoNCE for a batch of N pairs, how many positive pairs and negative pairs are formed?",
       "options": [
-        "1 positive and N negatives",
         "N positives along the diagonal of the similarity matrix and N*(N-1) negatives off-diagonal",
+        "1 positive and N negatives",
         "N positives and N negatives",
         "N^2 positives"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "The N matching pairs sit on the diagonal; everything off-diagonal is a negative."
     },
     {
@@ -31,11 +31,11 @@
       "question": "Why is the contrastive temperature usually a learned parameter?",
       "options": [
         "PyTorch requires it",
-        "Hand-tuning is fragile; letting tau learn allows the model to find the right softmax peakedness as the embedding scale evolves during training",
         "Learned tau is faster on GPU",
+        "Hand-tuning is fragile; letting tau learn allows the model to find the right softmax peakedness as the embedding scale evolves during training",
         "It avoids using Adam"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "CLIP introduced learned log-tau so the contrastive softmax stays in the useful regime as embedding norms grow."
     },
     {
@@ -43,11 +43,11 @@
       "question": "Which sub-modules receive gradient from the LM loss but not from the contrastive loss?",
       "options": [
         "The vision encoder",
-        "The cross-attention decoder",
+        "The text-side encoder",
         "The MLP projector",
-        "The text-side encoder"
+        "The cross-attention decoder"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "Contrastive loss does not touch the decoder; LM loss does not touch the text-side mean-pool encoder."
     },
     {
@@ -66,12 +66,12 @@
       "stage": "post",
       "question": "Why is a 50-step demo on synthetic data enough to call the lesson complete?",
       "options": [
-        "The model reaches state of the art at 50 steps",
         "The demo proves the gradient plumbing works end to end; production training shape is identical but runs for millions of steps on real data",
+        "The model reaches state of the art at 50 steps",
         "50 steps is the maximum supported",
         "Real data would change the architecture"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "The dynamics demonstrated (both losses decrease, no NaN, stable tau) are the same dynamics a billion-image run would show; just scaled up."
     }
   ]

--- a/phases/19-capstone-projects/63-multimodal-eval/quiz.json
+++ b/phases/19-capstone-projects/63-multimodal-eval/quiz.json
@@ -18,12 +18,12 @@
       "stage": "pre",
       "question": "What is R@5 measuring in a 100-sample retrieval eval?",
       "options": [
-        "The fifth caption is always correct",
         "Fraction of queries whose correct match lands in the top 5 retrieved candidates out of 100",
+        "The fifth caption is always correct",
         "Five percent accuracy",
         "Five queries per second"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "R@K = fraction of queries with the target in the top K ranked candidates. Higher is better."
     },
     {
@@ -31,11 +31,11 @@
       "question": "Why does BLEU-4 take the geometric mean of 1- to 4-gram precisions instead of the arithmetic mean?",
       "options": [
         "Arithmetic is slower",
-        "Geometric mean is zero if any n-gram precision is zero, which is the strict matching property BLEU wants; smoothing handles the zero case",
         "Geometric mean is bigger",
+        "Geometric mean is zero if any n-gram precision is zero, which is the strict matching property BLEU wants; smoothing handles the zero case",
         "PyTorch supports only geometric mean"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "The geometric mean enforces that ALL n-gram orders contribute; a 4-gram precision of zero collapses the score before smoothing."
     },
     {
@@ -43,11 +43,11 @@
       "question": "What does the brevity penalty in BLEU-4 protect against?",
       "options": [
         "Long captions getting penalized",
-        "Short captions gaming high precision by emitting only safe high-frequency tokens; BP < 1 when generated < reference length",
+        "Tokenizer errors",
         "Memory leaks",
-        "Tokenizer errors"
+        "Short captions gaming high precision by emitting only safe high-frequency tokens; BP < 1 when generated < reference length"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "Without BP a one-word caption matching one reference word would score 1.0. BP shrinks the score for too-short generations."
     },
     {
@@ -66,12 +66,12 @@
       "stage": "post",
       "question": "Which eval surface uses no model embeddings and only id-level matching?",
       "options": [
-        "Retrieval",
         "VQA exact match: a predicted answer id is compared directly to a reference id with no embedding step",
+        "Retrieval",
         "BLEU-4",
         "Cosine similarity"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "VQA exact match is an integer comparison after the model emits its answer token; no embedding or similarity math involved."
     }
   ]

--- a/phases/19-capstone-projects/78-zero-parameter-sharding/quiz.json
+++ b/phases/19-capstone-projects/78-zero-parameter-sharding/quiz.json
@@ -18,12 +18,12 @@
       "stage": "pre",
       "question": "What is the per-step wire pattern of ZeRO stage 1?",
       "options": [
-        "One allreduce",
         "One reduce_scatter on gradients plus one allgather on updated parameters",
+        "One allreduce",
         "One broadcast",
         "Nothing"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Reduce_scatter delivers each rank only its gradient shard; allgather distributes the updated parameter shards back. Total bytes equal allreduce, memory is divided by N."
     },
     {
@@ -31,11 +31,11 @@
       "question": "Why is the per-step bandwidth the same as DDP?",
       "options": [
         "Magic",
-        "Allreduce equals reduce_scatter plus allgather in bandwidth; ZeRO splits that into two halves on different data",
         "ZeRO uses compression",
+        "Allreduce equals reduce_scatter plus allgather in bandwidth; ZeRO splits that into two halves on different data",
         "It is not the same"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Ring allreduce is implemented as reduce_scatter then allgather. ZeRO does the same two operations but the allgather rotates the updated parameters, not the summed gradient."
     },
     {
@@ -43,11 +43,11 @@
       "question": "For a 7B model with Adam in mixed precision on 8 ranks, what is the memory drop vs vanilla DDP?",
       "options": [
         "10%",
-        "Around 65% (vanilla 16P vs ZeRO-1 4P + 12P/N = 5.5P)",
+        "0%",
         "99%",
-        "0%"
+        "Around 65% (vanilla 16P vs ZeRO-1 4P + 12P/N = 5.5P)"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "Vanilla: 2P + 2P + 4P + 4P + 4P = 16P. ZeRO-1: 2P + 2P + (4P+4P+4P)/8 = 5.5P. Drop is (16-5.5)/16 = 65.6%."
     },
     {
@@ -66,12 +66,12 @@
       "stage": "post",
       "question": "Why does ZeRO require the optimiser state checkpoint to record which rank owns which shard?",
       "options": [
-        "Cosmetic",
         "Without per-rank ownership the saved state is unreadable at restart; resuming on the same world size needs to put the right shard back on the right rank",
+        "Cosmetic",
         "It does not",
         "Compression"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Lesson 80 builds the sharded checkpoint manifest precisely so a ZeRO run can resume on the same topology."
     }
   ]

--- a/phases/19-capstone-projects/79-pipeline-parallel/quiz.json
+++ b/phases/19-capstone-projects/79-pipeline-parallel/quiz.json
@@ -18,12 +18,12 @@
       "stage": "pre",
       "question": "Why is GPipe's activation memory proportional to M?",
       "options": [
-        "Bug",
         "All M microbatches' activations must be held until the matching backward; nothing frees until the drain begins",
+        "Bug",
         "Compiler limit",
         "Hardware limit"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "GPipe fills the pipeline with all forwards before any backward. Each in-flight microbatch carries its activations until its backward starts."
     },
     {
@@ -31,11 +31,11 @@
       "question": "How does 1F1B improve over GPipe?",
       "options": [
         "Lower bubble",
-        "Same bubble but bounded activation memory; once mb 0's forward reaches the last stage, its backward begins and activations free",
         "Higher throughput",
+        "Same bubble but bounded activation memory; once mb 0's forward reaches the last stage, its backward begins and activations free",
         "Smaller model"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Megatron-LM and PipeDream use 1F1B to bound activation memory by pipeline depth, not microbatch count."
     },
     {
@@ -43,11 +43,11 @@
       "question": "Why is equal compute per stage more important than equal parameter count?",
       "options": [
         "Aesthetic",
-        "The slowest stage gates every cycle; other stages idle waiting for it. Embedding layers have many parameters but little compute, so partitioning by parameter count misbalances the pipeline",
+        "Easier to code",
         "Memory aligned",
-        "Easier to code"
+        "The slowest stage gates every cycle; other stages idle waiting for it. Embedding layers have many parameters but little compute, so partitioning by parameter count misbalances the pipeline"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "Megatron-LM exposes --num-layers-per-stage as a list to allow uneven layer counts when per-layer cost differs."
     },
     {
@@ -66,12 +66,12 @@
       "stage": "post",
       "question": "Pipeline plus ZeRO-1 combines what two memory wins?",
       "options": [
-        "Compression and quantisation",
         "Per-stage parameter sharding (each rank only holds one stage of layers) plus per-rank optimiser sharding (each rank only holds 1/N of optimiser state for its stage)",
+        "Compression and quantisation",
         "Activation only",
         "Nothing"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Pipeline shards layers across ranks; ZeRO shards optimiser state within the data-parallel group at each pipeline rank. Both wins compound."
     }
   ]

--- a/phases/19-capstone-projects/80-checkpoint-sharded-resume/quiz.json
+++ b/phases/19-capstone-projects/80-checkpoint-sharded-resume/quiz.json
@@ -18,12 +18,12 @@
       "stage": "pre",
       "question": "What does the manifest record that the shard files cannot?",
       "options": [
-        "Random numbers",
         "world_size, schema version, per-shard sha256, and shard ownership; gives the loader a contract to validate before touching state",
+        "Random numbers",
         "Filesystem name",
         "Hostname"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Without the manifest the loader has to guess which shard belongs to which rank and trust the file count is right."
     },
     {
@@ -31,11 +31,11 @@
       "question": "Why write to <name>.tmp and rename instead of writing directly?",
       "options": [
         "Faster",
-        "POSIX rename within a filesystem is atomic: a crash mid-write leaves the previous file untouched. Direct writes can leave half-finished checkpoints that poison the next resume",
         "Required by torch",
+        "POSIX rename within a filesystem is atomic: a crash mid-write leaves the previous file untouched. Direct writes can leave half-finished checkpoints that poison the next resume",
         "Saves memory"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "Without atomic write a partial save plus an updated manifest pointing at it corrupts state on the next load."
     },
     {
@@ -43,11 +43,11 @@
       "question": "What does sha256 per shard defend against?",
       "options": [
         "Network attacks",
-        "Partial or corrupted writes; verifying the hash on load catches truncated shards before they touch model state",
+        "Memory leak",
         "Slowdown",
-        "Memory leak"
+        "Partial or corrupted writes; verifying the hash on load catches truncated shards before they touch model state"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "Without sha256 verification a truncated shard loads silently and corrupts the optimiser, surfacing later as NaN loss."
     },
     {
@@ -66,12 +66,12 @@
       "stage": "post",
       "question": "Why does production rotate checkpoints (keep last K)?",
       "options": [
-        "Aesthetic",
         "Without rotation the disk fills mid-run and the next checkpoint fails; rotation deletes the oldest before writing the new one, bounding disk usage",
+        "Aesthetic",
         "Compression",
         "It does not"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Real runs keep 3-5 recent checkpoints; the oldest is dropped before each new save so the disk budget is fixed."
     }
   ]

--- a/phases/19-capstone-projects/81-end-to-end-distributed-train/quiz.json
+++ b/phases/19-capstone-projects/81-end-to-end-distributed-train/quiz.json
@@ -18,12 +18,12 @@
       "stage": "pre",
       "question": "What four invariants does the demo verify?",
       "options": [
-        "Speed",
         "(a) loss runs to step 20 without NaN, (b) every rank's parameter norm agrees, (c) per-rank optimiser memory equals the ZeRO-1 formula, (d) the step-10 checkpoint reloads byte-equal",
+        "Speed",
         "Tokens per second",
         "Hardware"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "Each invariant catches a different composition bug: NaN catches divergence, norm-agree catches sync drift, memory catches sharding bugs, checkpoint catches write atomicity."
     },
     {
@@ -31,11 +31,11 @@
       "question": "Why is the model a tiny GPT instead of an MLP?",
       "options": [
         "Look fancy",
-        "GPT adds LayerNorm running statistics, embedding gradient shape, and softmax+cross-entropy edge cases that an MLP would hide",
         "Faster",
+        "GPT adds LayerNorm running statistics, embedding gradient shape, and softmax+cross-entropy edge cases that an MLP would hide",
         "Required"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": "MLP gradient sync was verified in lesson 77; the capstone needs a model with more edge cases to prove composition under realistic ops."
     },
     {
@@ -43,11 +43,11 @@
       "question": "What does self-terminating mean in this context?",
       "options": [
         "Process kills itself",
-        "Fixed step count (20), exit 0 on completion, no human in the loop; if any piece deadlocks the demo never returns and CI catches it",
+        "Manual",
         "Crash recovery",
-        "Manual"
+        "Fixed step count (20), exit 0 on completion, no human in the loop; if any piece deadlocks the demo never returns and CI catches it"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": "A bounded run with exit 0 lets the test rig assert termination; while-True loops mask deadlocks."
     },
     {
@@ -66,12 +66,12 @@
       "stage": "post",
       "question": "Why does production use wall-clock checkpoint cadence instead of step count?",
       "options": [
-        "Looks cleaner",
         "Step time varies with sequence length and microbatch count; a 10-minute cadence catches the same compute regardless of model size",
+        "Looks cleaner",
         "Faster",
         "Required by NCCL"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": "The lesson uses step-based for clarity; production runs typically save every 5-15 minutes of wall-clock."
     }
   ]

--- a/phases/19-capstone-projects/87-end-to-end-safety-gate/quiz.json
+++ b/phases/19-capstone-projects/87-end-to-end-safety-gate/quiz.json
@@ -18,12 +18,12 @@
       "stage": "pre",
       "question": "What is the goal of during-gen filtering?",
       "options": [
-        "To translate the output to another language",
         "To buffer chunks and terminate the stream early when a known harmful continuation appears, before the user sees it",
+        "To translate the output to another language",
         "To increase token throughput",
         "To replace the prompt with a refusal"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     },
     {
@@ -31,11 +31,11 @@
       "question": "How does the aggregator decide the final action?",
       "options": [
         "By averaging the confidences of every signal",
-        "By taking the maximum severity across detector, token-filter, classifier, and rules signals and mapping it to block, redact, warn, or allow",
         "By calling the model a second time",
+        "By taking the maximum severity across detector, token-filter, classifier, and rules signals and mapping it to block, redact, warn, or allow",
         "By looking only at the rules engine"
       ],
-      "correct": 1,
+      "correct": 2,
       "explanation": ""
     },
     {
@@ -43,11 +43,11 @@
       "question": "Why does the gate emit a structured RequestTrace per request?",
       "options": [
         "To slow the system down",
-        "To give a reviewer a per-checkpoint audit trail so a regression in any layer can be traced to the right module",
+        "To replicate the trace into the prompt",
         "To replace logging",
-        "To replicate the trace into the prompt"
+        "To give a reviewer a per-checkpoint audit trail so a regression in any layer can be traced to the right module"
       ],
-      "correct": 1,
+      "correct": 3,
       "explanation": ""
     },
     {
@@ -66,12 +66,12 @@
       "stage": "post",
       "question": "Why does the demo intentionally let some encoding-trick prompts reach during-gen?",
       "options": [
-        "Because encoding tricks are not real attacks",
         "Because the input pipeline does not always normalize them in time; the during-gen filter is the defense in depth that catches the leaked continuation",
+        "Because encoding tricks are not real attacks",
         "Because the model refuses them anyway",
         "Because the rules engine handles encoding"
       ],
-      "correct": 1,
+      "correct": 0,
       "explanation": ""
     }
   ]

--- a/scripts/audit_lessons.py
+++ b/scripts/audit_lessons.py
@@ -191,6 +191,27 @@ def check_quiz(audit: Audit, lesson: Path) -> None:
                 quiz,
                 f"question[{idx}] correct={correct!r} not a valid index in options[0..{len(options) - 1}]",
             )
+    check_quiz_answer_distribution(audit, lesson, quiz, questions)
+
+
+def check_quiz_answer_distribution(
+    audit: Audit, lesson: Path, quiz: Path, questions: list[object]
+) -> None:
+    correct_indices: list[int] = []
+    for q in questions:
+        if not isinstance(q, dict):
+            continue
+        options = q.get("options")
+        correct = q.get("correct")
+        if isinstance(options, list) and isinstance(correct, int) and 0 <= correct < len(options):
+            correct_indices.append(correct)
+    if len(correct_indices) >= 3 and len(set(correct_indices)) == 1:
+        audit.add(
+            "L011",
+            lesson,
+            quiz,
+            f"all {len(correct_indices)} valid questions use answer index {correct_indices[0]}",
+        )
 
 
 def check_internal_links(audit: Audit, lesson: Path, text: str) -> None:

--- a/scripts/list_quiz_answer_patterns.py
+++ b/scripts/list_quiz_answer_patterns.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""List answer-index patterns for lesson quizzes."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+PHASES_DIR = ROOT / "phases"
+
+
+def quiz_questions(path: Path) -> list[dict]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(data, dict):
+        questions = data.get("questions", [])
+    elif isinstance(data, list):
+        questions = data
+    else:
+        questions = []
+    return [q for q in questions if isinstance(q, dict)]
+
+
+def correct_pattern(path: Path) -> list[int]:
+    pattern: list[int] = []
+    for question in quiz_questions(path):
+        correct = question.get("correct")
+        options = question.get("options")
+        if isinstance(correct, int) and isinstance(options, list) and 0 <= correct < len(options):
+            pattern.append(correct)
+    return pattern
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--all-same",
+        action="store_true",
+        help="show only quizzes with one repeated answer index",
+    )
+    parser.add_argument(
+        "--summary",
+        action="store_true",
+        help="show pattern counts instead of one row per quiz",
+    )
+    args = parser.parse_args()
+
+    quiz_paths = sorted(PHASES_DIR.glob("**/quiz.json"))
+    rows: list[tuple[str, list[int]]] = []
+    for path in quiz_paths:
+        pattern = correct_pattern(path)
+        if not pattern:
+            continue
+        if args.all_same and len(set(pattern)) != 1:
+            continue
+        rows.append((path.relative_to(ROOT).as_posix(), pattern))
+
+    print(f"total={len(quiz_paths)} matched={len(rows)}")
+    if args.summary:
+        counts = Counter(",".join(str(i) for i in pattern) for _, pattern in rows)
+        for pattern, count in counts.most_common():
+            print(f"{count}\t{pattern}")
+    else:
+        for rel_path, pattern in rows:
+            print(f"{rel_path}\t{','.join(str(i) for i in pattern)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/site/lesson.html
+++ b/site/lesson.html
@@ -3305,66 +3305,65 @@
         if (pathLower.indexOf('math') >= 0 || pathLower.indexOf('linear-algebra') >= 0 || pathLower.indexOf('calculus') >= 0) {
           return [
             { q: 'What does a dot product measure between two vectors?', opts: ['Their sum', 'How aligned they are', 'Their cross product', 'The distance between them'], answer: 1, explain: 'The dot product measures the similarity or alignment between two vectors. When it is zero, the vectors are orthogonal.' },
-            { q: 'What does the gradient of a function point toward?', opts: ['The minimum', 'The steepest ascent', 'The nearest saddle point', 'A random direction'], answer: 1, explain: 'The gradient always points in the direction of steepest increase. Gradient descent moves opposite to the gradient to find minima.' },
-            { q: 'A matrix with shape (3, 5) multiplied by (5, 2) produces what shape?', opts: ['(3, 2)', '(5, 5)', '(3, 5)', '(2, 3)'], answer: 0, explain: 'Matrix multiplication: (m, n) x (n, p) = (m, p). So (3, 5) x (5, 2) = (3, 2).' }
+            { q: 'What does the gradient of a function point toward?', opts: ['The steepest ascent', 'The minimum', 'The nearest saddle point', 'A random direction'], answer: 0, explain: 'The gradient always points in the direction of steepest increase. Gradient descent moves opposite to the gradient to find minima.' },
+            { q: 'A matrix with shape (3, 5) multiplied by (5, 2) produces what shape?', opts: ['(3, 5)', '(5, 5)', '(3, 2)', '(2, 3)'], answer: 2, explain: 'Matrix multiplication: (m, n) x (n, p) = (m, p). So (3, 5) x (5, 2) = (3, 2).' }
           ];
         }
 
         if (pathLower.indexOf('ml') >= 0 || pathLower.indexOf('regression') >= 0 || pathLower.indexOf('classification') >= 0 || pathLower.indexOf('supervised') >= 0) {
           return [
             { q: 'What is the purpose of a loss function in machine learning?', opts: ['To generate data', 'To measure how wrong predictions are', 'To select features', 'To split data'], answer: 1, explain: 'A loss function quantifies the difference between predicted and actual values. The optimizer minimizes this value during training.' },
-            { q: 'Why do we split data into train and test sets?', opts: ['To save memory', 'To evaluate generalization on unseen data', 'To make training faster', 'To reduce the dataset size'], answer: 1, explain: 'The test set acts as unseen data, revealing whether the model memorized training data or learned generalizable patterns.' },
-            { q: 'What does overfitting mean?', opts: ['The model is too simple', 'The model memorizes training data but fails on new data', 'The model trains too slowly', 'The loss is too low'], answer: 1, explain: 'Overfitting occurs when a model performs well on training data but poorly on new data because it learned noise rather than signal.' }
+            { q: 'Why do we split data into train and test sets?', opts: ['To evaluate generalization on unseen data', 'To save memory', 'To make training faster', 'To reduce the dataset size'], answer: 0, explain: 'The test set acts as unseen data, revealing whether the model memorized training data or learned generalizable patterns.' },
+            { q: 'What does overfitting mean?', opts: ['The model is too simple', 'The model trains too slowly', 'The model memorizes training data but fails on new data', 'The loss is too low'], answer: 2, explain: 'Overfitting occurs when a model performs well on training data but poorly on new data because it learned noise rather than signal.' }
           ];
         }
 
         if (pathLower.indexOf('deep-learning') >= 0 || pathLower.indexOf('neural') >= 0 || pathLower.indexOf('backprop') >= 0 || pathLower.indexOf('activation') >= 0) {
           return [
             { q: 'What does backpropagation compute?', opts: ['Forward predictions', 'The gradient of the loss with respect to each weight', 'The learning rate', 'New training data'], answer: 1, explain: 'Backpropagation uses the chain rule to compute how much each weight contributed to the error, then adjusts weights accordingly.' },
-            { q: 'Why do neural networks need non-linear activation functions?', opts: ['To speed up training', 'Without them, stacking layers is equivalent to a single linear layer', 'To reduce memory usage', 'To normalize outputs'], answer: 1, explain: 'Without non-linearities, any composition of linear layers collapses to a single linear transformation. Activations like ReLU let the network learn complex patterns.' },
-            { q: 'What does the learning rate control?', opts: ['How many epochs to train', 'The size of each weight update step', 'The number of layers', 'The batch size'], answer: 1, explain: 'The learning rate scales the gradient update. Too large causes divergence, too small causes slow or stuck training.' }
+            { q: 'Why do neural networks need non-linear activation functions?', opts: ['Without them, stacking layers is equivalent to a single linear layer', 'To speed up training', 'To reduce memory usage', 'To normalize outputs'], answer: 0, explain: 'Without non-linearities, any composition of linear layers collapses to a single linear transformation. Activations like ReLU let the network learn complex patterns.' },
+            { q: 'What does the learning rate control?', opts: ['How many epochs to train', 'The number of layers', 'The size of each weight update step', 'The batch size'], answer: 2, explain: 'The learning rate scales the gradient update. Too large causes divergence, too small causes slow or stuck training.' }
           ];
         }
 
         if (pathLower.indexOf('llm') >= 0 || pathLower.indexOf('transformer') >= 0 || pathLower.indexOf('attention') >= 0 || pathLower.indexOf('tokeniz') >= 0 || pathLower.indexOf('fine-tun') >= 0) {
           return [
             { q: 'What does self-attention allow a transformer to do?', opts: ['Process tokens in order', 'Weight the importance of every token relative to every other token', 'Reduce vocabulary size', 'Compress the model'], answer: 1, explain: 'Self-attention computes pairwise relevance scores across all positions, allowing the model to relate distant tokens without recurrence.' },
-            { q: 'Why do LLMs use tokenizers instead of raw characters?', opts: ['Characters are too large', 'Tokens compress frequent patterns into single units, reducing sequence length', 'Tokenizers are faster to train', 'Characters cannot be embedded'], answer: 1, explain: 'Subword tokenizers like BPE balance vocabulary size against sequence length, making common words single tokens while handling rare words as pieces.' },
-            { q: 'What is the key difference between pre-training and fine-tuning?', opts: ['Pre-training uses labeled data', 'Pre-training learns general language; fine-tuning adapts to a specific task', 'Fine-tuning uses more data', 'There is no difference'], answer: 1, explain: 'Pre-training learns language patterns from massive unlabeled text. Fine-tuning takes that foundation and specializes it on smaller, task-specific data.' }
+            { q: 'Why do LLMs use tokenizers instead of raw characters?', opts: ['Tokens compress frequent patterns into single units, reducing sequence length', 'Characters are too large', 'Tokenizers are faster to train', 'Characters cannot be embedded'], answer: 0, explain: 'Subword tokenizers like BPE balance vocabulary size against sequence length, making common words single tokens while handling rare words as pieces.' },
+            { q: 'What is the key difference between pre-training and fine-tuning?', opts: ['Pre-training uses labeled data', 'Fine-tuning uses more data', 'Pre-training learns general language; fine-tuning adapts to a specific task', 'There is no difference'], answer: 2, explain: 'Pre-training learns language patterns from massive unlabeled text. Fine-tuning takes that foundation and specializes it on smaller, task-specific data.' }
           ];
         }
 
         if (pathLower.indexOf('rag') >= 0 || pathLower.indexOf('retrieval') >= 0 || pathLower.indexOf('embed') >= 0 || pathLower.indexOf('vector') >= 0) {
           return [
             { q: 'What is the core idea behind RAG?', opts: ['Training a larger model', 'Retrieving relevant context before generating a response', 'Using more GPUs', 'Reducing model size'], answer: 1, explain: 'RAG (Retrieval-Augmented Generation) grounds LLM responses in retrieved documents, reducing hallucination and enabling knowledge updates without retraining.' },
-            { q: 'What do embedding models produce?', opts: ['Text summaries', 'Dense vector representations of text', 'Token counts', 'Grammar corrections'], answer: 1, explain: 'Embedding models map text into fixed-dimensional vectors where semantic similarity corresponds to geometric proximity.' },
-            { q: 'Why use cosine similarity for comparing embeddings?', opts: ['It is the only metric', 'It measures angular similarity regardless of vector magnitude', 'It is faster than dot product', 'It works with integers only'], answer: 1, explain: 'Cosine similarity normalizes for magnitude, focusing on direction. Two texts about the same topic will have high cosine similarity regardless of length.' }
+            { q: 'What do embedding models produce?', opts: ['Dense vector representations of text', 'Text summaries', 'Token counts', 'Grammar corrections'], answer: 0, explain: 'Embedding models map text into fixed-dimensional vectors where semantic similarity corresponds to geometric proximity.' },
+            { q: 'Why use cosine similarity for comparing embeddings?', opts: ['It is the only metric', 'It is faster than dot product', 'It measures angular similarity regardless of vector magnitude', 'It works with integers only'], answer: 2, explain: 'Cosine similarity normalizes for magnitude, focusing on direction. Two texts about the same topic will have high cosine similarity regardless of length.' }
           ];
         }
 
         if (pathLower.indexOf('agent') >= 0 || pathLower.indexOf('tool') >= 0 || pathLower.indexOf('mcp') >= 0) {
           return [
             { q: 'What distinguishes an AI agent from a simple chatbot?', opts: ['Agents are faster', 'Agents can take actions and use tools autonomously', 'Agents use bigger models', 'There is no difference'], answer: 1, explain: 'Agents have a loop: observe, decide, act. They can call tools, read files, search the web, and chain multiple steps to complete complex tasks.' },
-            { q: 'What is MCP (Model Context Protocol)?', opts: ['A model training format', 'A standardized protocol for connecting AI models to tools and data sources', 'A compression algorithm', 'A testing framework'], answer: 1, explain: 'MCP provides a universal interface between AI assistants and external tools/data, replacing one-off integrations with a standard protocol.' },
-            { q: 'Why is tool-use important for LLMs?', opts: ['It reduces cost', 'It lets LLMs access real-time information and take actions beyond text generation', 'It makes responses shorter', 'It removes hallucinations entirely'], answer: 1, explain: 'Tools extend LLMs beyond their training data cutoff, enabling real-time lookups, calculations, code execution, and interaction with external systems.' }
+            { q: 'What is MCP (Model Context Protocol)?', opts: ['A standardized protocol for connecting AI models to tools and data sources', 'A model training format', 'A compression algorithm', 'A testing framework'], answer: 0, explain: 'MCP provides a universal interface between AI assistants and external tools/data, replacing one-off integrations with a standard protocol.' },
+            { q: 'Why is tool-use important for LLMs?', opts: ['It reduces cost', 'It makes responses shorter', 'It lets LLMs access real-time information and take actions beyond text generation', 'It removes hallucinations entirely'], answer: 2, explain: 'Tools extend LLMs beyond their training data cutoff, enabling real-time lookups, calculations, code execution, and interaction with external systems.' }
           ];
         }
 
         if (pathLower.indexOf('eval') >= 0 || pathLower.indexOf('safety') >= 0 || pathLower.indexOf('alignment') >= 0 || pathLower.indexOf('deploy') >= 0) {
           return [
             { q: 'Why are evals critical for production AI systems?', opts: ['To save money', 'To measure performance objectively before and after changes', 'To make the model bigger', 'Evals are optional'], answer: 1, explain: 'Evals are the tests of AI engineering. Without them, you cannot know if a change improved or regressed quality. They should run on every code change.' },
-            { q: 'What does "alignment" mean in AI safety?', opts: ['Aligning text on screen', 'Ensuring AI systems act according to human intentions and values', 'Making models faster', 'Using the same training data'], answer: 1, explain: 'Alignment ensures that as AI systems become more capable, they remain helpful, honest, and harmless, acting in accordance with human goals.' },
-            { q: 'What is a guardrail in the context of deployed LLMs?', opts: ['A physical barrier', 'A check that prevents harmful, off-topic, or policy-violating outputs', 'A backup model', 'A caching layer'], answer: 1, explain: 'Guardrails filter inputs and outputs at runtime, catching toxicity, prompt injection, PII leaks, and other risks before they reach the user.' }
+            { q: 'What does "alignment" mean in AI safety?', opts: ['Ensuring AI systems act according to human intentions and values', 'Aligning text on screen', 'Making models faster', 'Using the same training data'], answer: 0, explain: 'Alignment ensures that as AI systems become more capable, they remain helpful, honest, and harmless, acting in accordance with human goals.' },
+            { q: 'What is a guardrail in the context of deployed LLMs?', opts: ['A physical barrier', 'A backup model', 'A check that prevents harmful, off-topic, or policy-violating outputs', 'A caching layer'], answer: 2, explain: 'Guardrails filter inputs and outputs at runtime, catching toxicity, prompt injection, PII leaks, and other risks before they reach the user.' }
           ];
         }
 
         return [
           { q: 'What does "from scratch" mean in this course?', opts: ['Using no computer', 'Building each concept by implementing it yourself, not just reading theory', 'Starting from assembly language', 'Only using pen and paper'], answer: 1, explain: 'This course follows a Build-Use-Ship methodology: first understand by building it, then apply it, then ship it as a real artifact.' },
-          { q: 'Why does this course combine math, ML, and engineering?', opts: ['To make it longer', 'Because real AI engineering requires all three to build production systems', 'Math is just for fun', 'Engineering is optional'], answer: 1, explain: 'Production AI systems require mathematical foundations (for understanding), ML knowledge (for modeling), and engineering skills (for deployment and reliability).' },
+          { q: 'Why does this course combine math, ML, and engineering?', opts: ['Because real AI engineering requires all three to build production systems', 'To make it longer', 'Math is just for fun', 'Engineering is optional'], answer: 0, explain: 'Production AI systems require mathematical foundations (for understanding), ML knowledge (for modeling), and engineering skills (for deployment and reliability).' },
           { q: 'What is the "Ship" step in the Build-Use-Ship framework?', opts: ['Mailing physical goods', 'Creating a reusable artifact like a prompt, skill, or tool from what you learned', 'Publishing a paper', 'Deleting your code'], answer: 2, explain: 'The Ship step turns your learning into something tangible: a prompt, skill file, MCP tool, or CLI utility that others (or future you) can use immediately.' }
         ];
       }
-
       function lessonQuizPanelQuestions(data) {
         var source = data && (data.questions || data);
         if (!Array.isArray(source)) return [];


### PR DESCRIPTION
<!-- Thanks for contributing. Fill out what applies. Delete sections that don't. -->

## What this PR does

Varies quiz correct-answer positions so the correct option is no longer consistently B across affected lessons.

## Kind of change

- [ ] New lesson
- [x] Fix to an existing lesson
- [ ] Translation
- [ ] New output (prompt, skill, agent, MCP server)
- [ ] Docs / website / tooling

## Checklist

- [x] Code runs without errors with the listed dependencies
- [x] No comments in code files (docs explain, code is self-explanatory)
- [ ] Built from scratch first, then shown with a framework (for new lessons)
- [x] Lesson folder matches `LESSON_TEMPLATE.md` structure
- [x] ROADMAP.md row for the lesson is a markdown link (`[Name](phases/...)`), not bare text
- [ ] One lesson per commit (atomic per-lesson rule)
- [x] Tested locally / code output matches what `docs/en.md` claims

## Phase / lesson

Multiple lessons, including:
  - Phase 00 · 02-git-and-collaboration
  - Phase 01 · 02-vectors-matrices-operations
  - Phase 01 · 03-matrix-transformations

## Notes for reviewer

Verified all quiz files under `phases/`: 338 total quizzes checked, and 0 still have every correct answer at option B.

Closes #368 