### PR TITLE
fix(requirements): pin numba floor to fix Python 3.12 install failure

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ pandas>=2.0
 pillow>=10.0
 librosa>=0.10
 soundfile>=0.12
+numba>=0.59
 tiktoken>=0.5
 anthropic>=0.25
 openai>=1.0


### PR DESCRIPTION
## Summary
- `uv pip install -r requirements.txt` fails on a fresh Python 3.12 environment because the resolver backtracks librosa's `numba` dependency down to `numba==0.53.1`/`llvmlite==0.36.0`, which only support Python <3.10 and fail to build.
- Added a `numba>=0.59` floor (first numba release with official Python 3.12 support) so the resolver stays on modern, compatible versions.

## Test plan
- [x] Fresh `uv venv --python 3.12` + `uv pip install -r requirements.txt` completes without errors
- [x] `uv pip check` reports all packages compatible
- [x] Ran the course's `phases/00-setup-and-tooling/01-dev-environment/code/verify.py` — 7/7 core checks pass
- [x] Confirmed no code in the repo imports `numba` directly — this is a resolver-steering pin for librosa's transitive dependency only

🤖 Generated with [Claude Code](https://claude.com/claude-code)