### PR TITLE
fix(i18n): make translation publishing retry-safe

### DIFF
--- a/.github/workflows/curriculum.yml
+++ b/.github/workflows/curriculum.yml
@@ -17,6 +17,7 @@ on:
       - "scripts/readme_translations.py"
       - "scripts/build_catalog.py"
       - "scripts/check_readme_counts.py"
+      - "scripts/test_translate_workflow.py"
       - "README.md"
       - "ROADMAP.md"
       - "glossary/**"
@@ -24,6 +25,7 @@ on:
       - "site/**"
       - "vercel.json"
       - ".github/workflows/curriculum.yml"
+      - ".github/workflows/translate.yml"
   pull_request:
     branches: [main]
     paths:
@@ -40,6 +42,7 @@ on:
       - "scripts/readme_translations.py"
       - "scripts/build_catalog.py"
       - "scripts/check_readme_counts.py"
+      - "scripts/test_translate_workflow.py"
       - "README.md"
       - "ROADMAP.md"
       - "glossary/**"
@@ -47,6 +50,7 @@ on:
       - "site/**"
       - "vercel.json"
       - ".github/workflows/curriculum.yml"
+      - ".github/workflows/translate.yml"
 
 permissions:
   contents: read
@@ -80,6 +84,8 @@ jobs:
         run: python3 scripts/debias_certification_questions.py --check
       - name: README translations are in sync with English
         run: python3 scripts/build_readme_i18n.py --check
+      - name: translation workflow publisher retries safely
+        run: python3 scripts/test_translate_workflow.py
       - name: learning skills mirror is in sync
         # skills/ is the canonical, agent-neutral home (what `npx skills add`
         # installs for every agent); .claude/skills/ is a mirror so cloning the

--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -22,10 +22,17 @@ on:
     branches: [main]
     paths:
       - "phases/**/docs/en.md"
+      - "languages.json"
+      # Publisher fixes must be able to bootstrap a missing translations branch
+      # even when no English lesson changed in the same merge.
+      - ".github/workflows/translate.yml"
   workflow_dispatch:
     inputs:
       langs:
         description: "space-separated language codes; blank = the ci:true set in languages.json"
+        default: ""
+      phase:
+        description: "one phase directory (for example 01-math-foundations); blank = all phases"
         default: ""
 
 concurrency:
@@ -47,6 +54,7 @@ jobs:
       - id: set
         env:
           REQUESTED: ${{ github.event.inputs.langs }}
+          REQUESTED_PHASE: ${{ github.event.inputs.phase }}
         run: |
           # every emitted code must exist in the registry; requested codes are
           # intersected with it, so untrusted input can never reach matrix.lang
@@ -59,9 +67,21 @@ jobs:
             JSON=$(jq -c '[.languages[] | select(.ci == true) | .code]' languages.json)
           fi
           echo "langs=$JSON" >> "$GITHUB_OUTPUT"
-          # one shard per phase dir (NN-name); the README is handled off-matrix
-          PHASES=$(find phases -mindepth 1 -maxdepth 1 -type d -printf '%f\n' \
-            | grep -E '^[0-9]{2}-[a-z0-9-]+$' | sort | jq -R . | jq -cs .)
+          # Manual runs can select one phase for a cheap end-to-end smoke test.
+          # Push runs and blank manual inputs retain the full phase matrix.
+          if [ -n "$REQUESTED_PHASE" ]; then
+            PHASE_LIST=$(find phases -mindepth 1 -maxdepth 1 -type d -exec basename {} \; \
+              | grep -E '^[0-9]{2}-[a-z0-9-]+$' | sort)
+            if ! printf '%s\n' "$PHASE_LIST" | grep -Fqx -- "$REQUESTED_PHASE"; then
+              echo "unknown phase: $REQUESTED_PHASE" >&2
+              exit 1
+            fi
+            PHASES=$(jq -cn --arg phase "$REQUESTED_PHASE" '[$phase]')
+          else
+            # one shard per phase dir (NN-name); the README is handled off-matrix
+            PHASES=$(find phases -mindepth 1 -maxdepth 1 -type d -exec basename {} \; \
+              | grep -E '^[0-9]{2}-[a-z0-9-]+$' | sort | jq -R . | jq -cs .)
+          fi
           echo "phases=$PHASES" >> "$GITHUB_OUTPUT"
 
   translate:
@@ -132,23 +152,49 @@ jobs:
         run: |
           # checkout used persist-credentials:false, so authenticate the push
           # explicitly with the job token rather than a stored credential
-          git remote set-url origin \
-            "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+          if [ -n "${TRANSLATION_PUSH_URL:-}" ]; then
+            # Local regression tests use a bare repository instead of GitHub.
+            git remote set-url origin "$TRANSLATION_PUSH_URL"
+          else
+            git remote set-url origin \
+              "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+          fi
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           SLICE="i18n/$LANG_CODE/phases/$PHASE"
           CACHE="i18n/$LANG_CODE/.cache/$PHASE.json"
+          PUBLISH_DIR="$RUNNER_TEMP/translation-publish"
+
+          cleanup_publish_worktree() {
+            # Removing the directory alone leaves Git's worktree registration
+            # behind, so the next retry cannot recreate it. Remove both.
+            git worktree remove --force "$PUBLISH_DIR" 2>/dev/null || true
+            rm -rf "$PUBLISH_DIR"
+            git worktree prune
+          }
+          trap cleanup_publish_worktree EXIT
+
           # Sync only this (lang, phase) slice + its cache. Other phases in the
           # same language live on the branch untouched, so parallel shards merge
-          # without clobbering each other; retries rebuild from the latest branch.
+          # without clobbering each other. A detached worktree lets each retry
+          # rebuild from the latest remote branch without a stale local branch or
+          # a removed-but-still-registered worktree blocking the next attempt.
           for attempt in 1 2 3 4 5 6 7 8; do
-            rm -rf ../pub && git worktree add --force -B translations ../pub origin/translations 2>/dev/null \
-              || git worktree add --force -b translations ../pub
-            rm -rf "../pub/$SLICE"
-            mkdir -p "../pub/$(dirname "$SLICE")" "../pub/i18n/$LANG_CODE/.cache"
-            [ -d "$SLICE" ] && cp -r "$SLICE" "../pub/$SLICE"
-            [ -f "$CACHE" ] && cp "$CACHE" "../pub/$CACHE"
-            ( cd ../pub
+            cleanup_publish_worktree
+            if git fetch origin "+refs/heads/translations:refs/remotes/origin/translations"; then
+              BASE=origin/translations
+            else
+              # The first successful shard creates the translations branch.
+              # A concurrent creator makes this push lose normally; the next
+              # attempt fetches that winner and reapplies only this shard.
+              BASE=HEAD
+            fi
+            git worktree add --detach "$PUBLISH_DIR" "$BASE"
+            rm -rf "$PUBLISH_DIR/$SLICE"
+            mkdir -p "$PUBLISH_DIR/$(dirname "$SLICE")" "$PUBLISH_DIR/i18n/$LANG_CODE/.cache"
+            [ -d "$SLICE" ] && cp -r "$SLICE" "$PUBLISH_DIR/$SLICE"
+            [ -f "$CACHE" ] && cp "$CACHE" "$PUBLISH_DIR/$CACHE"
+            ( cd "$PUBLISH_DIR" || exit 1
               # -f: the translations branch is created from main's checkout
               # (when it doesn't exist yet) and so carries main's .gitignore,
               # which deliberately excludes i18n/*/phases/ and i18n/*/.cache/
@@ -156,13 +202,32 @@ jobs:
               # here, so every publish reports "no changes" and nothing is
               # ever pushed. Force past it: this branch exists specifically
               # to hold these files.
-              git add -f "i18n/$LANG_CODE"
+              if ! git add -f "i18n/$LANG_CODE"; then
+                echo "could not stage translation slice" >&2
+                exit 1
+              fi
               # nothing staged is the only success-without-push case; a real
               # commit or push failure must fall through to a retry, not be
               # swallowed as "no changes"
-              if git diff --cached --quiet; then echo "no changes"; exit 0; fi
-              git commit -m "chore(i18n): $LANG_CODE / $PHASE (NLLB-200)"
-              git push origin translations ) && exit 0
-            echo "push race, retrying ($attempt)"; git fetch origin "+refs/heads/translations:refs/remotes/origin/translations" || true; sleep $((RANDOM % 12 + 3))
+              if git diff --cached --quiet; then
+                echo "no changes"
+                exit 0
+              else
+                DIFF_STATUS=$?
+                if [ "$DIFF_STATUS" -ne 1 ]; then
+                  echo "could not inspect staged translation slice" >&2
+                  exit 1
+                fi
+              fi
+              if ! git commit -m "chore(i18n): $LANG_CODE / $PHASE (NLLB-200)"; then
+                echo "could not commit translation slice" >&2
+                exit 1
+              fi
+              if ! git push origin HEAD:refs/heads/translations; then
+                echo "could not push translation slice" >&2
+                exit 1
+              fi ) && exit 0
+            echo "push race, retrying ($attempt)"
+            sleep "${TRANSLATION_PUBLISH_RETRY_DELAY:-$((RANDOM % 12 + 3))}"
           done
           echo "could not publish after retries" >&2; exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,6 +186,8 @@ stored quiz or assessment, and preserve progress in
 `CLAUDE-CERTIFICATION.md`. Do not modify checked-in reference artifacts as
 learner work. The certification curriculum is delivered through GitHub and the
 website and is intentionally outside the book-generation pipeline.
+It remains English-only and is intentionally outside the machine-translation
+pipeline as well.
 
 ### code/
 

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -2,6 +2,8 @@
 
 The English lessons are canonical. Translated **lesson** markdown is machine-generated and **never committed to `main`** — it lives on a separate `translations` branch, and the site fetches it at runtime the same free way it fetches English (`raw.githubusercontent.com`). No Vercel functions, no KV, no per-view cost. The one exception is the per-language **README**, which is hand-authored for quality and committed to `main` (see below).
 
+This pipeline covers lessons under `phases/` only. Certification curricula remain English-only and are intentionally excluded from both machine translation and book generation.
+
 The default engine is **NLLB-200** ([No Language Left Behind, Meta AI, 2022](https://arxiv.org/abs/2207.04672)), an open translation model covering 200 languages, which runs **inside the GitHub Actions runner with no API key and no bill**. Compute is the free CI runner; there is no translation-API cost at all. Paid LLM providers (Anthropic/OpenAI) and DeepL remain available as optional higher-quality upgrades via `--provider`.
 
 ## Pieces
@@ -34,7 +36,7 @@ Both matrices read from `ci: true`, so the same flag opts a language into lesson
 
 ## How it runs
 
-1. A push to `main` that changes any `docs/en.md` triggers `.github/workflows/translate.yml`.
+1. A push to `main` that changes `phases/**/docs/en.md`, `languages.json`, or the translation workflow itself triggers `.github/workflows/translate.yml`. Certification lesson changes do not trigger it.
 2. The matrix is **one job per (language, phase)**. A full 503-lesson language run is ~27h on a CPU runner, far past the 6-hour job limit, so a per-language job always timed out before publishing. Splitting by phase keeps the largest job (phase 19, 85 lessons) near ~4.5h, well under the limit. Each job restores its language's prior output from the branch, runs `translate_lessons.py --phase <phase>`, and pushes only its own `i18n/<lang>/phases/<phase>/` slice back with a fetch-and-retry loop, so disjoint slices merge without collisions.
 3. The site's language switcher sets `?lang=<code>`; `fetchLesson` pulls `…/translations/i18n/<lang>/…/<lang>.md` and **falls back to canonical English** if that translation isn't published yet. English (`lang=en`) is byte-identical to the pre-i18n fetch path.
 

--- a/scripts/test_translate_workflow.py
+++ b/scripts/test_translate_workflow.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Regression checks for the phase-only translation workflow publisher."""
+
+from __future__ import annotations
+
+import os
+import shlex
+import stat
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "translate.yml"
+PREPARE_STEP = "      - id: set"
+PUBLISH_STEP = "      - name: Publish this phase slice to translations branch (race-safe)"
+
+
+def run(
+    *args: str,
+    cwd: Path,
+    env: dict[str, str] | None = None,
+    capture: bool = False,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        args,
+        cwd=cwd,
+        env=env,
+        check=check,
+        text=True,
+        stdout=subprocess.PIPE if capture else subprocess.DEVNULL,
+        stderr=subprocess.PIPE if capture else subprocess.DEVNULL,
+    )
+
+
+def step_script(marker: str) -> str:
+    lines = WORKFLOW.read_text(encoding="utf-8").splitlines()
+    start = lines.index(marker)
+    run_line = next(i for i in range(start, len(lines)) if lines[i] == "        run: |")
+    body: list[str] = []
+    for line in lines[run_line + 1 :]:
+        if line and not line.startswith("          "):
+            break
+        body.append(line[10:] if line else "")
+    return textwrap.dedent("\n".join(body))
+
+
+def publish_script() -> str:
+    return step_script(PUBLISH_STEP)
+
+
+def create_publisher_fixture(root: Path) -> tuple[Path, Path, Path]:
+    source = root / "source"
+    remote = root / "remote.git"
+    runner_temp = root / "runner"
+    source.mkdir()
+    runner_temp.mkdir()
+
+    run("git", "init", "--bare", "--initial-branch=main", str(remote), cwd=root)
+    run("git", "init", "--initial-branch=main", cwd=source)
+    run("git", "config", "user.name", "test", cwd=source)
+    run("git", "config", "user.email", "test@example.com", cwd=source)
+    (source / ".gitignore").write_text(
+        "i18n/*/phases/\ni18n/*/.cache/\n", encoding="utf-8"
+    )
+    (source / "README.md").write_text("English source\n", encoding="utf-8")
+    run("git", "add", ".gitignore", "README.md", cwd=source)
+    run("git", "commit", "-m", "initial", cwd=source)
+    run("git", "remote", "add", "origin", str(remote), cwd=source)
+    run("git", "push", "origin", "main", cwd=source)
+
+    translated = source / "i18n/fr/phases/01-foundations/lesson.md"
+    translated.parent.mkdir(parents=True)
+    translated.write_text("traduit\n", encoding="utf-8")
+    cache = source / "i18n/fr/.cache/01-foundations.json"
+    cache.parent.mkdir(parents=True)
+    cache.write_text("{}\n", encoding="utf-8")
+    return source, remote, runner_temp
+
+
+def publisher_env(remote: Path, runner_temp: Path) -> dict[str, str]:
+    env = os.environ.copy()
+    env.update(
+        {
+            "GH_TOKEN": "test",
+            "LANG_CODE": "fr",
+            "PHASE": "01-foundations",
+            "RUNNER_TEMP": str(runner_temp),
+            "TRANSLATION_PUSH_URL": str(remote),
+            "TRANSLATION_PUBLISH_RETRY_DELAY": "0",
+        }
+    )
+    return env
+
+
+class TranslateWorkflowContractTest(unittest.TestCase):
+    def test_trigger_and_manual_scope_remain_phase_only(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn('- "phases/**/docs/en.md"', workflow)
+        self.assertIn('- "languages.json"', workflow)
+        self.assertIn('- ".github/workflows/translate.yml"', workflow)
+        self.assertIn("REQUESTED_PHASE: ${{ github.event.inputs.phase }}", workflow)
+        self.assertIn("grep -Fqx -- \"$REQUESTED_PHASE\"", workflow)
+        self.assertNotIn("certifications/", workflow)
+
+    def test_manual_phase_rejects_traversal_that_resolves_to_a_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "phases/01-math-foundations").mkdir(parents=True)
+            (root / "phases/02-ml-foundations").mkdir()
+            (root / "languages.json").write_text(
+                '{"languages":[{"code":"fr","ci":true}]}\n', encoding="utf-8"
+            )
+            output = root / "github-output"
+            env = os.environ.copy()
+            env.update(
+                {
+                    "REQUESTED": "fr",
+                    "REQUESTED_PHASE": "01-math-foundations/../02-ml-foundations",
+                    "GITHUB_OUTPUT": str(output),
+                }
+            )
+            result = run(
+                "bash",
+                "-euo",
+                "pipefail",
+                "-c",
+                step_script(PREPARE_STEP),
+                cwd=root,
+                env=env,
+                capture=True,
+                check=False,
+            )
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("unknown phase", result.stderr)
+
+    def test_publisher_uses_retryable_detached_worktree(self) -> None:
+        script = publish_script()
+        self.assertIn('git worktree remove --force "$PUBLISH_DIR"', script)
+        self.assertIn('git worktree add --detach "$PUBLISH_DIR" "$BASE"', script)
+        self.assertIn("BASE=origin/translations", script)
+        self.assertIn("BASE=HEAD", script)
+        self.assertIn("git push origin HEAD:refs/heads/translations", script)
+        self.assertIn("if ! git add -f", script)
+        self.assertIn("if ! git commit", script)
+        self.assertIn("if ! git push", script)
+        self.assertNotIn("worktree add --force -B translations", script)
+
+    def test_rejected_bootstrap_push_retries_and_cleans_registration(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source, remote, runner_temp = create_publisher_fixture(root)
+
+            reject_once = remote / "reject-once"
+            reject_once.touch()
+            hook = remote / "hooks/pre-receive"
+            hook.write_text(
+                "#!/bin/sh\n"
+                f"if [ -f {shlex.quote(str(reject_once))} ]; then\n"
+                f"  rm {shlex.quote(str(reject_once))}\n"
+                "  echo 'intentional first-push rejection' >&2\n"
+                "  exit 1\n"
+                "fi\n",
+                encoding="utf-8",
+            )
+            hook.chmod(hook.stat().st_mode | stat.S_IXUSR)
+
+            run(
+                "bash",
+                "-euo",
+                "pipefail",
+                "-c",
+                publish_script(),
+                cwd=source,
+                env=publisher_env(remote, runner_temp),
+            )
+
+            published = run(
+                "git",
+                f"--git-dir={remote}",
+                "show",
+                "translations:i18n/fr/phases/01-foundations/lesson.md",
+                cwd=root,
+                capture=True,
+            )
+            self.assertEqual(published.stdout, "traduit\n")
+            published_cache = run(
+                "git",
+                f"--git-dir={remote}",
+                "show",
+                "translations:i18n/fr/.cache/01-foundations.json",
+                cwd=root,
+                capture=True,
+            )
+            self.assertEqual(published_cache.stdout, "{}\n")
+            worktrees = run("git", "worktree", "list", "--porcelain", cwd=source, capture=True)
+            self.assertEqual(worktrees.stdout.count("worktree "), 1)
+            self.assertFalse((runner_temp / "translation-publish").exists())
+
+    def test_commit_failure_never_reports_publish_success(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source, remote, runner_temp = create_publisher_fixture(root)
+            hook = source / ".git/hooks/pre-commit"
+            hook.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+            hook.chmod(hook.stat().st_mode | stat.S_IXUSR)
+
+            result = run(
+                "bash",
+                "-euo",
+                "pipefail",
+                "-c",
+                publish_script(),
+                cwd=source,
+                env=publisher_env(remote, runner_temp),
+                capture=True,
+                check=False,
+            )
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("could not commit translation slice", result.stderr)
+            self.assertIn("could not publish after retries", result.stderr)
+            branch = run(
+                "git",
+                f"--git-dir={remote}",
+                "show-ref",
+                "--verify",
+                "--quiet",
+                "refs/heads/translations",
+                cwd=root,
+                check=False,
+            )
+            self.assertNotEqual(branch.returncode, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/site/about.html
+++ b/site/about.html
@@ -19,7 +19,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=VT323&family=Source+Serif+4:ital,opsz,wght@0,8..60,400..700;1,8..60,400..700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css?v=20260808f">
+  <link rel="stylesheet" href="style.css?v=20260809a">
   <style>
     .about {
       max-width: 760px;

--- a/site/assessment.html
+++ b/site/assessment.html
@@ -8,7 +8,7 @@
   <link rel="canonical" href="https://aiengineeringfromscratch.com/assessment.html">
   <meta name="robots" content="noindex,follow">
   <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link href="https://fonts.googleapis.com/css2?family=VT323&family=Source+Serif+4:ital,opsz,wght@0,8..60,400..700;1,8..60,400..700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css?v=20260808f"><link rel="stylesheet" href="certifications.css?v=20260809a">
+  <link rel="stylesheet" href="style.css?v=20260809a"><link rel="stylesheet" href="certifications.css?v=20260809a">
 </head>
 <body data-cert-page="assessment">
   <a href="#main" class="skip-link">Skip to content</a>

--- a/site/catalog.html
+++ b/site/catalog.html
@@ -19,7 +19,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=VT323&family=Source+Serif+4:ital,opsz,wght@0,8..60,400..700;1,8..60,400..700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css?v=20260808f">
+  <link rel="stylesheet" href="style.css?v=20260809a">
   <style>
     .catalog-page {
       padding: 100px 0 80px;

--- a/site/certification.html
+++ b/site/certification.html
@@ -13,7 +13,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=VT323&family=Source+Serif+4:ital,opsz,wght@0,8..60,400..700;1,8..60,400..700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css?v=20260808f">
+  <link rel="stylesheet" href="style.css?v=20260809a">
   <link rel="stylesheet" href="certifications.css?v=20260809a">
 </head>
 <body data-cert-page="track">

--- a/site/certifications.html
+++ b/site/certifications.html
@@ -13,7 +13,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=VT323&family=Source+Serif+4:ital,opsz,wght@0,8..60,400..700;1,8..60,400..700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css?v=20260808f">
+  <link rel="stylesheet" href="style.css?v=20260809a">
   <link rel="stylesheet" href="certifications.css?v=20260809a">
 </head>
 <body data-cert-page="catalog">

--- a/site/glossary.html
+++ b/site/glossary.html
@@ -19,7 +19,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=VT323&family=Source+Serif+4:ital,opsz,wght@0,8..60,400..700;1,8..60,400..700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css?v=20260808f">
+  <link rel="stylesheet" href="style.css?v=20260809a">
   <style>
     .glossary-page {
       padding-block: 104px 80px;

--- a/site/index.html
+++ b/site/index.html
@@ -19,7 +19,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=VT323&family=Source+Serif+4:ital,opsz,wght@0,8..60,400..700;1,8..60,400..700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css?v=20260808f">
+  <link rel="stylesheet" href="style.css?v=20260809a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",

--- a/site/lesson.html
+++ b/site/lesson.html
@@ -19,7 +19,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=VT323&family=Source+Serif+4:ital,opsz,wght@0,8..60,400..700;1,8..60,400..700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css?v=20260808f">
+  <link rel="stylesheet" href="style.css?v=20260809a">
   <link rel="stylesheet" href="certifications.css?v=20260809a">
   <style>
     .scroll-progress {

--- a/site/prereqs.html
+++ b/site/prereqs.html
@@ -19,7 +19,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=VT323&family=Source+Serif+4:ital,opsz,wght@0,8..60,400..700;1,8..60,400..700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css?v=20260808f">
+  <link rel="stylesheet" href="style.css?v=20260809a">
   <link rel="stylesheet" href="roadmap.css?v=20260808e">
 </head>
 <body>

--- a/site/style.css
+++ b/site/style.css
@@ -1184,8 +1184,25 @@ body.js-anim .toc-row.in-view {
 
   .footer-inner {
     flex-direction: column;
+    align-items: stretch;
     text-align: center;
-    gap: 8px;
+    gap: 16px;
+  }
+
+  .footer-inner p,
+  .footer-links {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .footer-inner p {
+    overflow-wrap: anywhere;
+  }
+
+  .footer-links {
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 10px 20px;
   }
 }
 


### PR DESCRIPTION
## Summary

- keep machine translation limited to core `phases/` lessons
- document that certification curricula stay English-only and outside book generation
- trigger translation CI when `languages.json` or the publisher workflow changes
- add an optional single-phase manual smoke run
- rebuild every publish attempt from a clean detached worktree
- make staging, commit, and push failures retry instead of reporting false success

## Root cause

The previous bootstrap generated translated files, but main's inherited `.gitignore` prevented the first branch from being published. After force-add fixed that, rejected concurrent pushes still left a stale registered worktree, so the advertised retry could not recreate it. Workflow-only fixes also did not match the workflow's own path filter.

## Verification

- `python3 scripts/test_translate_workflow.py` (5 tests)
- forced first-push rejection retries and publishes the ignored lesson slice and cache
- forced commit failure exits nonzero and never creates a translations branch
- traversal-like phase input is rejected
- `python3 scripts/audit_lessons.py` (503 lessons, 0 issues)
- `python3 scripts/audit_certifications.py` (33 lessons, 8 assessments, 295 questions, 0 issues)
- `python3 scripts/backfill_certification_references.py --check`
- `python3 scripts/build_readme_i18n.py --check`
- workflow YAML parse and `git diff --check`