### PR TITLE
Fix: Add init=0 to prevent empty collection crash during threshold tuning.

### DIFF
--- a/phases/02-ml-fundamentals/03-logistic-regression/code/main.jl
+++ b/phases/02-ml-fundamentals/03-logistic-regression/code/main.jl
@@ -119,13 +119,13 @@ end
 
 
 function build_metrics(y_true::Vector{Int}, y_pred::Vector{Int})
-    tp = sum(1 for i in 1:length(y_true) if y_true[i] == 1 && y_pred[i] == 1; init=0)
-    tn = sum(1 for i in 1:length(y_true) if y_true[i] == 0 && y_pred[i] == 0; init=0)
-    fp = sum(1 for i in 1:length(y_true) if y_true[i] == 0 && y_pred[i] == 1; init=0)
-    fn = sum(1 for i in 1:length(y_true) if y_true[i] == 1 && y_pred[i] == 0; init=0)
+  # count() naturally returns 0 for empty matches, preventing crashes
+    tp = count(i -> y_true[i] == 1 && y_pred[i] == 1, eachindex(y_true))
+    tn = count(i -> y_true[i] == 0 && y_pred[i] == 0, eachindex(y_true))
+    fp = count(i -> y_true[i] == 0 && y_pred[i] == 1, eachindex(y_true))
+    fn = count(i -> y_true[i] == 1 && y_pred[i] == 0, eachindex(y_true))
     return ClassificationMetrics(tp, tn, fp, fn)
 end
-
 
 metric_accuracy(m::ClassificationMetrics) =
     (m.tp + m.tn + m.fp + m.fn) > 0 ? (m.tp + m.tn) / (m.tp + m.tn + m.fp + m.fn) : 0.0

--- a/phases/02-ml-fundamentals/03-logistic-regression/code/main.jl
+++ b/phases/02-ml-fundamentals/03-logistic-regression/code/main.jl
@@ -127,6 +127,7 @@ function build_metrics(y_true::Vector{Int}, y_pred::Vector{Int})
     return ClassificationMetrics(tp, tn, fp, fn)
 end
 
+
 metric_accuracy(m::ClassificationMetrics) =
     (m.tp + m.tn + m.fp + m.fn) > 0 ? (m.tp + m.tn) / (m.tp + m.tn + m.fp + m.fn) : 0.0
 metric_precision(m::ClassificationMetrics) =

--- a/phases/02-ml-fundamentals/03-logistic-regression/code/main.jl
+++ b/phases/02-ml-fundamentals/03-logistic-regression/code/main.jl
@@ -119,10 +119,10 @@ end
 
 
 function build_metrics(y_true::Vector{Int}, y_pred::Vector{Int})
-    tp = sum(1 for i in 1:length(y_true) if y_true[i] == 1 && y_pred[i] == 1)
-    tn = sum(1 for i in 1:length(y_true) if y_true[i] == 0 && y_pred[i] == 0)
-    fp = sum(1 for i in 1:length(y_true) if y_true[i] == 0 && y_pred[i] == 1)
-    fn = sum(1 for i in 1:length(y_true) if y_true[i] == 1 && y_pred[i] == 0)
+    tp = sum(1 for i in 1:length(y_true) if y_true[i] == 1 && y_pred[i] == 1; init=0)
+    tn = sum(1 for i in 1:length(y_true) if y_true[i] == 0 && y_pred[i] == 0; init=0)
+    fp = sum(1 for i in 1:length(y_true) if y_true[i] == 0 && y_pred[i] == 1; init=0)
+    fn = sum(1 for i in 1:length(y_true) if y_true[i] == 1 && y_pred[i] == 0; init=0)
     return ClassificationMetrics(tp, tn, fp, fn)
 end
 


### PR DESCRIPTION
<!-- Thanks for contributing. Fill out what applies. Delete sections that don't. -->

## What this PR does

Fixes #434 

Fixes an `ArgumentError` in `main.jl` by adding `; init=0` to the `sum()` generators in the `build_metrics` function to handle edge cases during threshold tuning

## Kind of change

- [ ] New lesson
- [X] Fix to an existing lesson
- [ ] Translation
- [ ] New output (prompt, skill, agent, MCP server)
- [ ] Docs / website / tooling

## Checklist

- [X] Code runs without errors with the listed dependencies
- [ ] No comments in code files (docs explain, code is self-explanatory)
- [ ] Built from scratch first, then shown with a framework (for new lessons)
- [ ] Lesson folder matches `LESSON_TEMPLATE.md` structure
- [ ] ROADMAP.md row for the lesson is a markdown link (`[Name](phases/...)`), not bare text
- [X] One lesson per commit (atomic per-lesson rule)
- [X] Tested locally / code output matches what `docs/en.md` claims

## Phase / lesson

Phase 2 · 03-logistic-regression

## Notes for reviewer

When running `demo_threshold_tuning`, extreme thresholds (like `0.7`) can result in the model predicting exactly zero positive cases. When `y_pred` contains only `0`s, the generator comprehensions inside `build_metrics`. (e.g., `sum(1 for i in 1:length(y_true) if y_true[i] == 1 && y_pred[i] == 1)`) becomes empty. This causes Julia to throw an `ArgumentError: reducing over an empty collection is not allowed`. Adding the `; init=0` keyword argument resolves this by safely returning 0 and allowing the script to complete successfully.)
