### PR TITLE
fix(phase-01/15): chi-squared p-value was 7.5x too large

### DIFF
--- a/phases/01-math-foundations/15-statistics-for-ml/code/statistics.py
+++ b/phases/01-math-foundations/15-statistics-for-ml/code/statistics.py
@@ -217,17 +217,45 @@ def chi_squared_p_value(chi2, df):
 def _lower_incomplete_gamma_ratio(a, x):
     if x <= 0:
         return 0.0
-    n_steps = 500
-    dt = x / n_steps
-    total = 0.0
-    for i in range(n_steps):
-        t = (i + 0.5) * dt
-        if t > 0:
-            total += math.exp((a - 1) * math.log(t) - t) * dt
-    gamma_a = math.exp(math.lgamma(a))
-    if gamma_a == 0:
-        return 0.0
-    return total / gamma_a
+    if x < a + 1.0:
+        return _gamma_series(a, x)
+    return 1.0 - _gamma_continued_fraction(a, x)
+
+
+def _gamma_series(a, x, max_iter=1000, tol=1e-16):
+    term = 1.0 / a
+    total = term
+    ap = a
+    for _ in range(max_iter):
+        ap += 1.0
+        term *= x / ap
+        total += term
+        if abs(term) < abs(total) * tol:
+            break
+    return total * math.exp(-x + a * math.log(x) - math.lgamma(a))
+
+
+def _gamma_continued_fraction(a, x, max_iter=1000, tol=1e-16):
+    tiny = 1e-300
+    b = x + 1.0 - a
+    c = 1.0 / tiny
+    d = 1.0 / b
+    h = d
+    for i in range(1, max_iter + 1):
+        an = -i * (i - a)
+        b += 2.0
+        d = an * d + b
+        if abs(d) < tiny:
+            d = tiny
+        c = b + an / c
+        if abs(c) < tiny:
+            c = tiny
+        d = 1.0 / d
+        delta = d * c
+        h *= delta
+        if abs(delta - 1.0) < tol:
+            break
+    return h * math.exp(-x + a * math.log(x) - math.lgamma(a))
 
 
 def bootstrap_statistic(data, stat_func, n_bootstrap=5000, ci=95):


### PR DESCRIPTION
## What this PR does

Replaces the Riemann-sum approximation of the regularized lower incomplete gamma in
`phases/01-math-foundations/15-statistics-for-ml/code/statistics.py`, so `chi_squared_test` returns
the correct p-value and stops overflowing at large `df`.

Fixes #375

## Kind of change

- [ ] New lesson
- [x] Fix to an existing lesson
- [ ] Translation
- [ ] New output (prompt, skill, agent, MCP server)
- [ ] Docs / website / tooling

## Checklist

- [x] Code runs without errors with the listed dependencies
- [x] No comments in code files (docs explain, code is self-explanatory)
- [ ] Built from scratch first, then shown with a framework (for new lessons)
- [x] Lesson folder matches `LESSON_TEMPLATE.md` structure
- [ ] ROADMAP.md row for the lesson is a markdown link (`[Name](phases/...)`), not bare text
- [x] One lesson per commit (atomic per-lesson rule)
- [x] Tested locally / code output matches what `docs/en.md` claims

## Phase / lesson

Phase 1 · 15-statistics-for-ml

## The problem

`_lower_incomplete_gamma_ratio` used a 500-step uniform midpoint Riemann sum. At `a = 0.5` (df = 1)
the integrand `t^(a-1) e^-t` has an integrable pole at `t = 0`, which a uniform grid cannot resolve,
so the sum under-integrated and `1 - ratio` came out too large:

```
chi_squared_test([120, 80], [100, 100])
  before : p = 0.03522706238876505
  exact  : p = 0.004677734981047276      (7.53x too large)
```

That is the exact table `docs/en.md:245-248` prints, right above the claim "With 1 degree of freedom,
chi^2 = 8 gives p < 0.005. The difference is significant." The code contradicted it.

Separately, line 227 divided by `math.exp(math.lgamma(a))`, which overflows for `df >= 344`:

```
chi_squared_p_value(450, 400)  ->  OverflowError: math range error
```

The shipped demo uses `df = 3`, where the quadrature error is only ~0.2%, which is why this went
unnoticed.

## The fix

The standard split for the regularized lower incomplete gamma, no new dependencies:

- power series `P(a, x)` for `x < a + 1`
- Lentz continued fraction for `Q(a, x)` otherwise

Both scale by `exp(-x + a*ln(x) - lgamma(a))`, so `lgamma` never leaves the exponent and the
`df >= 344` overflow is gone.

## Verification

Against `scipy.special.gammainc` as a reference oracle (used only to check, **not** added as a
dependency) over 130 `(a, x)` pairs spanning `a ∈ [0.5, 100000]`, `x ∈ [0.01, 50000]`:

```
max absolute error = 7.8e-16
```

Symptom checks:

```
chi_squared_test([120, 80], [100, 100])['p_value'] = 0.004677734981047288   (docs' "p < 0.005" ✓)
chi_squared_p_value(450, 400)                      = 0.04249935069791977    (was OverflowError)
```

`python3 scripts/audit_lessons.py` → `503 lesson(s) checked, 0 issue(s)`.

## Notes for reviewer

**The lesson's printed demo output is byte-identical before and after this change** — I diffed the
full `python statistics.py` transcript, zero changed lines. The demo runs at `df = 3` where the old
error was ~0.2%, below the `.4f` the demo prints. So this is a correctness fix with no visible churn
in the lesson output.

`_regularized_beta` just above has the same class of defect (a 200-step uniform midpoint sum) and
affects the t-test p-values. I've filed that separately and will send it as its own PR, per the
one-contribution-per-PR rule — it touches a different function and does change printed output, so
it deserves its own review.
