### PR TITLE
fix(phase-02/03): handle empty cells in Julia build_metrics

### DIFF
--- a/phases/02-ml-fundamentals/03-logistic-regression/code/main.jl
+++ b/phases/02-ml-fundamentals/03-logistic-regression/code/main.jl
@@ -119,10 +119,11 @@ end
 
 
 function build_metrics(y_true::Vector{Int}, y_pred::Vector{Int})
-    tp = sum(1 for i in 1:length(y_true) if y_true[i] == 1 && y_pred[i] == 1)
-    tn = sum(1 for i in 1:length(y_true) if y_true[i] == 0 && y_pred[i] == 0)
-    fp = sum(1 for i in 1:length(y_true) if y_true[i] == 0 && y_pred[i] == 1)
-    fn = sum(1 for i in 1:length(y_true) if y_true[i] == 1 && y_pred[i] == 0)
+    # count returns 0 for empty matches; filtered sum() throws on empty gens.
+    tp = count(i -> y_true[i] == 1 && y_pred[i] == 1, eachindex(y_true))
+    tn = count(i -> y_true[i] == 0 && y_pred[i] == 0, eachindex(y_true))
+    fp = count(i -> y_true[i] == 0 && y_pred[i] == 1, eachindex(y_true))
+    fn = count(i -> y_true[i] == 1 && y_pred[i] == 0, eachindex(y_true))
     return ClassificationMetrics(tp, tn, fp, fn)
 end
 


### PR DESCRIPTION
## Summary
- Fixes #434: `build_metrics` crashed with `ArgumentError: reducing over an empty collection` when a threshold produced all-negative (or otherwise empty-cell) predictions.
- Replaces filtered `sum(1 for ... if ...)` with `count(...)`, which returns `0` for empty matches so threshold tuning completes.

## Test plan
- [x] Unit-style checks: all-negative and all-positive predictions return correct TP/TN/FP/FN without throwing
- [x] `julia main.jl` / full `main()` completes through threshold tuning and the rest of the demo
- [ ] CI audit passes on the PR


Made with [Cursor](https://cursor.com)