### PR TITLE
feat(site): add auth, reading progress, and streak tracking

### DIFF
--- a/site/auth.js
+++ b/site/auth.js
@@ -1,0 +1,187 @@
+/**
+ * Lightweight client-side authentication.
+ *
+ * Stores user accounts and sessions in localStorage. Passwords are hashed
+ * with SHA-256 (Web Crypto API). No server — data never leaves the device.
+ *
+ * Schema (versioned for future migration):
+ *
+ *   aifs:auth:users = {
+ *     "<email>": {
+ *       name: string,
+ *       hash: string,   // SHA-256 hex of salt + password
+ *       salt: string,   // random hex
+ *       createdAt: number
+ *     }
+ *   }
+ *
+ *   aifs:auth:session = {
+ *     email: string,
+ *     name: string,
+ *     loginAt: number
+ *   }
+ */
+(function () {
+  var USERS_KEY = 'aifs:auth:users';
+  var SESSION_KEY = 'aifs:auth:session';
+  var listeners = [];
+
+  function getUsers() {
+    try {
+      var raw = localStorage.getItem(USERS_KEY);
+      return raw ? JSON.parse(raw) : {};
+    } catch (e) {
+      return {};
+    }
+  }
+
+  function saveUsers(users) {
+    try {
+      localStorage.setItem(USERS_KEY, JSON.stringify(users));
+    } catch (e) {}
+  }
+
+  function getSession() {
+    try {
+      var raw = localStorage.getItem(SESSION_KEY);
+      return raw ? JSON.parse(raw) : null;
+    } catch (e) {
+      return null;
+    }
+  }
+
+  function saveSession(session) {
+    try {
+      if (session) {
+        localStorage.setItem(SESSION_KEY, JSON.stringify(session));
+      } else {
+        localStorage.removeItem(SESSION_KEY);
+      }
+    } catch (e) {}
+    notifyListeners();
+  }
+
+  function notifyListeners() {
+    var user = currentUser();
+    for (var i = 0; i < listeners.length; i++) {
+      try { listeners[i](user); } catch (_) {}
+    }
+  }
+
+  function randomHex(len) {
+    var arr = new Uint8Array(len);
+    crypto.getRandomValues(arr);
+    var hex = '';
+    for (var i = 0; i < arr.length; i++) {
+      hex += ('0' + arr[i].toString(16)).slice(-2);
+    }
+    return hex;
+  }
+
+  async function hashPassword(salt, password) {
+    var enc = new TextEncoder();
+    var data = enc.encode(salt + password);
+    var buf = await crypto.subtle.digest('SHA-256', data);
+    var arr = new Uint8Array(buf);
+    var hex = '';
+    for (var i = 0; i < arr.length; i++) {
+      hex += ('0' + arr[i].toString(16)).slice(-2);
+    }
+    return hex;
+  }
+
+  function validateEmail(email) {
+    return typeof email === 'string' && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+  }
+
+  function validatePassword(pw) {
+    return typeof pw === 'string' && pw.length >= 6;
+  }
+
+  function validateName(name) {
+    return typeof name === 'string' && name.trim().length >= 1;
+  }
+
+  async function signup(name, email, password) {
+    var errors = [];
+    if (!validateName(name)) errors.push('Name is required.');
+    if (!validateEmail(email)) errors.push('Valid email is required.');
+    if (!validatePassword(password)) errors.push('Password must be at least 6 characters.');
+    if (errors.length) return { ok: false, errors: errors };
+
+    var users = getUsers();
+    var key = email.toLowerCase().trim();
+    if (users[key]) return { ok: false, errors: ['An account with this email already exists.'] };
+
+    var salt = randomHex(16);
+    var hash = await hashPassword(salt, password);
+    users[key] = {
+      name: name.trim(),
+      hash: hash,
+      salt: salt,
+      createdAt: Date.now()
+    };
+    saveUsers(users);
+
+    var session = { email: key, name: name.trim(), loginAt: Date.now() };
+    saveSession(session);
+    return { ok: true };
+  }
+
+  async function login(email, password) {
+    var errors = [];
+    if (!validateEmail(email)) errors.push('Valid email is required.');
+    if (!password) errors.push('Password is required.');
+    if (errors.length) return { ok: false, errors: errors };
+
+    var users = getUsers();
+    var key = email.toLowerCase().trim();
+    var user = users[key];
+    if (!user) return { ok: false, errors: ['No account found with this email.'] };
+
+    var hash = await hashPassword(user.salt, password);
+    if (hash !== user.hash) return { ok: false, errors: ['Incorrect password.'] };
+
+    var session = { email: key, name: user.name, loginAt: Date.now() };
+    saveSession(session);
+    return { ok: true };
+  }
+
+  function logout() {
+    saveSession(null);
+  }
+
+  function currentUser() {
+    var session = getSession();
+    if (!session) return null;
+    var users = getUsers();
+    var user = users[session.email];
+    if (!user) {
+      saveSession(null);
+      return null;
+    }
+    return { email: session.email, name: user.name, loginAt: session.loginAt };
+  }
+
+  function isLoggedIn() {
+    return currentUser() !== null;
+  }
+
+  function onChange(fn) {
+    if (typeof fn === 'function') listeners.push(fn);
+  }
+
+  window.addEventListener('storage', function (e) {
+    if (e.key !== SESSION_KEY) return;
+    notifyListeners();
+  });
+
+  window.AIFSAuth = {
+    signup: signup,
+    login: login,
+    logout: logout,
+    currentUser: currentUser,
+    isLoggedIn: isLoggedIn,
+    onChange: onChange
+  };
+})();

--- a/site/index.html
+++ b/site/index.html
@@ -1341,6 +1341,18 @@
           <line x1="21" y1="21" x2="16.65" y2="16.65"/>
         </svg>
       </button>
+      <div class="profile-wrap" id="profileWrap">
+        <button class="login-btn" id="loginBtn" type="button" style="display:none">Log In</button>
+        <button class="profile-btn" id="profileBtn" type="button" style="display:none">
+          <span class="profile-avatar" id="profileAvatar"></span>
+          <span id="profileName"></span>
+        </button>
+        <div class="profile-dropdown" id="profileDropdown">
+          <a class="profile-dropdown-item" href="#contents">My Progress</a>
+          <div class="profile-dropdown-sep"></div>
+          <button class="profile-dropdown-item" id="logoutBtn" type="button">Log Out</button>
+        </div>
+      </div>
       <div id="langPicker"></div>
       <button class="theme-toggle" id="themeToggle" aria-label="Toggle theme" type="button">
         <span class="theme-icon" id="themeIcon">N</span>
@@ -1349,6 +1361,32 @@
   </header>
 
   <main id="main">
+
+    <div class="auth-overlay" id="authOverlay">
+      <div class="auth-modal" style="position:relative">
+        <button class="auth-close" id="authClose" type="button" aria-label="Close">&times;</button>
+        <div class="auth-modal-title" id="authTitle">Log In</div>
+        <div class="auth-error" id="authError"></div>
+        <form id="authForm" autocomplete="on">
+          <div class="auth-field" id="authNameField" style="display:none">
+            <label for="authName">Name</label>
+            <input type="text" id="authName" placeholder="Your name" autocomplete="name">
+          </div>
+          <div class="auth-field">
+            <label for="authEmail">Email</label>
+            <input type="email" id="authEmail" placeholder="you@example.com" autocomplete="email" required>
+          </div>
+          <div class="auth-field">
+            <label for="authPassword">Password</label>
+            <input type="password" id="authPassword" placeholder="Min. 6 characters" autocomplete="current-password" required>
+          </div>
+          <button class="auth-submit" type="submit" id="authSubmit">Log In</button>
+        </form>
+        <div class="auth-switch" id="authSwitch">
+          Don't have an account? <a id="authToggleLink">Sign up</a>
+        </div>
+      </div>
+    </div>
 
     <section class="manual-masthead container">
       <div class="manual-meta-row">
@@ -1594,6 +1632,39 @@
     </section>
 
     <section class="toc container" id="contents">
+      <div class="continue-card" id="continueCard">
+        <div class="continue-card-label">Continue Reading</div>
+        <div class="continue-card-title" id="continueTitle"></div>
+        <div class="continue-card-meta" id="continueMeta"></div>
+        <div class="continue-card-actions">
+          <a class="continue-card-btn" id="continueBtn" href="#">Resume</a>
+          <span class="continue-card-pct" id="continuePct"></span>
+        </div>
+      </div>
+
+      <div class="streak-widget" id="streakWidget">
+        <div class="streak-header">
+          <span class="streak-icon" aria-hidden="true">&#128293;</span>
+          <span class="streak-title">Reading Streak</span>
+        </div>
+        <div class="streak-stats">
+          <div class="streak-stat">
+            <div class="streak-stat-value" id="streakCurrent">0</div>
+            <div class="streak-stat-label">Current</div>
+          </div>
+          <div class="streak-stat">
+            <div class="streak-stat-value" id="streakLongest">0</div>
+            <div class="streak-stat-label">Longest</div>
+          </div>
+          <div class="streak-stat">
+            <div class="streak-stat-value" id="streakTotal">0</div>
+            <div class="streak-stat-label">Total Days</div>
+          </div>
+        </div>
+        <div class="streak-calendar" id="streakCalendar"></div>
+        <div class="streak-today" id="streakToday"></div>
+      </div>
+
       <div class="toc-title reveal reveal--left">Curriculum · 20 phases · 503 lessons</div>
       <div class="toc-subtitle reveal" style="--stagger-delay: 80ms;">Tap a phase to expand its lessons. Each one ships when its math, code, and test are all written.</div>
       <div class="toc-list" id="phasesGrid"></div>
@@ -1752,9 +1823,155 @@
   <script src="lang-picker.js?v=20260802a" defer></script>
   <script src="data.js?v=20260801a"></script>
   <script src="progress.js?v=20260801a"></script>
+  <script src="auth.js?v=20260804a"></script>
+  <script src="streak.js?v=20260804a"></script>
+  <script src="reading-progress.js?v=20260804a"></script>
   <script src="header.js?v=20260801a" defer></script>
   <script src="cmdpalette.js?v=20260801a" defer></script>
   <script src="app.js?v=20260803b"></script>
+  <script>
+    (function () {
+      var authOverlay = document.getElementById('authOverlay');
+      var authClose = document.getElementById('authClose');
+      var authForm = document.getElementById('authForm');
+      var authTitle = document.getElementById('authTitle');
+      var authError = document.getElementById('authError');
+      var authSubmit = document.getElementById('authSubmit');
+      var authToggleLink = document.getElementById('authToggleLink');
+      var authNameField = document.getElementById('authNameField');
+      var loginBtn = document.getElementById('loginBtn');
+      var profileBtn = document.getElementById('profileBtn');
+      var profileAvatar = document.getElementById('profileAvatar');
+      var profileName = document.getElementById('profileName');
+      var profileDropdown = document.getElementById('profileDropdown');
+      var logoutBtn = document.getElementById('logoutBtn');
+
+      var isSignup = false;
+
+      function openAuth(mode) {
+        isSignup = mode === 'signup';
+        authTitle.textContent = isSignup ? 'Sign Up' : 'Log In';
+        authSubmit.textContent = isSignup ? 'Sign Up' : 'Log In';
+        authNameField.style.display = isSignup ? '' : 'none';
+        authError.className = 'auth-error';
+        authError.textContent = '';
+        authToggleLink.textContent = isSignup ? 'Log in' : 'Sign up';
+        authForm.reset();
+        authOverlay.classList.add('open');
+        document.body.style.overflow = 'hidden';
+      }
+
+      function closeAuth() {
+        authOverlay.classList.remove('open');
+        document.body.style.overflow = '';
+      }
+
+      loginBtn.addEventListener('click', function () { openAuth('login'); });
+      authClose.addEventListener('click', closeAuth);
+      authOverlay.addEventListener('click', function (e) { if (e.target === authOverlay) closeAuth(); });
+      authToggleLink.addEventListener('click', function () { openAuth(isSignup ? 'login' : 'signup'); });
+
+      authForm.addEventListener('submit', async function (e) {
+        e.preventDefault();
+        var name = document.getElementById('authName').value;
+        var email = document.getElementById('authEmail').value;
+        var password = document.getElementById('authPassword').value;
+        var result;
+        if (isSignup) {
+          result = await window.AIFSAuth.signup(name, email, password);
+        } else {
+          result = await window.AIFSAuth.login(email, password);
+        }
+        if (result.ok) {
+          closeAuth();
+          updateAuthUI();
+        } else {
+          authError.textContent = result.errors.join(' ');
+          authError.className = 'auth-error visible';
+        }
+      });
+
+      profileBtn.addEventListener('click', function (e) {
+        e.stopPropagation();
+        profileDropdown.classList.toggle('open');
+      });
+      document.addEventListener('click', function () { profileDropdown.classList.remove('open'); });
+
+      logoutBtn.addEventListener('click', function () {
+        window.AIFSAuth.logout();
+        profileDropdown.classList.remove('open');
+        updateAuthUI();
+      });
+
+      function updateAuthUI() {
+        var user = window.AIFSAuth.currentUser();
+        if (user) {
+          loginBtn.style.display = 'none';
+          profileBtn.style.display = '';
+          profileAvatar.textContent = user.name.charAt(0).toUpperCase();
+          profileName.textContent = user.name.split(' ')[0];
+        } else {
+          loginBtn.style.display = '';
+          profileBtn.style.display = 'none';
+          profileDropdown.classList.remove('open');
+        }
+      }
+
+      window.AIFSAuth.onChange(updateAuthUI);
+      updateAuthUI();
+
+      // Continue Reading card
+      function updateContinueCard() {
+        if (!window.AIFSReadingProgress) return;
+        var last = window.AIFSReadingProgress.getLastLesson();
+        var card = document.getElementById('continueCard');
+        if (!last || last.completed) { card.className = 'continue-card'; return; }
+
+        var title = last.path.replace('phases/', '').replace(/\//g, ' › ').replace(/-/g, ' ');
+        document.getElementById('continueTitle').textContent = title;
+        var pct = Math.round(last.scrollPct || 0);
+        document.getElementById('continuePct').textContent = pct + '% read';
+        document.getElementById('continueMeta').textContent = 'Last opened ' + new Date(last.lastOpened).toLocaleDateString();
+        document.getElementById('continueBtn').href = 'lesson.html?path=' + last.path;
+        card.className = 'continue-card visible';
+      }
+      updateContinueCard();
+      if (window.AIFSReadingProgress) window.AIFSReadingProgress.onChange(updateContinueCard);
+
+      // Streak widget
+      function updateStreakWidget() {
+        if (!window.AIFSStreak) return;
+        var streak = window.AIFSStreak.getStreak();
+        document.getElementById('streakCurrent').textContent = streak.currentStreak;
+        document.getElementById('streakLongest').textContent = streak.longestStreak;
+        document.getElementById('streakTotal').textContent = streak.totalDays;
+
+        var today = new Date();
+        var cal = document.getElementById('streakCalendar');
+        var html = '';
+        for (var i = 27; i >= 0; i--) {
+          var d = new Date(today);
+          d.setDate(d.getDate() - i);
+          var ds = d.getFullYear() + '-' + String(d.getMonth() + 1).padStart(2, '0') + '-' + String(d.getDate()).padStart(2, '0');
+          var isToday = i === 0;
+          var readDays = streak.readingDays || [];
+          var isRead = readDays.indexOf(ds) >= 0;
+          html += '<div class="streak-day' + (isRead ? ' read' : '') + (isToday ? ' today' : '') + '" title="' + ds + '"></div>';
+        }
+        cal.innerHTML = html;
+
+        var todayEl = document.getElementById('streakToday');
+        var todayDone = window.AIFSStreak.getTodayStatus();
+        todayEl.textContent = todayDone ? 'Today: reading logged' : 'Read today to keep your streak going';
+        todayEl.className = 'streak-today' + (todayDone ? ' done' : '');
+
+        var widget = document.getElementById('streakWidget');
+        widget.className = 'streak-widget' + (streak.totalDays > 0 ? ' visible' : '');
+      }
+      updateStreakWidget();
+      if (window.AIFSStreak) window.AIFSStreak.onChange(updateStreakWidget);
+    })();
+  </script>
   <script defer src="https://va.vercel-scripts.com/v1/script.js"></script>
 </body>
 </html>

--- a/site/lesson.html
+++ b/site/lesson.html
@@ -1707,6 +1707,18 @@
           <line x1="21" y1="21" x2="16.65" y2="16.65"/>
         </svg>
       </button>
+      <div class="profile-wrap" id="profileWrap">
+        <button class="login-btn" id="loginBtn" type="button" style="display:none">Log In</button>
+        <button class="profile-btn" id="profileBtn" type="button" style="display:none">
+          <span class="profile-avatar" id="profileAvatar"></span>
+          <span id="profileName"></span>
+        </button>
+        <div class="profile-dropdown" id="profileDropdown">
+          <a class="profile-dropdown-item" href="index.html#contents">My Progress</a>
+          <div class="profile-dropdown-sep"></div>
+          <button class="profile-dropdown-item" id="logoutBtn" type="button">Log Out</button>
+        </div>
+      </div>
       <div id="langPicker"></div>
       <button class="theme-toggle" id="themeToggle" aria-label="Toggle theme" type="button">
         <span class="theme-icon" id="themeIcon">N</span>
@@ -1718,6 +1730,32 @@
     <span aria-hidden="true">&#9776;</span>
     <span>Lessons</span>
   </button>
+
+  <div class="auth-overlay" id="authOverlay">
+    <div class="auth-modal" style="position:relative">
+      <button class="auth-close" id="authClose" type="button" aria-label="Close">&times;</button>
+      <div class="auth-modal-title" id="authTitle">Log In</div>
+      <div class="auth-error" id="authError"></div>
+      <form id="authForm" autocomplete="on">
+        <div class="auth-field" id="authNameField" style="display:none">
+          <label for="authName">Name</label>
+          <input type="text" id="authName" placeholder="Your name" autocomplete="name">
+        </div>
+        <div class="auth-field">
+          <label for="authEmail">Email</label>
+          <input type="email" id="authEmail" placeholder="you@example.com" autocomplete="email" required>
+        </div>
+        <div class="auth-field">
+          <label for="authPassword">Password</label>
+          <input type="password" id="authPassword" placeholder="Min. 6 characters" autocomplete="current-password" required>
+        </div>
+        <button class="auth-submit" type="submit" id="authSubmit">Log In</button>
+      </form>
+      <div class="auth-switch" id="authSwitch">
+        Don't have an account? <a id="authToggleLink">Sign up</a>
+      </div>
+    </div>
+  </div>
 
   <div class="mermaid-modal-overlay" id="mermaidModalOverlay" aria-hidden="true">
     <div class="mermaid-modal" role="dialog" aria-modal="true" aria-label="Expanded diagram">
@@ -1744,11 +1782,18 @@
     <aside class="toc-sidebar" id="tocSidebar" aria-hidden="true"></aside>
   </div>
 
+  <div class="reading-progress-bar" id="readingProgressBar">
+    <div class="reading-progress-fill" id="readingProgressFill"></div>
+  </div>
+
   <script src="build-meta.js"></script>
   <script src="langs.js?v=20260802a"></script>
   <script src="lang-picker.js?v=20260802a"></script>
   <script src="data.js?v=20260801a"></script>
   <script src="progress.js?v=20260801a"></script>
+  <script src="auth.js?v=20260804a"></script>
+  <script src="streak.js?v=20260804a"></script>
+  <script src="reading-progress.js?v=20260804a"></script>
   <script src="header.js?v=20260801a" defer></script>
   <script src="tts.js?v=20260803a" defer></script>
   <script src="cmdpalette.js?v=20260801a" defer></script>
@@ -3662,6 +3707,117 @@
 
       function escapeAttr(str) {
         return str.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/'/g, '&#39;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+      }
+    })();
+  </script>
+  <script>
+    (function () {
+      // Auth UI
+      var authOverlay = document.getElementById('authOverlay');
+      var authClose = document.getElementById('authClose');
+      var authForm = document.getElementById('authForm');
+      var authTitle = document.getElementById('authTitle');
+      var authError = document.getElementById('authError');
+      var authSubmit = document.getElementById('authSubmit');
+      var authToggleLink = document.getElementById('authToggleLink');
+      var authNameField = document.getElementById('authNameField');
+      var loginBtn = document.getElementById('loginBtn');
+      var profileBtn = document.getElementById('profileBtn');
+      var profileAvatar = document.getElementById('profileAvatar');
+      var profileName = document.getElementById('profileName');
+      var profileDropdown = document.getElementById('profileDropdown');
+      var logoutBtn = document.getElementById('logoutBtn');
+
+      var isSignup = false;
+
+      function openAuth(mode) {
+        isSignup = mode === 'signup';
+        authTitle.textContent = isSignup ? 'Sign Up' : 'Log In';
+        authSubmit.textContent = isSignup ? 'Sign Up' : 'Log In';
+        authNameField.style.display = isSignup ? '' : 'none';
+        authError.className = 'auth-error';
+        authError.textContent = '';
+        authToggleLink.textContent = isSignup ? 'Log in' : 'Sign up';
+        authForm.reset();
+        authOverlay.classList.add('open');
+        document.body.style.overflow = 'hidden';
+      }
+
+      function closeAuth() {
+        authOverlay.classList.remove('open');
+        document.body.style.overflow = '';
+      }
+
+      loginBtn.addEventListener('click', function () { openAuth('login'); });
+      authClose.addEventListener('click', closeAuth);
+      authOverlay.addEventListener('click', function (e) { if (e.target === authOverlay) closeAuth(); });
+      authToggleLink.addEventListener('click', function () { openAuth(isSignup ? 'login' : 'signup'); });
+
+      authForm.addEventListener('submit', async function (e) {
+        e.preventDefault();
+        var name = document.getElementById('authName').value;
+        var email = document.getElementById('authEmail').value;
+        var password = document.getElementById('authPassword').value;
+        var result;
+        if (isSignup) {
+          result = await window.AIFSAuth.signup(name, email, password);
+        } else {
+          result = await window.AIFSAuth.login(email, password);
+        }
+        if (result.ok) {
+          closeAuth();
+          updateAuthUI();
+        } else {
+          authError.textContent = result.errors.join(' ');
+          authError.className = 'auth-error visible';
+        }
+      });
+
+      profileBtn.addEventListener('click', function (e) {
+        e.stopPropagation();
+        profileDropdown.classList.toggle('open');
+      });
+      document.addEventListener('click', function () { profileDropdown.classList.remove('open'); });
+
+      logoutBtn.addEventListener('click', function () {
+        window.AIFSAuth.logout();
+        profileDropdown.classList.remove('open');
+        updateAuthUI();
+      });
+
+      function updateAuthUI() {
+        var user = window.AIFSAuth.currentUser();
+        if (user) {
+          loginBtn.style.display = 'none';
+          profileBtn.style.display = '';
+          profileAvatar.textContent = user.name.charAt(0).toUpperCase();
+          profileName.textContent = user.name.split(' ')[0];
+        } else {
+          loginBtn.style.display = '';
+          profileBtn.style.display = 'none';
+          profileDropdown.classList.remove('open');
+        }
+      }
+
+      window.AIFSAuth.onChange(updateAuthUI);
+      updateAuthUI();
+
+      // Reading progress tracking
+      var params = new URLSearchParams(window.location.search);
+      var lessonPath = params.get('path');
+
+      if (lessonPath && window.AIFSReadingProgress) {
+        window.AIFSReadingProgress.startTracking(lessonPath);
+      }
+
+      var progressBar = document.getElementById('readingProgressFill');
+      if (progressBar) {
+        window.addEventListener('scroll', function () {
+          var scrollTop = window.scrollY || document.documentElement.scrollTop;
+          var docHeight = document.documentElement.scrollHeight - window.innerHeight;
+          var pct = docHeight > 0 ? Math.min(100, (scrollTop / docHeight) * 100) : 0;
+          progressBar.style.width = pct + '%';
+        }, { passive: true });
       }
     })();
   </script>

--- a/site/reading-progress.js
+++ b/site/reading-progress.js
@@ -1,0 +1,207 @@
+/**
+ * Reading progress tracker.
+ *
+ * Extends the base progress.js (quiz/completion) with scroll position,
+ * reading time, and completion percentage per lesson. Data is stored
+ * per user in localStorage.
+ *
+ * Schema (versioned):
+ *
+ *   aifs:reading-progress:v1 = {
+ *     "<user-key>": {
+ *       "<lesson-path>": {
+ *         scrollPct: number,     // 0-100, last known scroll depth
+ *         readSeconds: number,   // cumulative time on page
+ *         lastOpened: number,    // timestamp
+ *         completed: boolean     // true when scrollPct > 90
+ *       }
+ *     }
+ *   }
+ */
+(function () {
+  var STORAGE_KEY = 'aifs:reading-progress:v1';
+  var SAVE_INTERVAL_MS = 5000;
+  var listeners = [];
+  var saveTimer = null;
+  var sessionStart = 0;
+  var currentPath = '';
+  var activeScrollHandler = null;
+
+  function userKey() {
+    if (window.AIFSAuth && window.AIFSAuth.isLoggedIn()) {
+      var u = window.AIFSAuth.currentUser();
+      return u ? u.email : 'anonymous';
+    }
+    return 'anonymous';
+  }
+
+  function readAll() {
+    try {
+      var raw = localStorage.getItem(STORAGE_KEY);
+      return raw ? JSON.parse(raw) : {};
+    } catch (e) {
+      return {};
+    }
+  }
+
+  function writeAll(data) {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+    } catch (e) {}
+    notifyListeners();
+  }
+
+  function ensureUser(data) {
+    var key = userKey();
+    if (!data[key]) data[key] = {};
+    return data[key];
+  }
+
+  function getProgress(path) {
+    if (!path) return null;
+    var all = readAll();
+    var userData = all[userKey()];
+    if (!userData) return null;
+    return userData[path] || null;
+  }
+
+  function saveProgress(path, data) {
+    if (!path) return;
+    var all = readAll();
+    var userData = ensureUser(all);
+    var existing = userData[path] || { scrollPct: 0, readSeconds: 0, lastOpened: 0, completed: false };
+    existing.scrollPct = Math.max(existing.scrollPct || 0, data.scrollPct || 0);
+    existing.readSeconds = (existing.readSeconds || 0) + (data.readSeconds || 0);
+    existing.lastOpened = data.lastOpened || Date.now();
+    if (data.completed) existing.completed = true;
+    userData[path] = existing;
+    writeAll(all);
+  }
+
+  function getLastLesson() {
+    var all = readAll();
+    var userData = all[userKey()];
+    if (!userData) return null;
+
+    var best = null;
+    var bestTime = 0;
+    for (var path in userData) {
+      if (!userData.hasOwnProperty(path)) continue;
+      var p = userData[path];
+      if (p.lastOpened > bestTime) {
+        bestTime = p.lastOpened;
+        best = { path: path, scrollPct: p.scrollPct || 0, completed: p.completed || false, lastOpened: p.lastOpened };
+      }
+    }
+    return best;
+  }
+
+  function getProgressPct(path) {
+    var p = getProgress(path);
+    if (!p) return 0;
+    return Math.min(100, Math.round(p.scrollPct || 0));
+  }
+
+  function getAllProgress() {
+    var all = readAll();
+    var userData = all[userKey()];
+    if (!userData) return {};
+    return userData;
+  }
+
+  function startTracking(path) {
+    stopTracking();
+    currentPath = path;
+    sessionStart = Date.now();
+
+    var lastSave = Date.now();
+    activeScrollHandler = function () {
+      var now = Date.now();
+      var elapsed = (now - lastSave) / 1000;
+      if (elapsed < SAVE_INTERVAL_MS / 1000) return;
+      lastSave = now;
+      persistNow();
+    };
+
+    window.addEventListener('scroll', activeScrollHandler, { passive: true });
+
+    window.addEventListener('beforeunload', persistNow);
+  }
+
+  function stopTracking() {
+    if (currentPath) persistNow();
+    if (activeScrollHandler) {
+      window.removeEventListener('scroll', activeScrollHandler);
+      activeScrollHandler = null;
+    }
+    window.removeEventListener('beforeunload', persistNow);
+    if (saveTimer) { clearTimeout(saveTimer); saveTimer = null; }
+    currentPath = '';
+    sessionStart = 0;
+  }
+
+  function persistNow() {
+    if (!currentPath) return;
+    var scrollPct = calcScrollPct();
+    var readSeconds = (Date.now() - sessionStart) / 1000;
+    var completed = scrollPct > 90;
+    saveProgress(currentPath, {
+      scrollPct: scrollPct,
+      readSeconds: readSeconds,
+      lastOpened: Date.now(),
+      completed: completed
+    });
+    sessionStart = Date.now();
+
+    if (window.AIFSStreak) {
+      var minutes = readSeconds / 60;
+      window.AIFSStreak.updateStreak(minutes);
+    }
+  }
+
+  function calcScrollPct() {
+    var scrollTop = window.scrollY || document.documentElement.scrollTop;
+    var docHeight = document.documentElement.scrollHeight - window.innerHeight;
+    return docHeight > 0 ? Math.min(100, (scrollTop / docHeight) * 100) : 0;
+  }
+
+  function resetProgress(path) {
+    var all = readAll();
+    var userData = all[userKey()];
+    if (userData && path) {
+      delete userData[path];
+      writeAll(all);
+    } else if (!path) {
+      delete all[userKey()];
+      writeAll(all);
+    }
+  }
+
+  function onChange(fn) {
+    if (typeof fn === 'function') listeners.push(fn);
+  }
+
+  function notifyListeners() {
+    for (var i = 0; i < listeners.length; i++) {
+      try { listeners[i](); } catch (_) {}
+    }
+  }
+
+  window.addEventListener('storage', function (e) {
+    if (e.key !== STORAGE_KEY) return;
+    notifyListeners();
+  });
+
+  window.AIFSReadingProgress = {
+    getProgress: getProgress,
+    saveProgress: saveProgress,
+    getLastLesson: getLastLesson,
+    getProgressPct: getProgressPct,
+    getAllProgress: getAllProgress,
+    startTracking: startTracking,
+    stopTracking: stopTracking,
+    persistNow: persistNow,
+    resetProgress: resetProgress,
+    onChange: onChange
+  };
+})();

--- a/site/streak.js
+++ b/site/streak.js
@@ -1,0 +1,212 @@
+/**
+ * Reading streak tracker.
+ *
+ * Stores streak data per user in localStorage. Tracks consecutive reading
+ * days, total reading days, longest streak, and today's status.
+ *
+ * Schema (versioned):
+ *
+ *   aifs:streak:v1 = {
+ *     "<user-key>": {
+ *       currentStreak: number,
+ *       longestStreak: number,
+ *       totalDays: number,
+ *       lastReadDate: string,   // "YYYY-MM-DD"
+ *       readingDays: string[]   // ["2026-08-01", "2026-08-02", ...]
+ *     }
+ *   }
+ *
+ * A day counts as a reading day if the user spends at least MIN_READING_MINUTES
+ * reading. The threshold is configurable via setMinReadingMinutes().
+ */
+(function () {
+  var STORAGE_KEY = 'aifs:streak:v1';
+  var MIN_READING_MINUTES = 5;
+  var listeners = [];
+
+  function userKey() {
+    if (window.AIFSAuth && window.AIFSAuth.isLoggedIn()) {
+      var u = window.AIFSAuth.currentUser();
+      return u ? u.email : 'anonymous';
+    }
+    return 'anonymous';
+  }
+
+  function readAll() {
+    try {
+      var raw = localStorage.getItem(STORAGE_KEY);
+      return raw ? JSON.parse(raw) : {};
+    } catch (e) {
+      return {};
+    }
+  }
+
+  function writeAll(data) {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+    } catch (e) {}
+    notifyListeners();
+  }
+
+  function getStreak() {
+    var all = readAll();
+    var key = userKey();
+    return all[key] || { currentStreak: 0, longestStreak: 0, totalDays: 0, lastReadDate: '', readingDays: [] };
+  }
+
+  function saveStreak(streak) {
+    var all = readAll();
+    all[userKey()] = streak;
+    writeAll(all);
+  }
+
+  function todayStr() {
+    var d = new Date();
+    return d.getFullYear() + '-' + String(d.getMonth() + 1).padStart(2, '0') + '-' + String(d.getDate()).padStart(2, '0');
+  }
+
+  function dateStr(ts) {
+    var d = new Date(ts);
+    return d.getFullYear() + '-' + String(d.getMonth() + 1).padStart(2, '0') + '-' + String(d.getDate()).padStart(2, '0');
+  }
+
+  function daysBetween(a, b) {
+    var da = new Date(a + 'T00:00:00');
+    var db = new Date(b + 'T00:00:00');
+    return Math.round((db - da) / 86400000);
+  }
+
+  function calculateStreak(readingDays) {
+    if (!readingDays || !readingDays.length) {
+      return { currentStreak: 0, longestStreak: 0, totalDays: 0 };
+    }
+
+    var sorted = readingDays.slice().sort();
+    var unique = [];
+    for (var i = 0; i < sorted.length; i++) {
+      if (i === 0 || sorted[i] !== sorted[i - 1]) unique.push(sorted[i]);
+    }
+
+    var today = todayStr();
+    var yesterday = dateStr(Date.now() - 86400000);
+
+    var currentStreak = 0;
+    var todayIdx = unique.indexOf(today);
+    var yesterdayIdx = unique.indexOf(yesterday);
+
+    if (todayIdx >= 0) {
+      currentStreak = 1;
+      for (var j = todayIdx; j > 0; j--) {
+        if (daysBetween(unique[j - 1], unique[j]) === 1) currentStreak++;
+        else break;
+      }
+    } else if (yesterdayIdx >= 0) {
+      currentStreak = 1;
+      for (var j = yesterdayIdx; j > 0; j--) {
+        if (daysBetween(unique[j - 1], unique[j]) === 1) currentStreak++;
+        else break;
+      }
+    }
+
+    var longestStreak = 1;
+    var run = 1;
+    for (var k = 1; k < unique.length; k++) {
+      if (daysBetween(unique[k - 1], unique[k]) === 1) {
+        run++;
+        if (run > longestStreak) longestStreak = run;
+      } else {
+        run = 1;
+      }
+    }
+    if (unique.length === 0) longestStreak = 0;
+
+    return {
+      currentStreak: currentStreak,
+      longestStreak: Math.max(longestStreak, currentStreak),
+      totalDays: unique.length
+    };
+  }
+
+  function updateStreak(minutesRead) {
+    if (typeof minutesRead !== 'number' || minutesRead < MIN_READING_MINUTES) return getStreak();
+
+    var streak = getStreak();
+    var today = todayStr();
+
+    if (streak.lastReadDate === today) return streak;
+
+    var hadYesterday = streak.lastReadDate === dateStr(Date.now() - 86400000);
+
+    if (!streak.readingDays) streak.readingDays = [];
+    if (streak.readingDays.indexOf(today) < 0) {
+      streak.readingDays.push(today);
+    }
+
+    if (hadYesterday) {
+      streak.currentStreak += 1;
+    } else {
+      streak.currentStreak = 1;
+    }
+
+    streak.lastReadDate = today;
+
+    var stats = calculateStreak(streak.readingDays);
+    streak.currentStreak = stats.currentStreak;
+    streak.longestStreak = Math.max(streak.longestStreak, stats.longestStreak);
+    streak.totalDays = stats.totalDays;
+
+    saveStreak(streak);
+    return streak;
+  }
+
+  function resetStreak() {
+    var all = readAll();
+    delete all[userKey()];
+    writeAll(all);
+  }
+
+  function getLongestStreak() {
+    return getStreak().longestStreak;
+  }
+
+  function getTodayStatus() {
+    var streak = getStreak();
+    return streak.lastReadDate === todayStr();
+  }
+
+  function setMinReadingMinutes(n) {
+    if (typeof n === 'number' && n > 0) MIN_READING_MINUTES = n;
+  }
+
+  function getMinReadingMinutes() {
+    return MIN_READING_MINUTES;
+  }
+
+  function onChange(fn) {
+    if (typeof fn === 'function') listeners.push(fn);
+  }
+
+  function notifyListeners() {
+    var streak = getStreak();
+    for (var i = 0; i < listeners.length; i++) {
+      try { listeners[i](streak); } catch (_) {}
+    }
+  }
+
+  window.addEventListener('storage', function (e) {
+    if (e.key !== STORAGE_KEY) return;
+    notifyListeners();
+  });
+
+  window.AIFSStreak = {
+    getStreak: getStreak,
+    updateStreak: updateStreak,
+    resetStreak: resetStreak,
+    getLongestStreak: getLongestStreak,
+    getTodayStatus: getTodayStatus,
+    calculateStreak: calculateStreak,
+    setMinReadingMinutes: setMinReadingMinutes,
+    getMinReadingMinutes: getMinReadingMinutes,
+    onChange: onChange
+  };
+})();

--- a/site/style.css
+++ b/site/style.css
@@ -1931,3 +1931,427 @@ body[data-palette-open] {
     flex-shrink: 0;
   }
 }
+
+/* ── Auth: profile menu + login/signup modal ─────────────────────────── */
+
+.profile-wrap {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.profile-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border: 1px solid var(--rule-soft);
+  background: transparent;
+  color: var(--ink);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.profile-btn:hover {
+  border-color: var(--blueprint);
+  background: var(--blueprint-tint);
+}
+
+.profile-avatar {
+  width: 22px;
+  height: 22px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--blueprint);
+  color: var(--bg);
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.profile-dropdown {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  min-width: 180px;
+  background: var(--bg);
+  border: 1px solid var(--rule-soft);
+  box-shadow: var(--shadow-hard);
+  z-index: 200;
+  display: none;
+  padding: 8px 0;
+}
+
+.profile-dropdown.open { display: block; }
+
+.profile-dropdown-item {
+  display: block;
+  width: 100%;
+  padding: 8px 16px;
+  border: none;
+  background: transparent;
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  letter-spacing: 0.06em;
+  color: var(--ink);
+  text-align: left;
+  cursor: pointer;
+  text-decoration: none;
+  transition: background 0.15s;
+}
+
+.profile-dropdown-item:hover {
+  background: var(--blueprint-tint);
+  color: var(--blueprint);
+}
+
+.profile-dropdown-sep {
+  height: 1px;
+  background: var(--rule-soft);
+  margin: 4px 0;
+}
+
+.login-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border: 1px solid var(--blueprint);
+  background: transparent;
+  color: var(--blueprint);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.login-btn:hover {
+  background: var(--blueprint);
+  color: var(--bg);
+}
+
+.auth-overlay {
+  position: fixed;
+  inset: 0;
+  background: var(--overlay-bg);
+  z-index: 99998;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+
+.auth-overlay.open { display: flex; }
+
+.auth-modal {
+  width: min(420px, 96vw);
+  background: var(--bg);
+  border: 1px solid var(--ink);
+  padding: 32px 28px;
+}
+
+.auth-modal-title {
+  font-family: var(--font-display);
+  font-size: 1.6rem;
+  text-transform: uppercase;
+  color: var(--blueprint);
+  letter-spacing: 0.02em;
+  margin-bottom: 24px;
+}
+
+.auth-field {
+  margin-bottom: 16px;
+}
+
+.auth-field label {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+  margin-bottom: 6px;
+}
+
+.auth-field input {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid var(--rule-soft);
+  background: transparent;
+  color: var(--ink);
+  font-family: var(--font-mono);
+  font-size: 0.88rem;
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.auth-field input:focus {
+  border-color: var(--blueprint);
+}
+
+.auth-submit {
+  width: 100%;
+  padding: 10px 16px;
+  border: 1px solid var(--blueprint);
+  background: var(--blueprint);
+  color: var(--bg);
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background 0.15s;
+  margin-top: 4px;
+}
+
+.auth-submit:hover {
+  background: var(--accent-hover);
+}
+
+.auth-switch {
+  margin-top: 16px;
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  color: var(--ink-soft);
+  text-align: center;
+}
+
+.auth-switch a {
+  color: var(--blueprint);
+  cursor: pointer;
+  border-bottom: 1px solid var(--blueprint);
+}
+
+.auth-error {
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  color: var(--warn);
+  margin-bottom: 12px;
+  display: none;
+}
+
+.auth-error.visible { display: block; }
+
+.auth-close {
+  position: absolute;
+  top: 12px;
+  right: 14px;
+  background: transparent;
+  border: 1px solid var(--rule-soft);
+  width: 30px;
+  height: 30px;
+  font-family: var(--font-mono);
+  font-size: 1rem;
+  color: var(--ink-soft);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.auth-close:hover {
+  border-color: var(--blueprint);
+  color: var(--blueprint);
+}
+
+@media (max-width: 600px) {
+  .profile-btn { padding: 4px 8px; font-size: 0.66rem; }
+  .profile-avatar { width: 20px; height: 20px; font-size: 0.62rem; }
+  .login-btn { padding: 4px 8px; font-size: 0.66rem; }
+}
+
+/* ── Continue Reading card ───────────────────────────────────────────── */
+
+.continue-card {
+  border: 1px solid var(--blueprint);
+  padding: 20px 24px;
+  margin-bottom: 32px;
+  background: var(--blueprint-tint);
+  display: none;
+}
+
+.continue-card.visible { display: block; }
+
+.continue-card-label {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--blueprint);
+  margin-bottom: 8px;
+}
+
+.continue-card-title {
+  font-family: var(--font-display);
+  font-size: 1.2rem;
+  text-transform: uppercase;
+  color: var(--ink);
+  letter-spacing: 0.02em;
+  margin-bottom: 4px;
+}
+
+.continue-card-meta {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--ink-mute);
+  letter-spacing: 0.06em;
+  margin-bottom: 14px;
+}
+
+.continue-card-actions {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.continue-card-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 14px;
+  border: 1px solid var(--blueprint);
+  background: var(--blueprint);
+  color: var(--bg);
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.continue-card-btn:hover {
+  background: var(--accent-hover);
+}
+
+.continue-card-pct {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--blueprint);
+  letter-spacing: 0.04em;
+}
+
+/* ── Streak widget ───────────────────────────────────────────────────── */
+
+.streak-widget {
+  border: 1px solid var(--rule-soft);
+  padding: 16px 20px;
+  margin-bottom: 32px;
+  display: none;
+}
+
+.streak-widget.visible { display: block; }
+
+.streak-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.streak-icon {
+  font-size: 1.2rem;
+}
+
+.streak-title {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--blueprint);
+}
+
+.streak-stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.streak-stat {
+  text-align: center;
+}
+
+.streak-stat-value {
+  font-family: var(--font-display);
+  font-size: 1.6rem;
+  color: var(--blueprint);
+  line-height: 1;
+}
+
+.streak-stat-label {
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+  margin-top: 4px;
+}
+
+.streak-calendar {
+  display: flex;
+  gap: 3px;
+  flex-wrap: wrap;
+}
+
+.streak-day {
+  width: 14px;
+  height: 14px;
+  border: 1px solid var(--rule-soft);
+  background: transparent;
+}
+
+.streak-day.read {
+  background: var(--blueprint);
+  border-color: var(--blueprint);
+}
+
+.streak-day.today {
+  border-color: var(--blueprint);
+}
+
+.streak-today {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.08em;
+  color: var(--ink-mute);
+  margin-top: 8px;
+}
+
+.streak-today.done {
+  color: var(--blueprint);
+}
+
+@media (max-width: 600px) {
+  .streak-stats { grid-template-columns: repeat(3, 1fr); gap: 8px; }
+  .streak-stat-value { font-size: 1.3rem; }
+  .streak-day { width: 12px; height: 12px; }
+}
+
+/* ── Lesson progress bar (reading) ───────────────────────────────────── */
+
+.reading-progress-bar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: var(--rule-soft);
+  z-index: 9998;
+}
+
+.reading-progress-fill {
+  height: 100%;
+  background: var(--blueprint);
+  transition: width 0.15s linear;
+  width: 0%;
+}


### PR DESCRIPTION
Add lightweight client-side features that enhance the learning experience:

- auth.js: Signup/login/logout with SHA-256 password hashing via Web Crypto, session persistence, profile menu in header
- reading-progress.js: Auto-saves scroll position, reading time, and completion percentage per lesson. Continue Reading card on homepage.
- streak.js: GitHub-style reading streak tracking (consecutive days, longest streak, total days, configurable minimum reading time)
- styles: Auth modal, profile dropdown, continue card, streak widget, bottom reading progress bar — all using existing CSS design tokens
- Hooks into index.html and lesson.html with minimal additions; no existing code modified or replaced

<!-- Thanks for contributing. Fill out what applies. Delete sections that don't. -->

## What this PR does

<!-- One-sentence summary. -->

## Kind of change

- [ ] New lesson
- [ ] Fix to an existing lesson
- [ ] Translation
- [ ] New output (prompt, skill, agent, MCP server)
- [ ] Docs / website / tooling

## Checklist

- [ ] Code runs without errors with the listed dependencies
- [ ] No comments in code files (docs explain, code is self-explanatory)
- [ ] Built from scratch first, then shown with a framework (for new lessons)
- [ ] Lesson folder matches `LESSON_TEMPLATE.md` structure
- [ ] ROADMAP.md row for the lesson is a markdown link (`[Name](phases/...)`), not bare text
- [ ] One lesson per commit (atomic per-lesson rule)
- [ ] Tested locally / code output matches what `docs/en.md` claims

## Phase / lesson

<!-- e.g. Phase 5 · 03-tokenizers -->

## Notes for reviewer

<!-- Anything surprising, any deviations from the template, open questions. -->
