### PR TITLE
fix(phase-01/15): t-test p-value collapsed to 0 at large df

### DIFF
--- a/phases/01-math-foundations/15-statistics-for-ml/code/statistics.py
+++ b/phases/01-math-foundations/15-statistics-for-ml/code/statistics.py
@@ -158,20 +158,57 @@ def _regularized_beta(x, a, b):
         return 0.0
     if x >= 1:
         return 1.0
-    n_steps = 200
-    total = 0.0
-    dt = x / n_steps
-    for i in range(n_steps):
-        t = (i + 0.5) * dt
-        total += t ** (a - 1) * (1 - t) ** (b - 1) * dt
-    beta_val = _beta_function(a, b)
-    if beta_val == 0:
-        return 0.0
-    return total / beta_val
+    front = math.exp(
+        a * math.log(x) + b * math.log(1.0 - x) - _log_beta_function(a, b)
+    )
+    if x < (a + 1.0) / (a + b + 2.0):
+        return front * _beta_continued_fraction(x, a, b) / a
+    return 1.0 - front * _beta_continued_fraction(1.0 - x, b, a) / b
+
+
+def _beta_continued_fraction(x, a, b, max_iter=300, tol=1e-15):
+    tiny = 1e-300
+    qab = a + b
+    qap = a + 1.0
+    qam = a - 1.0
+    c = 1.0
+    d = 1.0 - qab * x / qap
+    if abs(d) < tiny:
+        d = tiny
+    d = 1.0 / d
+    h = d
+    for m in range(1, max_iter + 1):
+        m2 = 2 * m
+        num = m * (b - m) * x / ((qam + m2) * (a + m2))
+        d = 1.0 + num * d
+        if abs(d) < tiny:
+            d = tiny
+        c = 1.0 + num / c
+        if abs(c) < tiny:
+            c = tiny
+        d = 1.0 / d
+        h *= d * c
+        num = -(a + m) * (qab + m) * x / ((a + m2) * (qap + m2))
+        d = 1.0 + num * d
+        if abs(d) < tiny:
+            d = tiny
+        c = 1.0 + num / c
+        if abs(c) < tiny:
+            c = tiny
+        d = 1.0 / d
+        delta = d * c
+        h *= delta
+        if abs(delta - 1.0) < tol:
+            break
+    return h
+
+
+def _log_beta_function(a, b):
+    return math.lgamma(a) + math.lgamma(b) - math.lgamma(a + b)
 
 
 def _beta_function(a, b):
-    return math.exp(math.lgamma(a) + math.lgamma(b) - math.lgamma(a + b))
+    return math.exp(_log_beta_function(a, b))
 
 
 def p_value_two_sided(t_val, df):
@@ -383,7 +420,7 @@ def run_multiple_ab_tests(
     }
 
 
-def statistical_vs_practical_significance(small_n=30, large_n=10000, effect=0.1):
+def statistical_vs_practical_significance(small_n=30, large_n=100000, effect=0.1):
     small_a = generate_normal(small_n, 50, 10)
     small_b = generate_normal(small_n, 50 + effect, 10)
     small_result = two_sample_ttest(small_a, small_b)
@@ -577,7 +614,7 @@ if __name__ == "__main__":
     print("STATISTICAL VS PRACTICAL SIGNIFICANCE")
     print("=" * 60)
     result = statistical_vs_practical_significance(
-        small_n=30, large_n=10000, effect=0.1
+        small_n=30, large_n=100000, effect=0.1
     )
     print(f"\nTrue effect: {result['true_effect']} (tiny)")
     print(f"\nSmall sample (n={result['small_sample']['n']}):")


### PR DESCRIPTION
## What this PR does

Replaces the Riemann-sum approximation of the regularized incomplete beta in
`phases/01-math-foundations/15-statistics-for-ml/code/statistics.py`, so t-test p-values are correct
at large `df` — and adjusts the `large_n` demo parameter so the lesson's headline point still holds
once the p-values are right.

Fixes #377

## Kind of change

- [ ] New lesson
- [x] Fix to an existing lesson
- [ ] Translation
- [ ] New output (prompt, skill, agent, MCP server)
- [ ] Docs / website / tooling

## Checklist

- [x] Code runs without errors with the listed dependencies
- [x] No comments in code files (docs explain, code is self-explanatory)
- [ ] Built from scratch first, then shown with a framework (for new lessons)
- [x] Lesson folder matches `LESSON_TEMPLATE.md` structure
- [ ] ROADMAP.md row for the lesson is a markdown link (`[Name](phases/...)`), not bare text
- [x] One lesson per commit (atomic per-lesson rule)
- [x] Tested locally / code output matches what `docs/en.md` claims

## Phase / lesson

Phase 1 · 15-statistics-for-ml

## The problem

`_regularized_beta` used a 200-step uniform midpoint Riemann sum. `t_cdf_approx` calls it with
`x = df/(df + t²)` and `a = df/2`, so as `df` grows the integrand collapses into a needle at the
right endpoint and 200 uniform nodes miss it:

```
df = 19992, t = 1.855
  before : p = 1.3312018154465477e-11
  exact  : p = 0.06361093769844328       # not significant at alpha = 0.05
```

This made the lesson's headline demo an artifact of the bug. `STATISTICAL VS PRACTICAL
SIGNIFICANCE` printed `p-value: 0.0000 / Significant: True` only because the quadrature had
collapsed to zero. The `n = 200` A/B path was also ~13% off (`0.4082` vs `0.4710`).

## The fix

1. **`_regularized_beta`** → the Lentz continued fraction for the regularized incomplete beta, with
   the standard `x < (a+1)/(a+b+2)` symmetry switch and the front factor computed in log space.
   No new dependencies. `_beta_function` is kept as a thin wrapper over the new
   `_log_beta_function` so nothing else changes shape.

2. **`large_n`: 10000 → 100000** in `statistical_vs_practical_significance` and its call site.

Point 2 needs justifying, since it's a demo parameter rather than a bug per se. With correct
p-values, `effect = 0.1` against `sigma = 10` at `n = 10000` per group is genuinely *not*
significant, so the fix alone would have made the demo print:

```
Large sample (n=10000):
  p-value:  0.0636
  Significant: False        <-- directly above "Lesson: large n can make a negligible effect 'significant'."
```

…which contradicts both its own next line and `docs/en.md:487`. At `n = 100000` the documented point
holds on the merits, with the effect size *more* clearly negligible than before:

```
Large sample (n=100000):
  p-value:  0.0019
  Cohen's d: -0.0139 (negligible)
  Significant: True
```

Runtime cost of the larger sample is ~0.1s.

## Verification

Against scipy as a reference oracle (used only to check, **not** added as a dependency):

```
regularized incomplete beta vs scipy.special.betainc
  216 cases, a ∈ [0.5, 100000], b ∈ {0.5, 1, 2}, x ∈ [1e-6, 1-1e-12]
  max absolute error = 2.5e-10

p_value_two_sided vs 2 * scipy.stats.t.sf
  63 cases, df ∈ [1, 100000], t ∈ [0.1, 16.5]
  max absolute error = 2.0e-11
```

`python3 scripts/audit_lessons.py` → `503 lesson(s) checked, 0 issue(s)`.

## Notes for reviewer

Full `python statistics.py` transcript diff — every changed line, nothing omitted:

```
 A/B TEST         p-value:      0.4082  ->  0.4710    corrected (was ~13% off)
 STAT-VS-PRACTICAL  header:    n=10000  ->  n=100000
 STAT-VS-PRACTICAL  p-value:    0.0000  ->  0.0019
 STAT-VS-PRACTICAL  Cohen's d: -0.0262  -> -0.0139    (still "negligible")
 POWER  n=50:                    0.34   ->  0.32      (63/200)
 POWER  n=200:                   0.85   ->  0.84      (168/200)
```

The two POWER lines move because the larger `large_n` draw shifts the shared `random.seed(42)`
stream, not because power analysis itself changed; the new values still bracket the textbook
expectations for `d = 0.3` at those sample sizes. `Significant: True` on the large-sample row is
unchanged — that's the whole point of the `large_n` bump.

There is a companion PR against this same file for `_lower_incomplete_gamma_ratio` — the same class
of defect in the chi-squared path. They're deliberately kept separate: different function, and
unlike that one, this change does move printed output, so it warrants its own review. Both branches
are cut from `main` and touch disjoint hunks, so they're independent — whichever lands second may
want a trivial rebase.
