### PR TITLE
fix: dark mode readability for Mermaid nodeLabel

### DIFF
--- a/site/lesson.html
+++ b/site/lesson.html
@@ -1268,6 +1268,11 @@
       color: var(--ink);
     }
 
+    [data-theme="dark"] .lesson-article .mermaid-render .nodeLabel,
+    [data-theme="dark"] .mermaid-modal-body .nodeLabel {
+      color: var(--ink);
+    }
+
     .lesson-nav-bottom {
       display: grid;
       grid-template-columns: repeat(2, minmax(0, 1fr));


### PR DESCRIPTION
Adds CSS override for Mermaid .nodeLabel elements in dark mode to ensure text remains readable against highlighted backgrounds.

Fixes #433