### PR TITLE
fix: align code with course statement

### DIFF
--- a/phases/11-llm-engineering/02-few-shot-cot/code/advanced_prompting.py
+++ b/phases/11-llm-engineering/02-few-shot-cot/code/advanced_prompting.py
@@ -334,15 +334,13 @@ def react_solve(question, client, model, max_steps=5):
 
 
 def solve_with_escalation(question, examples, client, model):
-    single_answer, single_text = few_shot_cot_solve(
-        question, examples, client, model
-    )
+    single_answer, _ = few_shot_cot_solve(question, examples, client, model)
 
     sc_answer, confidence, reasonings, votes = self_consistency_solve(
         question, examples, client, model, n_samples=5
     )
 
-    if confidence >= 0.8:
+    if confidence >= 0.8 and single_answer == sc_answer:
         return {
             "answer": sc_answer,
             "method": "self_consistency",

--- a/phases/11-llm-engineering/02-few-shot-cot/docs/en.md
+++ b/phases/11-llm-engineering/02-few-shot-cot/docs/en.md
@@ -438,22 +438,20 @@ The pipeline combines all techniques with an escalation strategy.
 
 ```python
 def solve_with_escalation(question, examples, client, model):
-    system, user = build_cot_prompt(question, examples)
-    single_response = call_llm(client, model, system, user, temperature=0.0)
-    single_answer = extract_answer(single_response)
+    single_answer, _ = few_shot_cot_solve(question, examples, client, model)
 
     sc_answer, confidence, _, _ = self_consistency_solve(
         question, examples, client, model, n_samples=5
     )
 
-    if confidence >= 0.8:
+    if confidence >= 0.8 and single_answer == sc_answer:
         return sc_answer, "self_consistency", confidence
 
     tot_answer, _ = tree_of_thought_solve(question, client, model)
     return tot_answer, "tree_of_thought", None
 ```
 
-The escalation logic: try cheap (single CoT) first. If self-consistency confidence is below 0.8 (less than 4 of 5 samples agree), escalate to ToT. This balances cost and accuracy -- most problems are solved cheaply, hard problems get more compute.
+The escalation logic: try cheap (single CoT) first. A single deterministic path gives no vote share, so its quality check is agreement: the temperature-0 answer has to match the majority answer from the sampled paths. If it does not, or if self-consistency confidence is below 0.8 (less than 4 of 5 samples agree), escalate to ToT. This balances cost and accuracy -- most problems are solved cheaply, hard problems get more compute.
 
 ## Use It
 


### PR DESCRIPTION
## What this PR does

Propose a fix to remove dead code, so that the single CoT call is actually used.

## Kind of change

- [ ] New lesson
- [x] Fix to an existing lesson
- [ ] Translation
- [ ] New output (prompt, skill, agent, MCP server)
- [ ] Docs / website / tooling

## Checklist

- [ ] Code runs without errors with the listed dependencies
- [x] No comments in code files (docs explain, code is self-explanatory)
- [ ] Built from scratch first, then shown with a framework (for new lessons)
- [ ] Lesson folder matches `LESSON_TEMPLATE.md` structure
- [ ] ROADMAP.md row for the lesson is a markdown link (`[Name](phases/...)`), not bare text
- [x] One lesson per commit (atomic per-lesson rule)
- [ ] Tested locally / code output matches what `docs/en.md` claims

## Phase / lesson

Phase 11 · 02-few-shot-cot

## Notes for reviewer

In the existing lesson, the outcome of the 'call_llm()' in 'solve_with_escalation()' is not used. To prevent that, we could either:
- remove the dead code
- implement a confidence check on the result, just before the 'self_consistency_solve()' call, to return early
- merge the single CoT and the self consistency outcomes

From my point of view, the third option is the most satisfying one since we can keep the single CoT, and we can get a minimalist change to the code, that allows to have a code consistent with the course statements.