### PR TITLE
fix(julia): add init=0 to sum() calls in build_metrics to handle empty generators

### DIFF
--- a/BACKERS.md
+++ b/BACKERS.md
@@ -1,6 +1,6 @@
 # Backers
 
-This file tracks the Backer tier sponsors for [ai-engineering-from-scratch](../SPONSORS.md).
+This file tracks the Backer tier sponsors for [ai-engineering-from-scratch](SPONSORS.md).
 
 Backer tier ($25/month) sponsors are listed here once their sponsorship is active.
 

--- a/BACKERS.md
+++ b/BACKERS.md
@@ -1,7 +1,0 @@
-# Backers
-
-This file tracks the Backer tier sponsors for [ai-engineering-from-scratch](SPONSORS.md).
-
-Backer tier ($25/month) sponsors are listed here once their sponsorship is active.
-
-*No backers yet.* Become the first Backer at https://github.com/sponsors/rohitg00

--- a/BACKERS.md
+++ b/BACKERS.md
@@ -1,0 +1,7 @@
+# Backers
+
+This file tracks the Backer tier sponsors for [ai-engineering-from-scratch](../SPONSORS.md).
+
+Backer tier ($25/month) sponsors are listed here once their sponsorship is active.
+
+*No backers yet.* Become the first Backer at https://github.com/sponsors/rohitg00

--- a/phases/02-ml-fundamentals/03-logistic-regression/code/main.jl
+++ b/phases/02-ml-fundamentals/03-logistic-regression/code/main.jl
@@ -119,10 +119,10 @@ end
 
 
 function build_metrics(y_true::Vector{Int}, y_pred::Vector{Int})
-    tp = sum(1 for i in 1:length(y_true) if y_true[i] == 1 && y_pred[i] == 1)
-    tn = sum(1 for i in 1:length(y_true) if y_true[i] == 0 && y_pred[i] == 0)
-    fp = sum(1 for i in 1:length(y_true) if y_true[i] == 0 && y_pred[i] == 1)
-    fn = sum(1 for i in 1:length(y_true) if y_true[i] == 1 && y_pred[i] == 0)
+    tp = sum(1 for i in 1:length(y_true) if y_true[i] == 1 && y_pred[i] == 1; init=0)
+    tn = sum(1 for i in 1:length(y_true) if y_true[i] == 0 && y_pred[i] == 0; init=0)
+    fp = sum(1 for i in 1:length(y_true) if y_true[i] == 0 && y_pred[i] == 1; init=0)
+    fn = sum(1 for i in 1:length(y_true) if y_true[i] == 1 && y_pred[i] == 0; init=0)
     return ClassificationMetrics(tp, tn, fp, fn)
 end
 


### PR DESCRIPTION
Fixes #434 - When demo_threshold_tuning produces all-zero predictions, the generator comprehensions in build_metrics become empty, causing ArgumentError: reducing over an empty collection is not allowed.

Adding init=0 to each sum() call prevents the crash when the model predicts zero positive cases.