### PR TITLE
fix(phase-modal): themed scrollbar matches theme

### DIFF
--- a/site/style.css
+++ b/site/style.css
@@ -452,6 +452,8 @@ p.dropcap::first-letter {
   padding: 36px 32px 28px;
   transform: translateY(16px);
   transition: transform 0.25s ease;
+  scrollbar-width: thin;
+  scrollbar-color: var(--rule-soft) transparent;
 }
 
 .modal-overlay.open .modal {
@@ -1330,6 +1332,22 @@ body.js-anim .toc-row.in-view {
   flex: 1;
   min-height: 0;
   overscroll-behavior: contain;
+}
+
+.modal::-webkit-scrollbar       { width: 10px; transition: width 0.15s ease; }
+.modal::-webkit-scrollbar-track { background: var(--bg-surface); border-radius: 5px; }
+.modal::-webkit-scrollbar-thumb { background: var(--rule-soft); border-radius: 5px; border: 2px solid var(--bg-surface); transition: background 0.15s ease; }
+.modal:hover::-webkit-scrollbar { width: 14px; }
+.modal::-webkit-scrollbar-thumb:hover { background: var(--ink-mute); }
+
+.catalog-table-wrap::-webkit-scrollbar       { width: 8px; height: 8px; transition: width 0.15s ease, height 0.15s ease; }
+.catalog-table-wrap::-webkit-scrollbar-track { background: var(--bg-surface); border-radius: 4px; }
+.catalog-table-wrap::-webkit-scrollbar-thumb { background: var(--rule-soft); border-radius: 4px; border: 2px solid var(--bg-surface); transition: background 0.15s ease; }
+.catalog-table-wrap:hover::-webkit-scrollbar { width: 12px; height: 12px; }
+.catalog-table-wrap::-webkit-scrollbar-thumb:hover { background: var(--ink-mute); }
+.catalog-table-wrap {
+  scrollbar-width: thin;
+  scrollbar-color: var(--rule-soft) transparent;
 }
 
 .cp-results::-webkit-scrollbar       { width: 4px; }


### PR DESCRIPTION
## What this fixes

When opening phase content on the homepage or scrolling the lesson catalog table, the scrollbars appeared as default browser scrollbars that did not match the site's light/dark theme. This created a visual inconsistency, especially noticeable in dark mode where the default white scrollbar clashed with the dark UI.

## Changes made

### Phase modal (homepage)
- Added themed scrollbar styles for the phase modal popup
- Default width: 10px, expands smoothly to 14px on hover
- Thumb and track colors now use theme CSS variables
- Added Firefox support via scrollbar-width/color

### Catalog page table wrapper
- Added themed scrollbar styles for the scrollable lesson table
- Default width/height: 8px, expands smoothly to 12px on hover
- Thumb and track colors now use theme CSS variables
- Added Firefox support via scrollbar-width/color

## Why this approach

Native scrollbars on scrollable containers can be styled with WebKit pseudo-elements and the standardized scrollbar-width/color properties. This keeps the implementation simple and dependency-free while delivering a consistent visual experience across Chrome, Edge, Safari, and Firefox.

## Testing

1. Open http://localhost:3000
2. Click any phase card to open the modal — scrollbar should be themed and expand on hover
3. Open http://localhost:3000/catalog.html — scroll the table wrapper to see the themed scrollbar
4. Toggle the theme switch to verify the scrollbar adapts to both light and dark modes

## Notes

The native <select> dropdown's internal scrollbar is controlled by the browser/OS and cannot be styled with CSS. The table wrapper scrollbar is what users see when filtering and browsing lessons, so it is the main scrollable surface on the catalog page.
