### PR TITLE
fix(scripts): seed quiz de-bias from a POSIX-normalized path

### DIFF
--- a/scripts/debias_quizzes.py
+++ b/scripts/debias_quizzes.py
@@ -36,9 +36,6 @@ ANCHOR = re.compile(
 
 
 def seed_for(path, question_text):
-    # glob yields OS-native separators, so seeding off the raw path would give
-    # Windows a different arrangement than Linux. Normalize first, matching
-    # debias_certification_questions.py, which seeds off `relative_to(ROOT).as_posix()`.
     normalized = path.replace("\\", "/")
     h = hashlib.sha256(f"{normalized}\x00{question_text}".encode("utf-8")).hexdigest()
     return int(h[:16], 16)
@@ -123,8 +120,6 @@ def main():
     ap.add_argument("--check", action="store_true", help="report only, do not write")
     args = ap.parse_args()
 
-    # Regression guard: the committed arrangement is only reproducible if the
-    # seed ignores the path separator, so both forms must agree on every OS.
     assert seed_for("phases/a/quiz.json", "q") == seed_for("phases\\a\\quiz.json", "q"), (
         "seed_for must not depend on the platform path separator"
     )

--- a/scripts/debias_quizzes.py
+++ b/scripts/debias_quizzes.py
@@ -36,7 +36,11 @@ ANCHOR = re.compile(
 
 
 def seed_for(path, question_text):
-    h = hashlib.sha256(f"{path}\x00{question_text}".encode("utf-8")).hexdigest()
+    # glob yields OS-native separators, so seeding off the raw path would give
+    # Windows a different arrangement than Linux. Normalize first, matching
+    # debias_certification_questions.py, which seeds off `relative_to(ROOT).as_posix()`.
+    normalized = path.replace("\\", "/")
+    h = hashlib.sha256(f"{normalized}\x00{question_text}".encode("utf-8")).hexdigest()
     return int(h[:16], 16)
 
 
@@ -118,6 +122,12 @@ def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--check", action="store_true", help="report only, do not write")
     args = ap.parse_args()
+
+    # Regression guard: the committed arrangement is only reproducible if the
+    # seed ignores the path separator, so both forms must agree on every OS.
+    assert seed_for("phases/a/quiz.json", "q") == seed_for("phases\\a\\quiz.json", "q"), (
+        "seed_for must not depend on the platform path separator"
+    )
 
     pos = collections.Counter()
     total = 0


### PR DESCRIPTION
## What this PR does

Seeds the quiz option shuffle from a POSIX-normalized path so the de-biased arrangement is identical on every OS. Fixes #465.

## Kind of change

- [x] Docs / website / tooling

## Why

`seed_for()` hashed the raw path from `glob.glob("phases/*/*/quiz.json")`, which carries OS-native separators, so Windows derived a different seed than Linux for the same question. Two consequences on Windows, same commit:

1. `--check` — the command CI runs as the `quiz answer positions are de-biased` gate — **false-fails** with `FAIL: 2098 quiz question(s) are not de-biased`, even though the committed arrangement is correct.
2. A bare `python scripts/debias_quizzes.py` (the documented remediation) rewrites **2098 questions across 373 files** into an arrangement Linux CI then rejects.

Measured locally:

| paths fed to `seed_for` | `--check` |
|---|---|
| OS-native (`\`) | `FAIL`, 2098 rewrites, exit 1 |
| POSIX-normalized | `0` rewrites, exit 0 |

## The change

```python
normalized = path.replace("\\", "/")
h = hashlib.sha256(f"{normalized}\x00{question_text}".encode("utf-8")).hexdigest()
```

This mirrors `scripts/debias_certification_questions.py`, which already seeds off `path.relative_to(ROOT).as_posix()` and is not affected by this bug — that script was the reference for the intended contract.

POSIX paths contain no backslashes, so the normalized value is byte-identical to the input on Linux and macOS: the committed arrangement and the CI gate are unchanged.

## Regression coverage

`main()` now asserts `seed_for("phases/a/quiz.json", …) == seed_for("phases\a\quiz.json", …)`. That runs on every invocation, including the CI `--check` gate, so losing the normalization fails the build instead of silently changing the shuffle.

## Verification

- `python scripts/debias_quizzes.py --check` → exit 0, `files affected: 0  questions would rewrite: 0`
- Positional distribution matches Linux exactly: `A 539  B 582  C 528  D 588`
- `seed_for` maps `a/b` and `a\b` to one seed, and the POSIX seed is unchanged from before the patch
- `python scripts/audit_lessons.py` → 523 lessons, 0 issues
- `node site/build.js` → `site/data.js` timestamp only (not committed here)
- `diff -r skills .claude/skills` → clean
- `python scripts/check_readme_counts.py`, `python scripts/build_readme_i18n.py --check` → exit 0

No quiz content, arrangement, dependency, or public interface changes.

## Checklist

- [x] Code runs without errors with the listed dependencies
- [x] One contribution per pull request
- [ ] No comments in code files — two short "why" comments were added; they follow the existing style in this same file (e.g. `# duplicate options make identity tracking ambiguous`). Happy to drop them if you'd rather the script stay comment-free.

## Phase / lesson

Tooling only — `scripts/debias_quizzes.py`. No lesson, phase, or `site/data.js` content is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
