### PR TITLE
fix(site): scope language picker to lesson pages

### DIFF
--- a/site/lang-picker.js
+++ b/site/lang-picker.js
@@ -201,12 +201,13 @@
 
   function init() {
     var host = document.getElementById('langPicker');
+    if (!host || typeof window.AIFS_onLangChange !== 'function') return;
     if (isCertificationLesson()) {
       applyDir('en');
-      if (host) host.hidden = true;
+      host.hidden = true;
       return;
     }
-    if (host) mount(host);
+    mount(host);
   }
   if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init);
   else init();


### PR DESCRIPTION
## What this PR does

Scopes the language picker to lesson pages only, since `window.AIFS_onLangChange` — the hook that actually re-renders content in the selected language — is only ever defined on `lesson.html`.

## Kind of change

- [x] Docs / website / tooling

## Checklist

- [x] Code runs without errors with the listed dependencies
- [x] No comments in code files (docs explain, code is self-explanatory)
- [x] Tested locally / code output matches what `docs/en.md` claims

## Phase / lesson

N/A — this is a site-level fix (`site/lang-picker.js`), not a lesson change.

## Notes for reviewer

Root cause: the picker mounted on `index.html` too, but the landing page has no `AIFS_onLangChange` hook, so selecting a language updated `localStorage`/the URL but never re-rendered content — matching the reported bug. `docs/i18n.md`'s "Site switcher" row documents `lesson.html` as the only intended location, so I gated `init()` on `window.AIFS_onLangChange` being defined rather than trying to add landing-page translations that don't exist in the pipeline.

Tested locally on both pages: `index.html` no longer mounts the picker; `lesson.html` still mounts it and language switching still works (translated markdown still fetches, falls back to English correctly).

Left the empty `<div id="langPicker">` in `index.html` in place rather than removing it — kept the diff to one file/one behavior per the contribution guidelines.

Fixes #404