### PR TITLE
fix(readme): restore count-pinned toolkit sentence for the counts-sync bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1032,9 +1032,9 @@ npx skills add rohitg00/ai-engineering-from-scratch
 `.cursor/skills/`, `.codex/skills/`, OpenClaw's skills folder, Hermes's bundle
 path, or any SKILL.md-aware tool. One command, every agent.
 
-**The 388 lesson artifacts** (skills and prompts under `phases/**/outputs/`)
-install via `scripts/install_skills.py`. Requires cloning the repo. Supports
-tag filters, dry-runs, and per-agent layouts:
+**The lesson artifacts.** The repo ships 388 skills and 99 prompts under
+`phases/**/outputs/`; install them via `scripts/install_skills.py`. Requires
+cloning the repo. Supports tag filters, dry-runs, and per-agent layouts:
 
 ```bash
 python3 scripts/install_skills.py <target>                                 # every skill, default --layout skills (nested)

--- a/i18n/ar/README.md
+++ b/i18n/ar/README.md
@@ -1031,9 +1031,9 @@ npx skills add rohitg00/ai-engineering-from-scratch
 `.cursor/skills/`, `.codex/skills/`, OpenClaw's skills folder, Hermes's bundle
 path, or any SKILL.md-aware tool. One command, every agent.
 
-**The 388 lesson artifacts** (skills and prompts under `phases/**/outputs/`)
-install via `scripts/install_skills.py`. Requires cloning the repo. Supports
-tag filters, dry-runs, and per-agent layouts:
+**The lesson artifacts.** The repo ships 388 skills and 99 prompts under
+`phases/**/outputs/`; install them via `scripts/install_skills.py`. Requires
+cloning the repo. Supports tag filters, dry-runs, and per-agent layouts:
 
 ```bash
 python3 scripts/install_skills.py <target>                                 # every skill, default --layout skills (nested)

--- a/i18n/de/README.md
+++ b/i18n/de/README.md
@@ -1031,9 +1031,9 @@ npx skills add rohitg00/ai-engineering-from-scratch
 `.cursor/skills/`, `.codex/skills/`, OpenClaw's skills folder, Hermes's bundle
 path, or any SKILL.md-aware tool. One command, every agent.
 
-**The 388 lesson artifacts** (skills and prompts under `phases/**/outputs/`)
-install via `scripts/install_skills.py`. Requires cloning the repo. Supports
-tag filters, dry-runs, and per-agent layouts:
+**The lesson artifacts.** The repo ships 388 skills and 99 prompts under
+`phases/**/outputs/`; install them via `scripts/install_skills.py`. Requires
+cloning the repo. Supports tag filters, dry-runs, and per-agent layouts:
 
 ```bash
 python3 scripts/install_skills.py <target>                                 # every skill, default --layout skills (nested)

--- a/i18n/es/README.md
+++ b/i18n/es/README.md
@@ -1031,9 +1031,9 @@ npx skills add rohitg00/ai-engineering-from-scratch
 `.cursor/skills/`, `.codex/skills/`, OpenClaw's skills folder, Hermes's bundle
 path, or any SKILL.md-aware tool. One command, every agent.
 
-**The 388 lesson artifacts** (skills and prompts under `phases/**/outputs/`)
-install via `scripts/install_skills.py`. Requires cloning the repo. Supports
-tag filters, dry-runs, and per-agent layouts:
+**The lesson artifacts.** The repo ships 388 skills and 99 prompts under
+`phases/**/outputs/`; install them via `scripts/install_skills.py`. Requires
+cloning the repo. Supports tag filters, dry-runs, and per-agent layouts:
 
 ```bash
 python3 scripts/install_skills.py <target>                                 # every skill, default --layout skills (nested)

--- a/i18n/fr/README.md
+++ b/i18n/fr/README.md
@@ -1031,9 +1031,9 @@ npx skills add rohitg00/ai-engineering-from-scratch
 `.cursor/skills/`, `.codex/skills/`, OpenClaw's skills folder, Hermes's bundle
 path, or any SKILL.md-aware tool. One command, every agent.
 
-**The 388 lesson artifacts** (skills and prompts under `phases/**/outputs/`)
-install via `scripts/install_skills.py`. Requires cloning the repo. Supports
-tag filters, dry-runs, and per-agent layouts:
+**The lesson artifacts.** The repo ships 388 skills and 99 prompts under
+`phases/**/outputs/`; install them via `scripts/install_skills.py`. Requires
+cloning the repo. Supports tag filters, dry-runs, and per-agent layouts:
 
 ```bash
 python3 scripts/install_skills.py <target>                                 # every skill, default --layout skills (nested)

--- a/i18n/hi/README.md
+++ b/i18n/hi/README.md
@@ -1031,9 +1031,9 @@ npx skills add rohitg00/ai-engineering-from-scratch
 `.cursor/skills/`, `.codex/skills/`, OpenClaw's skills folder, Hermes's bundle
 path, or any SKILL.md-aware tool. One command, every agent.
 
-**The 388 lesson artifacts** (skills and prompts under `phases/**/outputs/`)
-install via `scripts/install_skills.py`. Requires cloning the repo. Supports
-tag filters, dry-runs, and per-agent layouts:
+**The lesson artifacts.** The repo ships 388 skills and 99 prompts under
+`phases/**/outputs/`; install them via `scripts/install_skills.py`. Requires
+cloning the repo. Supports tag filters, dry-runs, and per-agent layouts:
 
 ```bash
 python3 scripts/install_skills.py <target>                                 # every skill, default --layout skills (nested)

--- a/i18n/it/README.md
+++ b/i18n/it/README.md
@@ -1031,9 +1031,9 @@ npx skills add rohitg00/ai-engineering-from-scratch
 `.cursor/skills/`, `.codex/skills/`, OpenClaw's skills folder, Hermes's bundle
 path, or any SKILL.md-aware tool. One command, every agent.
 
-**The 388 lesson artifacts** (skills and prompts under `phases/**/outputs/`)
-install via `scripts/install_skills.py`. Requires cloning the repo. Supports
-tag filters, dry-runs, and per-agent layouts:
+**The lesson artifacts.** The repo ships 388 skills and 99 prompts under
+`phases/**/outputs/`; install them via `scripts/install_skills.py`. Requires
+cloning the repo. Supports tag filters, dry-runs, and per-agent layouts:
 
 ```bash
 python3 scripts/install_skills.py <target>                                 # every skill, default --layout skills (nested)

--- a/i18n/ja/README.md
+++ b/i18n/ja/README.md
@@ -1031,9 +1031,9 @@ npx skills add rohitg00/ai-engineering-from-scratch
 `.cursor/skills/`, `.codex/skills/`, OpenClaw's skills folder, Hermes's bundle
 path, or any SKILL.md-aware tool. One command, every agent.
 
-**The 388 lesson artifacts** (skills and prompts under `phases/**/outputs/`)
-install via `scripts/install_skills.py`. Requires cloning the repo. Supports
-tag filters, dry-runs, and per-agent layouts:
+**The lesson artifacts.** The repo ships 388 skills and 99 prompts under
+`phases/**/outputs/`; install them via `scripts/install_skills.py`. Requires
+cloning the repo. Supports tag filters, dry-runs, and per-agent layouts:
 
 ```bash
 python3 scripts/install_skills.py <target>                                 # every skill, default --layout skills (nested)

--- a/i18n/ko/README.md
+++ b/i18n/ko/README.md
@@ -1031,9 +1031,9 @@ npx skills add rohitg00/ai-engineering-from-scratch
 `.cursor/skills/`, `.codex/skills/`, OpenClaw's skills folder, Hermes's bundle
 path, or any SKILL.md-aware tool. One command, every agent.
 
-**The 388 lesson artifacts** (skills and prompts under `phases/**/outputs/`)
-install via `scripts/install_skills.py`. Requires cloning the repo. Supports
-tag filters, dry-runs, and per-agent layouts:
+**The lesson artifacts.** The repo ships 388 skills and 99 prompts under
+`phases/**/outputs/`; install them via `scripts/install_skills.py`. Requires
+cloning the repo. Supports tag filters, dry-runs, and per-agent layouts:
 
 ```bash
 python3 scripts/install_skills.py <target>                                 # every skill, default --layout skills (nested)

--- a/i18n/pt/README.md
+++ b/i18n/pt/README.md
@@ -1031,9 +1031,9 @@ npx skills add rohitg00/ai-engineering-from-scratch
 `.cursor/skills/`, `.codex/skills/`, OpenClaw's skills folder, Hermes's bundle
 path, or any SKILL.md-aware tool. One command, every agent.
 
-**The 388 lesson artifacts** (skills and prompts under `phases/**/outputs/`)
-install via `scripts/install_skills.py`. Requires cloning the repo. Supports
-tag filters, dry-runs, and per-agent layouts:
+**The lesson artifacts.** The repo ships 388 skills and 99 prompts under
+`phases/**/outputs/`; install them via `scripts/install_skills.py`. Requires
+cloning the repo. Supports tag filters, dry-runs, and per-agent layouts:
 
 ```bash
 python3 scripts/install_skills.py <target>                                 # every skill, default --layout skills (nested)

--- a/i18n/ru/README.md
+++ b/i18n/ru/README.md
@@ -1031,9 +1031,9 @@ npx skills add rohitg00/ai-engineering-from-scratch
 `.cursor/skills/`, `.codex/skills/`, OpenClaw's skills folder, Hermes's bundle
 path, or any SKILL.md-aware tool. One command, every agent.
 
-**The 388 lesson artifacts** (skills and prompts under `phases/**/outputs/`)
-install via `scripts/install_skills.py`. Requires cloning the repo. Supports
-tag filters, dry-runs, and per-agent layouts:
+**The lesson artifacts.** The repo ships 388 skills and 99 prompts under
+`phases/**/outputs/`; install them via `scripts/install_skills.py`. Requires
+cloning the repo. Supports tag filters, dry-runs, and per-agent layouts:
 
 ```bash
 python3 scripts/install_skills.py <target>                                 # every skill, default --layout skills (nested)

--- a/i18n/tr/README.md
+++ b/i18n/tr/README.md
@@ -1031,9 +1031,9 @@ npx skills add rohitg00/ai-engineering-from-scratch
 `.cursor/skills/`, `.codex/skills/`, OpenClaw's skills folder, Hermes's bundle
 path, or any SKILL.md-aware tool. One command, every agent.
 
-**The 388 lesson artifacts** (skills and prompts under `phases/**/outputs/`)
-install via `scripts/install_skills.py`. Requires cloning the repo. Supports
-tag filters, dry-runs, and per-agent layouts:
+**The lesson artifacts.** The repo ships 388 skills and 99 prompts under
+`phases/**/outputs/`; install them via `scripts/install_skills.py`. Requires
+cloning the repo. Supports tag filters, dry-runs, and per-agent layouts:
 
 ```bash
 python3 scripts/install_skills.py <target>                                 # every skill, default --layout skills (nested)

--- a/i18n/zh/README.md
+++ b/i18n/zh/README.md
@@ -1031,9 +1031,9 @@ npx skills add rohitg00/ai-engineering-from-scratch
 `.cursor/skills/`, `.codex/skills/`, OpenClaw's skills folder, Hermes's bundle
 path, or any SKILL.md-aware tool. One command, every agent.
 
-**The 388 lesson artifacts** (skills and prompts under `phases/**/outputs/`)
-install via `scripts/install_skills.py`. Requires cloning the repo. Supports
-tag filters, dry-runs, and per-agent layouts:
+**The lesson artifacts.** The repo ships 388 skills and 99 prompts under
+`phases/**/outputs/`; install them via `scripts/install_skills.py`. Requires
+cloning the repo. Supports tag filters, dry-runs, and per-agent layouts:
 
 ```bash
 python3 scripts/install_skills.py <target>                                 # every skill, default --layout skills (nested)


### PR DESCRIPTION
The learning-flow rewrite in #387 dropped the exact sentence `check_readme_counts.py` pins ("The repo ships N skills and N prompts"), which failed the README counts auto-fix job on main after merge. This restores countable phrasing (both patterns match again, counts stay auto-synced) and regenerates the 12 translated READMEs.

Verified locally: counts check, i18n sync check, quiz check, and skills-mirror check all pass.